### PR TITLE
fix(client): drop modal chrome from embedded settings sections

### DIFF
--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -178,7 +178,7 @@ window.__ModuleLoader__.load({
 
       const tabs = ["all", "preference", "project", "decision", "history"];
 
-      const body = react.createElement("div", { style: embedded ? { ...styles.panel, width: "100%", maxWidth: "100%", maxHeight: "none" } : styles.panel },
+      const body = react.createElement("div", { style: embedded ? { width: "100%", display: "flex", flexDirection: "column" } : styles.panel },
         !embedded && react.createElement("div", { style: styles.header },
           react.createElement("span", { style: styles.title }, t("memory.panel.title")),
           react.createElement("button", { style: styles.close, onClick: onClose }, "×")
@@ -365,7 +365,7 @@ window.__ModuleLoader__.load({
       const hintStyle = { fontSize: 11, color: "var(--dsw-alias-label-tertiary, #999)", marginBottom: 8 };
       const rowStyle = { display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8, padding: "6px 0", borderBottom: "1px solid var(--dsw-alias-border-l1, #eee)" };
 
-      const body = h("div", { style: embedded ? { ...styles.panel, width: "100%", maxWidth: "100%", maxHeight: "none" } : styles.panel },
+      const body = h("div", { style: embedded ? { width: "100%", display: "flex", flexDirection: "column" } : styles.panel },
         !embedded && h("div", { style: styles.header },
           h("span", { style: styles.title }, t("memory.settings.title")),
           h("button", { style: styles.close, onClick: onClose }, "×")

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -24,3 +24,21 @@ test("client bundle is lib-only with no src counterpart", () => {
   assert.equal(existsSync(join(root, "src/client.js")), false, "src/ must not contain client.js");
   assert.equal(existsSync(join(root, "lib/client.js")), true, "lib/client.js must exist");
 });
+
+// Both panels render in two modes: a portal modal (styles.panel, full chrome)
+// and an embedded settings-section variant. The embedded variant must drop the
+// modal-only chrome (background, radius, padding, shadow) — the settings host
+// already provides its own surface, so reusing the modal panel style makes the
+// section render as a floating card with an inset box and shadow inside the
+// settings page.
+test("embedded variant drops the modal panel chrome", () => {
+  const branches = clientSource.match(/embedded \? \{[^}]+\}/g);
+  assert.ok(branches, "panels must branch on the embedded flag");
+  assert.equal(branches.length, 2, "both MemoryPanel and SettingsPanel must branch");
+  for (const branch of branches) {
+    assert.equal(branch.includes("styles.panel"), false, "embedded branch must not reuse the modal panel style");
+    for (const chrome of ["boxShadow", "background", "borderRadius", "padding"]) {
+      assert.equal(branch.includes(chrome), false, `embedded branch must not carry ${chrome}`);
+    }
+  }
+});


### PR DESCRIPTION
The MemoryPanel and SettingsPanel both render in two modes: a portal modal (styles.panel, full chrome) and an embedded variant used by the 'settings.section' slot inside the DSH settings page. The embedded branch reused the modal panel style with only width/maxWidth/maxHeight overridden, so the section rendered as a floating card — white background, 12px radius, 16px padding, and a 0 8px 40px shadow — inside the settings host's own surface, producing an unwanted inset box with a shadow on the left edge of the settings page.

The embedded variant now uses a plain full-width flex column with no background, radius, padding, or shadow; the modal (portal) mode keeps the panel chrome unchanged.

Adds a regression test asserting both panels' embedded branches carry none of the modal-only chrome.