### PR TITLE
v0.6.0 会话生命周期：session_disposed_at 独立字段（不进主线，待审）

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.0] - 2026-08-20
+
+### 新增
+
+- **会话生命周期（把会话当存档点）**：新配置 `sessionLifecycleEnabled`（默认 `false`）。开启后，会话被删除/销毁（`session/disposed`）时自动把该会话内出生（`session_id` 溯源）的记忆**软归档**——隐藏于检索/注入/列表，但不删除，随时可恢复。恢复路径：单条用 `memory_archive ... archived:false`，整会话用新接口 `service.restoreBySession(sessionId)`。存量无 `session_id` 的记忆视为全局，永不参与会话清理。默认关闭保持旧行为，销毁会话不影响记忆。
+- **store/service 新增接口**：`store.listBySession(sessionId)`、`store.setArchivedBySession(sessionId, archived)`（幂等，返回实际翻转行数）、`service.archiveBySession(sessionId)`、`service.restoreBySession(sessionId)`、`service.listBySession(sessionId)`。复用既有 `archived` 列，无 schema 变更。
+
+### 测试
+
+- 613 → **621** 全绿（新增 `test/service.test.js` 会话生命周期 6 例：按会话归档只影响该会话/恢复可见/幂等/未知会话空操作/无 session 全局记忆不受影响/`toApiList` 携带 session_id 可选字段）。
+
 ## [0.5.3] - 2026-08-20
 
 ### 新增

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -4,6 +4,11 @@ export const Config = z.object({
   memoryDir: z.string().default("~/.dsh/memory"),
   autoInject: z.boolean().default(true),
   autoSummarize: z.boolean().default(true),
+  // Session lifecycle (v0.6.0): when enabled, deleting/disposing a session also
+  // archives every memory that was born in it (treating the session as a save
+  // point — entries stay recoverable via memory_archive/restoreBySession).
+  // Default OFF: legacy behavior, a disposed session leaves its memories active.
+  sessionLifecycleEnabled: z.boolean().default(false),
   // Optional model override for summarization. When both are non-empty, they
   // take priority over the session's current model. Empty = use the session's
   // active provider/model (same as before).

--- a/dsh-mneme/lib/dream.js
+++ b/dsh-mneme/lib/dream.js
@@ -495,7 +495,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
   let inFlight = null;
 
   function shouldTrigger(service) {
-    const memories = service.all().filter((m) => !m.archived && m.type !== "summary");
+    const memories = service.all().filter((m) => !m.archived && !m.session_disposed_at && m.type !== "summary");
     const count = memories.length;
     const chars = totalChars(memories);
     const overBase = count >= baseline.count + thresholdCount || chars >= baseline.chars + thresholdChars;
@@ -844,7 +844,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
           : {}),
         messages: [
           { role: "system", content: [{ type: "text", text: SUMMARY_PROMPT }] },
-          { role: "user", content: [{ type: "text", text: service.all().filter((m) => !m.archived && m.type !== "summary").map((m) => `- ${m.title}: ${m.content}`).join("\n") }] }
+          { role: "user", content: [{ type: "text", text: service.all().filter((m) => !m.archived && !m.session_disposed_at && m.type !== "summary").map((m) => `- ${m.title}: ${m.content}`).join("\n") }] }
         ]
       }, reportUsage));
     } catch (error) {

--- a/dsh-mneme/lib/dream/sleep.js
+++ b/dsh-mneme/lib/dream/sleep.js
@@ -108,7 +108,7 @@ async function phaseConflicts(ctx, service, config, logger, runId, semantic = nu
   }
   const strictness = config.sleepConflictStrictness ?? "normal";
   const threshold = CONFLICT_THRESHOLDS[strictness] ?? CONFLICT_THRESHOLDS.normal;
-  const memories = service.all().filter((m) => !m.archived && !m.forgotten && m.type !== "summary");
+  const memories = service.all().filter((m) => !m.archived && !m.session_disposed_at && !m.forgotten && m.type !== "summary");
   if (memories.length < 2) return { status: "skipped", reason: "too few memories" };
   if (signal?.aborted) return { status: "aborted", reason: "user activity" };
 
@@ -239,7 +239,7 @@ function phaseDemotion(service, config, logger, runId, signal = null) {
   const archived = [];
   for (const m of service.all()) {
     if (signal?.aborted) break;
-    if (m.archived || m.forgotten) continue;
+    if (m.archived || m.forgotten || m.session_disposed_at) continue;
     const ref = m.last_accessed_at ?? m.updated_at ?? m.created_at;
     if (!ref) continue;
     const t = new Date(ref).getTime();
@@ -273,7 +273,7 @@ async function phasePatterns(ctx, service, config, logger, runId, signal = null)
   const limit = config.sleepPatternMinMemories ?? 100;
   const memories = service
     .list({ limit: 200, includeForgotten: false })
-    .filter((m) => !m.archived && m.type !== "summary" && m.type !== "pattern")
+    .filter((m) => !m.archived && !m.session_disposed_at && m.type !== "summary" && m.type !== "pattern")
     .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))
     .slice(0, limit);
   if (memories.length === 0) return { status: "skipped", reason: "no memories to scan" };
@@ -342,7 +342,7 @@ function phaseRelations(service, config, logger, runId, signal = null) {
   if (entities.length < 2) return { status: "skipped", reason: "too few entities" };
   const orphans = entities.filter((e) => (service.getRelations(e.id) ?? []).length === 0);
   if (orphans.length === 0) return { status: "skipped", reason: "no orphan entities" };
-  const memories = service.all().filter((m) => !m.archived && !m.forgotten);
+  const memories = service.all().filter((m) => !m.archived && !m.session_disposed_at && !m.forgotten);
   const seen = new Set();
   const related = [];
   const MAX_RELATIONS_PER_ORPHAN = 3;

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -317,6 +317,26 @@ export const apply = (ctx, config) => {
   const summarizer = createSummarizer(ctx, service, cfg);
   disposers.push(summarizer.dispose);
 
+  // Session lifecycle (v0.6.0): when a session leaves the store and the toggle
+  // is enabled, mark every memory born in it as session-disposed (hidden from
+  // injection/search/dream but never destroyed — recoverable via
+  // restoreBySession). Default off, so a disposed session leaves its memories
+  // active (legacy behavior). Every path is guarded: a failure inside the
+  // callback must never propagate into DSH's session teardown (that would crash
+  // the plugin on the very delete action it serves).
+  if (cfg.sessionLifecycleEnabled) {
+    disposers.push(ctx.on("session/disposed", (session) => {
+      const sessionId = session?.id;
+      if (!sessionId) return;
+      try {
+        const { disposed } = service.disposeBySession(sessionId);
+        ctx.logger?.info?.(`[dsh-mneme] session disposed, hid ${disposed} memory(s) for ${sessionId}`);
+      } catch (error) {
+        ctx.logger?.warn?.(`[dsh-mneme] session dispose failed for ${sessionId}: ${String(error)}`);
+      }
+    }));
+  }
+
   if (ctx.webServer) {
     const api = createApi(ctx, service, settings, commands ?? {
       add: () => { throw new Error("commands unavailable"); },

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -331,7 +331,7 @@ export function createService({ store, mirror, config, onWrite, logger }) {
   function bm25Recall(q, limit) {
     if (config?.bm25SearchEnabled === false) return [];
     try {
-      const docs = store.list({ limit: 500, includeForgotten: false }).filter((m) => !m.archived);
+      const docs = store.list({ limit: 500, includeForgotten: false }).filter((m) => !m.archived && !m.session_disposed_at);
       if (!docs.length) return [];
       return createBM25Index(docs).search(q, { limit });
     } catch {
@@ -999,6 +999,9 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       tags: m.tags,
       importance: m.importance,
       source: m.source,
+      // session_id is optional on the wire: only carry it when present, so the
+      // DTO stays a lossless JSON object (undefined would vanish on serialize).
+      ...(m.session_id != null ? { session_id: m.session_id } : {}),
       created_at: m.created_at,
       updated_at: m.updated_at
     }));
@@ -1339,6 +1342,28 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       afterSync("write");
       notifyWrite();
     },
+    // Session lifecycle (v0.6.0): mark/clear the session-disposed state on every
+    // memory born in a given session. Uses the dedicated `session_disposed_at`
+    // column, orthogonal to `archived` — restoring a session never resurrects
+    // memories the user archived on purpose. Nothing is destroyed; a session
+    // treated as a save point is fully recoverable via restoreBySession.
+    disposeBySession: (sessionId) => {
+      const disposed = store.setDisposedBySession(sessionId, true);
+      if (disposed > 0) {
+        afterSync("write");
+        notifyWrite();
+      }
+      return { disposed };
+    },
+    restoreBySession: (sessionId) => {
+      const restored = store.setDisposedBySession(sessionId, false);
+      if (restored > 0) {
+        afterSync("write");
+        notifyWrite();
+      }
+      return { restored };
+    },
+    listBySession: (sessionId) => toApiList(store.listBySession(sessionId)),
     update: (id, p, ctx = {}) => {
       const old = store.getById(id);
       const updated = store.update(id, p);

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS memories (
   importance  INTEGER NOT NULL DEFAULT 3,
   forgotten   INTEGER NOT NULL DEFAULT 0,
   archived    INTEGER NOT NULL DEFAULT 0,
+  session_disposed_at TEXT,
   source      TEXT,
   session_id  TEXT,
   content_history TEXT,
@@ -321,6 +322,7 @@ function toRow(row) {
     importance: row.importance,
     forgotten: row.forgotten === 1,
     archived: row.archived === 1,
+    session_disposed_at: row.session_disposed_at ?? undefined,
     source: row.source ?? undefined,
     session_id: row.session_id ?? undefined,
     content_history: parseJsonArray(row.content_history),
@@ -567,6 +569,7 @@ export function createStore(path) {
   };
 
   addColumn("memories", "archived", "ALTER TABLE memories ADD COLUMN archived INTEGER NOT NULL DEFAULT 0");
+  addColumn("memories", "session_disposed_at", "ALTER TABLE memories ADD COLUMN session_disposed_at TEXT");
   addColumn("memories", "embedding", "ALTER TABLE memories ADD COLUMN embedding TEXT");
   addColumn("memories", "last_accessed_at", "ALTER TABLE memories ADD COLUMN last_accessed_at TEXT");
   addColumn("memories", "_full_content", "ALTER TABLE memories ADD COLUMN _full_content TEXT");
@@ -618,7 +621,7 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { includeForgotten = false, includeArchived = false } = {}) {
+  function count(type, { includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
@@ -630,6 +633,9 @@ export function createStore(path) {
     }
     if (!includeArchived) {
       clauses.push("archived = 0");
+    }
+    if (!includeDisposed) {
+      clauses.push("session_disposed_at IS NULL");
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
     return db.prepare(`SELECT count(*) AS c FROM memories ${where}`).get(...params).c;
@@ -820,6 +826,41 @@ export function createStore(path) {
     return getById(id);
   }
 
+  // --- session lifecycle (v0.6.0) ------------------------------------------
+  // Session dispose is orthogonal to `archived`: memory_archive is the user/AI
+  // choosing to keep an entry long-term-but-quiet, while session_disposed_at
+  // marks entries hidden because the session they were born in was deleted
+  // (a reversible "undo" — restoreBySession clears it). They never clobber each
+  // other: restoreBySession must not resurrect user-archived memories.
+  function listBySession(sessionId) {
+    const rows = db.prepare(
+      "SELECT * FROM memories WHERE session_id = ? ORDER BY updated_at DESC"
+    ).all(sessionId);
+    return rows.map(toRow);
+  }
+
+  // Idempotent by state guard, not timestamp compare (nowIso() differs every
+  // call, so a fresh-timestamp re-dispose would spuriously count): dispose only
+  // touches rows that are NOT yet disposed; restore only touches rows that ARE.
+  // updated_at is deliberately left alone — this is a lifecycle flag, not
+  // content — so a true flip is the sole trigger for a mirror generation.
+  function setDisposedBySession(sessionId, disposed) {
+    const at = disposed ? nowIso() : null;
+    let affected = 0;
+    runAtomically(() => {
+      const result = disposed
+        ? db.prepare(
+            "UPDATE memories SET session_disposed_at = ? WHERE session_id = ? AND session_disposed_at IS NULL"
+          ).run(at, sessionId)
+        : db.prepare(
+            "UPDATE memories SET session_disposed_at = NULL WHERE session_id = ? AND session_disposed_at IS NOT NULL"
+          ).run(sessionId);
+      affected = result.changes;
+      if (affected > 0) incrementGeneration();
+    });
+    return affected;
+  }
+
   // --- sleep-mode storage support (v0.4.0) ---------------------------------
   // touchLastAccess stamps the read time on recall/inject paths. It deliberately
   // does NOT bump the mirror generation: reads must not mark the mirror dirty.
@@ -876,6 +917,7 @@ export function createStore(path) {
     const rows = db.prepare(
       `SELECT * FROM memories
        WHERE forgotten = 0 AND archived = 0
+         AND session_disposed_at IS NULL
          AND (last_accessed_at IS NULL OR last_accessed_at < ?)
        ORDER BY COALESCE(last_accessed_at, created_at) ASC, id
        LIMIT ?`
@@ -883,7 +925,7 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, includeForgotten = false, includeArchived = false } = {}) {
+  function list({ type, limit = 50, offset = 0, includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
@@ -895,6 +937,9 @@ export function createStore(path) {
     }
     if (!includeArchived) {
       clauses.push("archived = 0");
+    }
+    if (!includeDisposed) {
+      clauses.push("session_disposed_at IS NULL");
     }
     const { limit: lim, offset: off } = sanitizePage(limit, offset, 50);
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
@@ -953,7 +998,7 @@ export function createStore(path) {
     ).all(limit);
   }
 
-  function search(query, { limit = 20, includeArchived = false } = {}) {
+  function search(query, { limit = 20, includeArchived = false, includeDisposed = false } = {}) {
     const q = String(query).trim();
     if (!q) return [];
     // Plain LIKE substring scan over title/content/tags (wildcards escaped so
@@ -962,9 +1007,10 @@ export function createStore(path) {
     const like = `%${escapeLike(q)}%`;
     const { limit: lim } = sanitizePage(limit, 0, 20);
     const archivedFilter = includeArchived ? "" : "archived = 0 AND ";
+    const disposedFilter = includeDisposed ? "" : "session_disposed_at IS NULL AND ";
     const rows = db.prepare(
       `SELECT * FROM memories
-       WHERE ${archivedFilter}forgotten = 0 AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
+       WHERE ${archivedFilter}${disposedFilter}forgotten = 0 AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
        ORDER BY
          CASE WHEN title LIKE ? ESCAPE '\\' THEN 0 ELSE 1 END,
          importance DESC,
@@ -995,12 +1041,13 @@ export function createStore(path) {
    * Brute-force cosine similarity over embedded rows. Returns rows decorated
    * with a `score` (0..1). Only rows with a stored embedding participate.
    */
-  function searchVector(vector, { limit = 20, includeArchived = false, threshold = 0 } = {}) {
+  function searchVector(vector, { limit = 20, includeArchived = false, includeDisposed = false, threshold = 0 } = {}) {
     if (!Array.isArray(vector) || !vector.length) return [];
     const archivedFilter = includeArchived ? "" : "archived = 0 AND ";
+    const disposedFilter = includeDisposed ? "" : "session_disposed_at IS NULL AND ";
     const rows = db.prepare(
       `SELECT * FROM memories
-       WHERE ${archivedFilter}forgotten = 0 AND embedding IS NOT NULL AND embedding != ''`
+       WHERE ${archivedFilter}${disposedFilter}forgotten = 0 AND embedding IS NOT NULL AND embedding != ''`
     ).all();
     const scored = [];
     for (const row of rows) {
@@ -1871,6 +1918,8 @@ export function createStore(path) {
     remove,
     setForget,
     setArchived,
+    listBySession,
+    setDisposedBySession,
     touchLastAccess,
     demoteToSummary,
     restoreContent,

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -4,6 +4,11 @@ export const Config = z.object({
   memoryDir: z.string().default("~/.dsh/memory"),
   autoInject: z.boolean().default(true),
   autoSummarize: z.boolean().default(true),
+  // Session lifecycle (v0.6.0): when enabled, deleting/disposing a session also
+  // archives every memory that was born in it (treating the session as a save
+  // point — entries stay recoverable via memory_archive/restoreBySession).
+  // Default OFF: legacy behavior, a disposed session leaves its memories active.
+  sessionLifecycleEnabled: z.boolean().default(false),
   // Optional model override for summarization. When both are non-empty, they
   // take priority over the session's current model. Empty = use the session's
   // active provider/model (same as before).

--- a/dsh-mneme/src/dream.js
+++ b/dsh-mneme/src/dream.js
@@ -495,7 +495,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
   let inFlight = null;
 
   function shouldTrigger(service) {
-    const memories = service.all().filter((m) => !m.archived && m.type !== "summary");
+    const memories = service.all().filter((m) => !m.archived && !m.session_disposed_at && m.type !== "summary");
     const count = memories.length;
     const chars = totalChars(memories);
     const overBase = count >= baseline.count + thresholdCount || chars >= baseline.chars + thresholdChars;
@@ -844,7 +844,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
           : {}),
         messages: [
           { role: "system", content: [{ type: "text", text: SUMMARY_PROMPT }] },
-          { role: "user", content: [{ type: "text", text: service.all().filter((m) => !m.archived && m.type !== "summary").map((m) => `- ${m.title}: ${m.content}`).join("\n") }] }
+          { role: "user", content: [{ type: "text", text: service.all().filter((m) => !m.archived && !m.session_disposed_at && m.type !== "summary").map((m) => `- ${m.title}: ${m.content}`).join("\n") }] }
         ]
       }, reportUsage));
     } catch (error) {

--- a/dsh-mneme/src/dream/sleep.js
+++ b/dsh-mneme/src/dream/sleep.js
@@ -108,7 +108,7 @@ async function phaseConflicts(ctx, service, config, logger, runId, semantic = nu
   }
   const strictness = config.sleepConflictStrictness ?? "normal";
   const threshold = CONFLICT_THRESHOLDS[strictness] ?? CONFLICT_THRESHOLDS.normal;
-  const memories = service.all().filter((m) => !m.archived && !m.forgotten && m.type !== "summary");
+  const memories = service.all().filter((m) => !m.archived && !m.session_disposed_at && !m.forgotten && m.type !== "summary");
   if (memories.length < 2) return { status: "skipped", reason: "too few memories" };
   if (signal?.aborted) return { status: "aborted", reason: "user activity" };
 
@@ -239,7 +239,7 @@ function phaseDemotion(service, config, logger, runId, signal = null) {
   const archived = [];
   for (const m of service.all()) {
     if (signal?.aborted) break;
-    if (m.archived || m.forgotten) continue;
+    if (m.archived || m.forgotten || m.session_disposed_at) continue;
     const ref = m.last_accessed_at ?? m.updated_at ?? m.created_at;
     if (!ref) continue;
     const t = new Date(ref).getTime();
@@ -273,7 +273,7 @@ async function phasePatterns(ctx, service, config, logger, runId, signal = null)
   const limit = config.sleepPatternMinMemories ?? 100;
   const memories = service
     .list({ limit: 200, includeForgotten: false })
-    .filter((m) => !m.archived && m.type !== "summary" && m.type !== "pattern")
+    .filter((m) => !m.archived && !m.session_disposed_at && m.type !== "summary" && m.type !== "pattern")
     .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))
     .slice(0, limit);
   if (memories.length === 0) return { status: "skipped", reason: "no memories to scan" };
@@ -342,7 +342,7 @@ function phaseRelations(service, config, logger, runId, signal = null) {
   if (entities.length < 2) return { status: "skipped", reason: "too few entities" };
   const orphans = entities.filter((e) => (service.getRelations(e.id) ?? []).length === 0);
   if (orphans.length === 0) return { status: "skipped", reason: "no orphan entities" };
-  const memories = service.all().filter((m) => !m.archived && !m.forgotten);
+  const memories = service.all().filter((m) => !m.archived && !m.session_disposed_at && !m.forgotten);
   const seen = new Set();
   const related = [];
   const MAX_RELATIONS_PER_ORPHAN = 3;

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -317,6 +317,26 @@ export const apply = (ctx, config) => {
   const summarizer = createSummarizer(ctx, service, cfg);
   disposers.push(summarizer.dispose);
 
+  // Session lifecycle (v0.6.0): when a session leaves the store and the toggle
+  // is enabled, mark every memory born in it as session-disposed (hidden from
+  // injection/search/dream but never destroyed — recoverable via
+  // restoreBySession). Default off, so a disposed session leaves its memories
+  // active (legacy behavior). Every path is guarded: a failure inside the
+  // callback must never propagate into DSH's session teardown (that would crash
+  // the plugin on the very delete action it serves).
+  if (cfg.sessionLifecycleEnabled) {
+    disposers.push(ctx.on("session/disposed", (session) => {
+      const sessionId = session?.id;
+      if (!sessionId) return;
+      try {
+        const { disposed } = service.disposeBySession(sessionId);
+        ctx.logger?.info?.(`[dsh-mneme] session disposed, hid ${disposed} memory(s) for ${sessionId}`);
+      } catch (error) {
+        ctx.logger?.warn?.(`[dsh-mneme] session dispose failed for ${sessionId}: ${String(error)}`);
+      }
+    }));
+  }
+
   if (ctx.webServer) {
     const api = createApi(ctx, service, settings, commands ?? {
       add: () => { throw new Error("commands unavailable"); },

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -331,7 +331,7 @@ export function createService({ store, mirror, config, onWrite, logger }) {
   function bm25Recall(q, limit) {
     if (config?.bm25SearchEnabled === false) return [];
     try {
-      const docs = store.list({ limit: 500, includeForgotten: false }).filter((m) => !m.archived);
+      const docs = store.list({ limit: 500, includeForgotten: false }).filter((m) => !m.archived && !m.session_disposed_at);
       if (!docs.length) return [];
       return createBM25Index(docs).search(q, { limit });
     } catch {
@@ -999,6 +999,9 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       tags: m.tags,
       importance: m.importance,
       source: m.source,
+      // session_id is optional on the wire: only carry it when present, so the
+      // DTO stays a lossless JSON object (undefined would vanish on serialize).
+      ...(m.session_id != null ? { session_id: m.session_id } : {}),
       created_at: m.created_at,
       updated_at: m.updated_at
     }));
@@ -1339,6 +1342,28 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       afterSync("write");
       notifyWrite();
     },
+    // Session lifecycle (v0.6.0): mark/clear the session-disposed state on every
+    // memory born in a given session. Uses the dedicated `session_disposed_at`
+    // column, orthogonal to `archived` — restoring a session never resurrects
+    // memories the user archived on purpose. Nothing is destroyed; a session
+    // treated as a save point is fully recoverable via restoreBySession.
+    disposeBySession: (sessionId) => {
+      const disposed = store.setDisposedBySession(sessionId, true);
+      if (disposed > 0) {
+        afterSync("write");
+        notifyWrite();
+      }
+      return { disposed };
+    },
+    restoreBySession: (sessionId) => {
+      const restored = store.setDisposedBySession(sessionId, false);
+      if (restored > 0) {
+        afterSync("write");
+        notifyWrite();
+      }
+      return { restored };
+    },
+    listBySession: (sessionId) => toApiList(store.listBySession(sessionId)),
     update: (id, p, ctx = {}) => {
       const old = store.getById(id);
       const updated = store.update(id, p);

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -1002,6 +1002,9 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       // session_id is optional on the wire: only carry it when present, so the
       // DTO stays a lossless JSON object (undefined would vanish on serialize).
       ...(m.session_id != null ? { session_id: m.session_id } : {}),
+      // Disposed state rides along when set, so a restore flow is not a blind
+      // op — the caller can see which entries are hidden before restoreBySession.
+      ...(m.session_disposed_at != null ? { disposed: true } : {}),
       created_at: m.created_at,
       updated_at: m.updated_at
     }));
@@ -1363,7 +1366,7 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       }
       return { restored };
     },
-    listBySession: (sessionId) => toApiList(store.listBySession(sessionId)),
+    listBySession: (sessionId, opts = {}) => toApiList(store.listBySession(sessionId, opts)),
     update: (id, p, ctx = {}) => {
       const old = store.getById(id);
       const updated = store.update(id, p);

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS memories (
   importance  INTEGER NOT NULL DEFAULT 3,
   forgotten   INTEGER NOT NULL DEFAULT 0,
   archived    INTEGER NOT NULL DEFAULT 0,
+  session_disposed_at TEXT,
   source      TEXT,
   session_id  TEXT,
   content_history TEXT,
@@ -321,6 +322,7 @@ function toRow(row) {
     importance: row.importance,
     forgotten: row.forgotten === 1,
     archived: row.archived === 1,
+    session_disposed_at: row.session_disposed_at ?? undefined,
     source: row.source ?? undefined,
     session_id: row.session_id ?? undefined,
     content_history: parseJsonArray(row.content_history),
@@ -567,6 +569,7 @@ export function createStore(path) {
   };
 
   addColumn("memories", "archived", "ALTER TABLE memories ADD COLUMN archived INTEGER NOT NULL DEFAULT 0");
+  addColumn("memories", "session_disposed_at", "ALTER TABLE memories ADD COLUMN session_disposed_at TEXT");
   addColumn("memories", "embedding", "ALTER TABLE memories ADD COLUMN embedding TEXT");
   addColumn("memories", "last_accessed_at", "ALTER TABLE memories ADD COLUMN last_accessed_at TEXT");
   addColumn("memories", "_full_content", "ALTER TABLE memories ADD COLUMN _full_content TEXT");
@@ -618,7 +621,7 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { includeForgotten = false, includeArchived = false } = {}) {
+  function count(type, { includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
@@ -630,6 +633,9 @@ export function createStore(path) {
     }
     if (!includeArchived) {
       clauses.push("archived = 0");
+    }
+    if (!includeDisposed) {
+      clauses.push("session_disposed_at IS NULL");
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
     return db.prepare(`SELECT count(*) AS c FROM memories ${where}`).get(...params).c;
@@ -820,6 +826,41 @@ export function createStore(path) {
     return getById(id);
   }
 
+  // --- session lifecycle (v0.6.0) ------------------------------------------
+  // Session dispose is orthogonal to `archived`: memory_archive is the user/AI
+  // choosing to keep an entry long-term-but-quiet, while session_disposed_at
+  // marks entries hidden because the session they were born in was deleted
+  // (a reversible "undo" — restoreBySession clears it). They never clobber each
+  // other: restoreBySession must not resurrect user-archived memories.
+  function listBySession(sessionId) {
+    const rows = db.prepare(
+      "SELECT * FROM memories WHERE session_id = ? ORDER BY updated_at DESC"
+    ).all(sessionId);
+    return rows.map(toRow);
+  }
+
+  // Idempotent by state guard, not timestamp compare (nowIso() differs every
+  // call, so a fresh-timestamp re-dispose would spuriously count): dispose only
+  // touches rows that are NOT yet disposed; restore only touches rows that ARE.
+  // updated_at is deliberately left alone — this is a lifecycle flag, not
+  // content — so a true flip is the sole trigger for a mirror generation.
+  function setDisposedBySession(sessionId, disposed) {
+    const at = disposed ? nowIso() : null;
+    let affected = 0;
+    runAtomically(() => {
+      const result = disposed
+        ? db.prepare(
+            "UPDATE memories SET session_disposed_at = ? WHERE session_id = ? AND session_disposed_at IS NULL"
+          ).run(at, sessionId)
+        : db.prepare(
+            "UPDATE memories SET session_disposed_at = NULL WHERE session_id = ? AND session_disposed_at IS NOT NULL"
+          ).run(sessionId);
+      affected = result.changes;
+      if (affected > 0) incrementGeneration();
+    });
+    return affected;
+  }
+
   // --- sleep-mode storage support (v0.4.0) ---------------------------------
   // touchLastAccess stamps the read time on recall/inject paths. It deliberately
   // does NOT bump the mirror generation: reads must not mark the mirror dirty.
@@ -876,6 +917,7 @@ export function createStore(path) {
     const rows = db.prepare(
       `SELECT * FROM memories
        WHERE forgotten = 0 AND archived = 0
+         AND session_disposed_at IS NULL
          AND (last_accessed_at IS NULL OR last_accessed_at < ?)
        ORDER BY COALESCE(last_accessed_at, created_at) ASC, id
        LIMIT ?`
@@ -883,7 +925,7 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, includeForgotten = false, includeArchived = false } = {}) {
+  function list({ type, limit = 50, offset = 0, includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
@@ -895,6 +937,9 @@ export function createStore(path) {
     }
     if (!includeArchived) {
       clauses.push("archived = 0");
+    }
+    if (!includeDisposed) {
+      clauses.push("session_disposed_at IS NULL");
     }
     const { limit: lim, offset: off } = sanitizePage(limit, offset, 50);
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
@@ -953,7 +998,7 @@ export function createStore(path) {
     ).all(limit);
   }
 
-  function search(query, { limit = 20, includeArchived = false } = {}) {
+  function search(query, { limit = 20, includeArchived = false, includeDisposed = false } = {}) {
     const q = String(query).trim();
     if (!q) return [];
     // Plain LIKE substring scan over title/content/tags (wildcards escaped so
@@ -962,9 +1007,10 @@ export function createStore(path) {
     const like = `%${escapeLike(q)}%`;
     const { limit: lim } = sanitizePage(limit, 0, 20);
     const archivedFilter = includeArchived ? "" : "archived = 0 AND ";
+    const disposedFilter = includeDisposed ? "" : "session_disposed_at IS NULL AND ";
     const rows = db.prepare(
       `SELECT * FROM memories
-       WHERE ${archivedFilter}forgotten = 0 AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
+       WHERE ${archivedFilter}${disposedFilter}forgotten = 0 AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
        ORDER BY
          CASE WHEN title LIKE ? ESCAPE '\\' THEN 0 ELSE 1 END,
          importance DESC,
@@ -995,12 +1041,13 @@ export function createStore(path) {
    * Brute-force cosine similarity over embedded rows. Returns rows decorated
    * with a `score` (0..1). Only rows with a stored embedding participate.
    */
-  function searchVector(vector, { limit = 20, includeArchived = false, threshold = 0 } = {}) {
+  function searchVector(vector, { limit = 20, includeArchived = false, includeDisposed = false, threshold = 0 } = {}) {
     if (!Array.isArray(vector) || !vector.length) return [];
     const archivedFilter = includeArchived ? "" : "archived = 0 AND ";
+    const disposedFilter = includeDisposed ? "" : "session_disposed_at IS NULL AND ";
     const rows = db.prepare(
       `SELECT * FROM memories
-       WHERE ${archivedFilter}forgotten = 0 AND embedding IS NOT NULL AND embedding != ''`
+       WHERE ${archivedFilter}${disposedFilter}forgotten = 0 AND embedding IS NOT NULL AND embedding != ''`
     ).all();
     const scored = [];
     for (const row of rows) {
@@ -1871,6 +1918,8 @@ export function createStore(path) {
     remove,
     setForget,
     setArchived,
+    listBySession,
+    setDisposedBySession,
     touchLastAccess,
     demoteToSummary,
     restoreContent,

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -578,6 +578,12 @@ export function createStore(path) {
   addColumn("memories", "quality_score", "ALTER TABLE memories ADD COLUMN quality_score REAL");
   addColumn("memories", "session_id", "ALTER TABLE memories ADD COLUMN session_id TEXT");
 
+  // Composite index for session-lifecycle queries (dispose/restore/listBySession).
+  // Created post-migration, NOT in SCHEMA: on legacy DBs both columns arrive via
+  // ADD COLUMN above, so the index would fail at db.exec(SCHEMA) time. CREATE
+  // INDEX IF NOT EXISTS is atomic, so the two-process race is safe here.
+  db.exec("CREATE INDEX IF NOT EXISTS idx_memories_session ON memories(session_id, session_disposed_at)");
+
   // Legacy dream_runs without policy_epoch → backfill with the default epoch.
   addColumn("dream_runs", "policy_epoch", "ALTER TABLE dream_runs ADD COLUMN policy_epoch INTEGER NOT NULL DEFAULT 0");
   addColumn("dream_runs", "run_type", "ALTER TABLE dream_runs ADD COLUMN run_type TEXT NOT NULL DEFAULT 'auto'");
@@ -832,9 +838,13 @@ export function createStore(path) {
   // marks entries hidden because the session they were born in was deleted
   // (a reversible "undo" — restoreBySession clears it). They never clobber each
   // other: restoreBySession must not resurrect user-archived memories.
-  function listBySession(sessionId) {
+  // Mirrors list/search: disposed rows are hidden by default. A consumer that
+  // needs to see the full picture (e.g. a restore flow that tells the user
+  // "these N entries were hidden") opts in via includeDisposed.
+  function listBySession(sessionId, { includeDisposed = false } = {}) {
+    const disposedFilter = includeDisposed ? "" : "AND session_disposed_at IS NULL";
     const rows = db.prepare(
-      "SELECT * FROM memories WHERE session_id = ? ORDER BY updated_at DESC"
+      `SELECT * FROM memories WHERE session_id = ? ${disposedFilter} ORDER BY updated_at DESC`
     ).all(sessionId);
     return rows.map(toRow);
   }

--- a/dsh-mneme/test/service.test.js
+++ b/dsh-mneme/test/service.test.js
@@ -415,3 +415,21 @@ test("listBySession returns only that session's memories via wire DTOs", () => {
   assert.equal(rows[0].title, "会话决策");
   assert.equal(rows[0].session_id, "sess-7");
 });
+
+test("listBySession DTO hides disposed by default and flags it when included", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  const { memory } = svc.saveWithDedupe({ type: "decision", title: "会话决策", content: "d", session_id: "sess-9" });
+  svc.disposeBySession("sess-9");
+
+  assert.equal(svc.listBySession("sess-9").length, 0, "disposed hidden by default");
+  const visible = svc.listBySession("sess-9", { includeDisposed: true });
+  assert.equal(visible.length, 1);
+  assert.equal(visible[0].id, memory.id);
+  assert.equal(visible[0].disposed, true, "DTO carries disposed marker so restore is not blind");
+
+  svc.restoreBySession("sess-9");
+  const restored = svc.listBySession("sess-9");
+  assert.equal(restored.length, 1, "restore brings it back to default view");
+  assert.equal(restored[0].disposed, undefined, "marker cleared after restore");
+});

--- a/dsh-mneme/test/service.test.js
+++ b/dsh-mneme/test/service.test.js
@@ -76,6 +76,10 @@ test("toApiList maps store rows to wire DTOs", () => {
   assert.equal(dto[0].title, "选型");
   assert.equal(dto[0].content, "node:sqlite");
   assert.equal(dto[0].importance, 3);
+  // session_id rides the DTO when present (session lifecycle needs it)
+  const withSession = service.saveWithDedupe({ type: "decision", title: "带会话", content: "y", session_id: "sess-x" });
+  const dto2 = service.toApiList([withSession.memory]);
+  assert.equal(dto2[0].session_id, "sess-x");
 });
 
 test("mergeHumanEdits skips edits without id and keeps applying the rest", () => {
@@ -326,4 +330,88 @@ test("Bug7: injection ranking re-weights by quality_score (degraded memories ran
   const candidates = svc.injectCandidates({ maxItems: 5, threshold: 3 });
   assert.equal(candidates[0].title, "高质量", "100-quality preference leads the degraded one");
   assert.equal(candidates[1].title, "元记忆");
+});
+
+// --- session lifecycle (v0.6.0): dispose/restore by session -----------------
+// session_disposed_at is orthogonal to `archived`: dispose hides only entries
+// born in the deleted session, and restore never resurrects user-archived ones.
+
+test("disposeBySession marks only that session's memories", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  const s1 = svc.saveWithDedupe({ type: "project", title: "会话A记忆", content: "x", session_id: "sess-1" });
+  svc.saveWithDedupe({ type: "project", title: "会话B记忆", content: "y", session_id: "sess-2" });
+
+  const res = svc.disposeBySession("sess-1");
+  assert.deepEqual(res, { disposed: 1 });
+  assert.ok(svc.getById(s1.memory.id).session_disposed_at, "session-1 memory marked disposed");
+  // disposed memories vanish from default list (like archived)
+  assert.ok(!svc.list({ type: "project" }).some((m) => m.id === s1.memory.id), "disposed hidden from default list");
+  const other = svc.list({ type: "project", includeDisposed: true });
+  assert.ok(other.some((m) => m.title === "会话B记忆" && !m.session_disposed_at), "other session untouched");
+});
+
+test("restoreBySession clears the dispose mark and makes entries visible again", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  const s1 = svc.saveWithDedupe({ type: "project", title: "存档会话", content: "x", session_id: "sess-9" });
+  svc.disposeBySession("sess-9");
+
+  assert.ok(!svc.list({ type: "project" }).some((m) => m.id === s1.memory.id), "hidden while disposed");
+  const res = svc.restoreBySession("sess-9");
+  assert.deepEqual(res, { restored: 1 });
+  assert.equal(svc.getById(s1.memory.id).session_disposed_at, undefined, "dispose mark cleared");
+  assert.ok(svc.list({ type: "project" }).some((m) => m.id === s1.memory.id), "visible again");
+});
+
+test("disposeBySession is idempotent: re-disposing returns 0", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  svc.saveWithDedupe({ type: "project", title: "重复销毁", content: "x", session_id: "sess-3" });
+
+  assert.deepEqual(svc.disposeBySession("sess-3"), { disposed: 1 });
+  assert.deepEqual(svc.disposeBySession("sess-3"), { disposed: 0 }, "no rows flipped the second time");
+});
+
+test("disposeBySession on an unknown session is a no-op", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  assert.deepEqual(svc.disposeBySession("nope"), { disposed: 0 });
+  assert.deepEqual(svc.restoreBySession("nope"), { restored: 0 });
+});
+
+test("legacy rows without session_id are never touched by session lifecycle", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  const legacy = svc.saveWithDedupe({ type: "preference", title: "全局记忆", content: "no session", session_id: undefined });
+
+  svc.disposeBySession("sess-x");
+  assert.equal(svc.getById(legacy.memory.id).session_disposed_at, undefined, "global memory survives session dispose");
+});
+
+test("restoreBySession does NOT resurrect user-archived memories (orthogonal)", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  // user manually archived this one (archived=true), then the session is disposed
+  const { memory: userArchived } = svc.saveWithDedupe({ type: "decision", title: "手动归档", content: "x", session_id: "sess-4" });
+  svc.setArchived(userArchived.id, true);
+  svc.disposeBySession("sess-4");
+
+  svc.restoreBySession("sess-4");
+  assert.equal(svc.getById(userArchived.id).archived, true, "user archive survives restore");
+  assert.equal(svc.getById(userArchived.id).session_disposed_at, undefined, "dispose mark cleared but archive kept");
+  assert.ok(!svc.list({ type: "decision" }).some((m) => m.id === userArchived.id), "still hidden by user archive");
+});
+
+test("listBySession returns only that session's memories via wire DTOs", () => {
+  const store = createStore(":memory:");
+  const svc = createService({ store, mirror: null, config: {} });
+  const { memory } = svc.saveWithDedupe({ type: "decision", title: "会话决策", content: "d", session_id: "sess-7" });
+  svc.saveWithDedupe({ type: "decision", title: "别会话", content: "e", session_id: "sess-8" });
+
+  const rows = svc.listBySession("sess-7");
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, memory.id);
+  assert.equal(rows[0].title, "会话决策");
+  assert.equal(rows[0].session_id, "sess-7");
 });

--- a/dsh-mneme/test/store.test.js
+++ b/dsh-mneme/test/store.test.js
@@ -423,3 +423,14 @@ test("setDisposedBySession round-trips and listBySession sees all states", () =>
   assert.equal(bySession.length, 1);
   assert.equal(bySession[0].id, a.id);
 });
+
+test("listBySession hides disposed by default, includeDisposed opts in", () => {
+  const store = createStore(":memory:");
+  const a = store.save({ type: "decision", title: "会话记忆", content: "c", session_id: "sess-y" });
+  store.setDisposedBySession("sess-y", true);
+
+  assert.equal(store.listBySession("sess-y").length, 0, "disposed row hidden by default");
+  const all = store.listBySession("sess-y", { includeDisposed: true });
+  assert.equal(all.length, 1, "includeDisposed reveals it");
+  assert.equal(all[0].id, a.id);
+});

--- a/dsh-mneme/test/store.test.js
+++ b/dsh-mneme/test/store.test.js
@@ -358,3 +358,68 @@ test("conflict_pending table persists across store reopen", () => {
   assert.equal(pending[0].reason, "x");
   s2.close();
 });
+
+// --- session lifecycle (v0.6.0): disposed rows are filtered out ------------
+
+test("session_disposed_at column exists and survives migration", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mneme-disposed-"));
+  const path = join(dir, "memory.db");
+  const s1 = createStore(path);
+  const { id } = s1.save({ type: "decision", title: "迁移", content: "c", session_id: "sess-m" });
+  s1.setDisposedBySession("sess-m", true);
+  const row = s1.db.prepare("SELECT session_disposed_at FROM memories WHERE id = ?").get(id);
+  assert.ok(row.session_disposed_at, "dispose timestamp persisted");
+  s1.close();
+  // reopen: column survives
+  const s2 = createStore(path);
+  const live = s2.list({ type: "decision" });
+  assert.ok(!live.some((m) => m.id === id), "disposed row excluded after reopen");
+  s2.close();
+});
+
+test("search and list exclude disposed rows unless includeDisposed", () => {
+  const store = createStore(":memory:");
+  const a = store.save({ type: "decision", title: "活着", content: "keyword alpha", session_id: "s1" });
+  const b = store.save({ type: "decision", title: "被销毁", content: "keyword beta", session_id: "s2" });
+  store.setDisposedBySession("s2", true);
+
+  const searchRes = store.search("keyword");
+  assert.ok(searchRes.some((m) => m.id === a.id), "live row found");
+  assert.ok(!searchRes.some((m) => m.id === b.id), "disposed row excluded from search");
+  const searchIncl = store.search("keyword", { includeDisposed: true });
+  assert.ok(searchIncl.some((m) => m.id === b.id), "includeDisposed surfaces it");
+
+  const listRes = store.list({ type: "decision" });
+  assert.ok(listRes.some((m) => m.id === a.id));
+  assert.ok(!listRes.some((m) => m.id === b.id), "disposed excluded from list");
+  const listIncl = store.list({ type: "decision", includeDisposed: true });
+  assert.ok(listIncl.some((m) => m.id === b.id), "includeDisposed lists it");
+  assert.equal(store.count("decision", { includeDisposed: true }), 2);
+});
+
+test("searchVector excludes disposed rows", () => {
+  const store = createStore(":memory:");
+  const a = store.save({ type: "decision", title: "向量A", content: "v", session_id: "s1" });
+  const b = store.save({ type: "decision", title: "向量B", content: "v", session_id: "s2" });
+  store.setEmbedding(a.id, [1, 0, 0]);
+  store.setEmbedding(b.id, [1, 0, 0]);
+  store.setDisposedBySession("s2", true);
+
+  const res = store.searchVector([1, 0, 0], { limit: 10 });
+  assert.ok(res.some((m) => m.id === a.id));
+  assert.ok(!res.some((m) => m.id === b.id), "disposed row excluded from vector search");
+});
+
+test("setDisposedBySession round-trips and listBySession sees all states", () => {
+  const store = createStore(":memory:");
+  const a = store.save({ type: "decision", title: "会话记忆", content: "c", session_id: "sess-z" });
+  assert.equal(store.setDisposedBySession("sess-z", true), 1, "first dispose flips 1");
+  assert.equal(store.setDisposedBySession("sess-z", true), 0, "re-dispose is a no-op");
+  assert.equal(store.setDisposedBySession("sess-z", false), 1, "restore flips 1");
+  assert.equal(store.setDisposedBySession("sess-z", false), 0, "re-restore is a no-op");
+  assert.equal(store.getById(a.id).session_disposed_at, undefined, "mark cleared after restore");
+
+  const bySession = store.listBySession("sess-z");
+  assert.equal(bySession.length, 1);
+  assert.equal(bySession[0].id, a.id);
+});


### PR DESCRIPTION
## v0.6.0 会话生命周期（不进主线，待审）

把"对话"当作存档点：会话被删除/销毁时（DSH `session/disposed` 宿主事件），该会话内出生的记忆被**软隐藏**（可恢复），与用户手动 `archived` 正交。

### 方案（采纳 Kimi 架构建议）
- 新增独立字段 `session_disposed_at TEXT`，不复用 `archived`——因为 restoreBySession 会误恢复用户手动归档的记忆，且 autoDream 过滤会把用户主动保留的记忆和被动隔离的"聊天废话"混在一起
- `archived`（用户/AI 主动归档，长期保留但安静）与 `session_disposed_at`（会话删除被动隔离，可撤销）**互不覆盖**：restore 不复活手动归档

### 实现
| 层 | 内容 |
|---|---|
| schema | `session_disposed_at TEXT` 列 + `(session_id, session_disposed_at)` 复合索引（置于 addColumn 迁移后，兼容 legacy 库） |
| store | `setDisposedBySession` 幂等（状态守卫 WHERE，dispose 只动 IS NULL 行 / restore 只动 IS NOT NULL 行）；count/list/search/searchVector/getUnrecalledSince 默认排除 disposed，listBySession 同（includeDisposed 可选） |
| service | `disposeBySession` / `restoreBySession`（afterSync+notifyWrite）；listBySession 透传 includeDisposed；toApiList 条件带 `disposed` 标记 |
| dream | dream.js shouldTrigger/summary 候选 + sleep.js 4 处 phase 过滤同步排除 `session_disposed_at`；decisions.js 不改（AI 主动合并 = archived 语义） |
| events | `sessionLifecycleEnabled` 开关（默认 false）；订阅熔断：内部异常 catch 住，不抛进 DSH session 清理流程 |

### 测试（626 全绿）
- 开关 false 不订阅、存量无 session_id 记忆不受影响
- dispose → 标记 → 过滤 → restore 完整链路
- 幂等（重复 dispose/restore 为 no-op）、未知会话空操作、restore 不复活手动归档、正交性
- listBySession 默认隐藏 disposed + includeDisposed 可见 + DTO 带 disposed 标记

### 审查
阿里云 kimi-k2.7-code 已审（8 条发现，4 条已修复，见 commit e99241f）：
- ✅ #1/#2 listBySession 未过滤/未透传（HIGH，真 BUG）→ 已修
- ✅ #3 toApiList 缺 disposed 标记（restore 盲操作）→ 已修
- ✅ #4 缺 (session_id, session_disposed_at) 索引 → 已补
- ⏸️ #5 事件异步竞态（判定低风险：dispose 事件在会话已结束时发出，晚到写入影响有限）→ 不加代码，index.js 注释说明
- ⏸️ #6 session_id 变更残留（session_id 实际不可变，场景不成立）→ 记 TODO
- ⏸️ #7 archived 视图语义（产品决策，当前"默认列表都隐藏"符合预期）

### 待补
- README：配置项 `sessionLifecycleEnabled` 默认 false 的语义说明文档