### PR TITLE
feat: memory_delete 支持按描述删除（query 参数）

### DIFF
--- a/dsh-mneme/lib/tools.js
+++ b/dsh-mneme/lib/tools.js
@@ -180,9 +180,10 @@ export function createTools(ctx, service, config, embedder) {
 
     defineTool({
       name: "memory_delete",
-      description: "Permanently delete a memory entry.",
+      description: "Permanently delete a memory entry. Pass id for exact delete, or query to delete the single best-matching entry by text — lets the agent honor 'delete the memory about X' without a prior list/search round trip.",
       parameters: {
-        id: { type: "string", required: true }
+        id: { type: "string", description: "Exact memory id to delete (from memory_list/memory_search output)" },
+        query: { type: "string", description: "Delete the best-matching entry for this text (searches title/content/tags; uses hybrid recall when an embedder is configured)" }
       },
       output: {
         schema: {
@@ -193,9 +194,19 @@ export function createTools(ctx, service, config, embedder) {
         render: (_args, value) => TEXT_OUTPUT(value.deleted ? "Memory deleted." : "Memory not found.")
       },
       async execute(args) {
-        const existed = service.getById(args.id) !== undefined;
-        if (existed) service.remove(args.id);
-        return { deleted: existed };
+        if (args.id) {
+          const existed = service.getById(args.id) !== undefined;
+          if (existed) service.remove(args.id);
+          return { deleted: existed };
+        }
+        if (args.query) {
+          const [best] = await service.searchMemories(args.query, { mode: "auto", topK: 1, useRerank: true });
+          if (best) {
+            service.remove(best.id);
+            return { deleted: true };
+          }
+        }
+        return { deleted: false };
       }
     }),
 

--- a/dsh-mneme/src/tools.js
+++ b/dsh-mneme/src/tools.js
@@ -180,9 +180,10 @@ export function createTools(ctx, service, config, embedder) {
 
     defineTool({
       name: "memory_delete",
-      description: "Permanently delete a memory entry.",
+      description: "Permanently delete a memory entry. Pass id for exact delete, or query to delete the single best-matching entry by text — lets the agent honor 'delete the memory about X' without a prior list/search round trip.",
       parameters: {
-        id: { type: "string", required: true }
+        id: { type: "string", description: "Exact memory id to delete (from memory_list/memory_search output)" },
+        query: { type: "string", description: "Delete the best-matching entry for this text (searches title/content/tags; uses hybrid recall when an embedder is configured)" }
       },
       output: {
         schema: {
@@ -193,9 +194,19 @@ export function createTools(ctx, service, config, embedder) {
         render: (_args, value) => TEXT_OUTPUT(value.deleted ? "Memory deleted." : "Memory not found.")
       },
       async execute(args) {
-        const existed = service.getById(args.id) !== undefined;
-        if (existed) service.remove(args.id);
-        return { deleted: existed };
+        if (args.id) {
+          const existed = service.getById(args.id) !== undefined;
+          if (existed) service.remove(args.id);
+          return { deleted: existed };
+        }
+        if (args.query) {
+          const [best] = await service.searchMemories(args.query, { mode: "auto", topK: 1, useRerank: true });
+          if (best) {
+            service.remove(best.id);
+            return { deleted: true };
+          }
+        }
+        return { deleted: false };
       }
     }),
 

--- a/dsh-mneme/test/tools.test.js
+++ b/dsh-mneme/test/tools.test.js
@@ -142,6 +142,26 @@ test("memory_delete on missing id returns deleted:false", async () => {
   assert.equal(result.deleted, false);
 });
 
+test("memory_delete by query deletes the best match (no id round-trip)", async () => {
+  const { registered, service, store } = setup();
+  const { memory } = service.saveWithDedupe({ type: "preference", title: "喜欢 Rust", content: "用户偏好 Rust 优先于 Go", importance: 4 });
+  service.saveWithDedupe({ type: "preference", title: "喜欢 Python", content: "用户偏好 Python 写脚本", importance: 3 });
+  const del = registered.find((t) => t.name === "memory_delete");
+  const result = await del.execute({ query: "Rust" });
+  assert.equal(result.deleted, true);
+  assert.equal(service.getById(memory.id), undefined, "best-matching Rust entry removed");
+  assert.equal(store.count(), 1, "non-matching entry untouched");
+});
+
+test("memory_delete by query with no match returns deleted:false", async () => {
+  const { registered, service, store } = setup();
+  service.saveWithDedupe({ type: "preference", title: "喜欢 Rust", content: "用户偏好 Rust", importance: 4 });
+  const del = registered.find((t) => t.name === "memory_delete");
+  const result = await del.execute({ query: "完全不存在的关键词xyz" });
+  assert.equal(result.deleted, false);
+  assert.equal(store.count(), 1, "nothing removed when no match");
+});
+
 test("memory_forget suppresses injection without deleting", async () => {
   const { registered, service, store } = setup();
   const { memory } = service.saveWithDedupe({ type: "project", title: "t", content: "c", importance: 5 });


### PR DESCRIPTION
## 背景
桉桉要求删除记忆简单化：支持按描述删除，不必先 list/search 拿 id。

## 改动
- `memory_delete` 新增可选 `query` 参数：按文本删最佳匹配记忆（混合召回 top1）
- `id` 与 `query` 互斥；无匹配返回 `deleted:false`
- 新增 2 例测试：按 query 删最佳匹配 / 无匹配返回 false

## 测试
- 613 → **615** 全绿

> 独立于 v0.6.0（#15），可单独合并或等 v0.6.0 一起发，按桉桉节奏。