### PR TITLE
feat: add root package.json so dsh-plugin marketplace scanners can discover the plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@modusensus/dsh-mneme",
+  "version": "0.3.7",
+  "description": "Structured memory engine for DeepSeek Harness. Offline semantic search, entity-attribute-timeline, autoDream self-consolidation, and human-editable Markdown storage.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dsh-mneme/lib/index.js",
+  "exports": {
+    ".": { "default": "./dsh-mneme/lib/index.js" },
+    "./client": { "default": "./dsh-mneme/lib/client.js" },
+    "./package.json": "./dsh-mneme/package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": ["slots", "locale", "layout", "connection"],
+      "platform": "web"
+    },
+    "bundle": {
+      "patch": "./dsh-mneme/cordis.patch.yml"
+    },
+    "marketplace": {
+      "profiles": ["web"],
+      "requiresBuildApproval": false,
+      "requiresRestart": true,
+      "manualSteps": false
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+    "@deepseek-ai/schemastery": "^3.18.1"
+  }
+}


### PR DESCRIPTION
## Why

The DSH plugin marketplaces (e.g. YELEBAI/dsh-plugin-marketplace, w2112515/dsh-plugin-marketplace) discover plugins by auto-scanning the `dsh-plugin` GitHub topic and reading the **repository root** `package.json`. dsh-mneme's manifest currently lives only at `dsh-mneme/package.json`, so the scanners fail with `package-json-missing` and dsh-mneme cannot be listed/validated.

This adds a root `package.json` that mirrors the real manifest and points every DSH entry at the existing subdirectory files:

- `dsh.bundle.patch` → `./dsh-mneme/cordis.patch.yml` (already exists, inserts loader entry `@modusensus/dsh-mneme`)
- `dsh.client` (web platform) + `exports["./client"]` → `./dsh-mneme/lib/client.js` (already exists)
- `main`/`exports["."]` → `./dsh-mneme/lib/index.js`
- `dsh.marketplace` profile/install hints so scanners can classify the install

No existing layout is touched, and the npm package (`@modusensus/dsh-mneme`) is still published from `dsh-mneme/`.

## Effect

- YELEBAI, w2112515 and similar topic-scanning marketplaces will now be able to validate and list dsh-mneme automatically on their next scan.
- UntR and AwesomeHou marketplaces (live topic sync) continue to list it.