### PR TITLE
docs: 路线图补充 v0.7.0 + v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ dsh web
 ## 🗺️ 路线图
 
 ```
-🧬 基因（v0.3.0）→ 🛡️ 审计加固（v0.3.6–0.3.9）→ 💤 睡眠维护（v0.4.0）→ 🕸️ 召回融合与图谱（v0.5.0）→ ✨ 面板增强（v0.6.x）→ 🌡️ 自进化记忆（v0.7.0）
+🧬 基因（v0.3.0）→ 🛡️ 审计加固（v0.3.6–0.3.9）→ 💤 睡眠维护（v0.4.0）→ 🕸️ 召回融合与图谱（v0.5.0）→ ✨ 面板增强（v0.6.x）→ 🌡️ 自进化记忆（v0.7.0）→ 🕸️ 图谱增强（v0.8.0）
 ```
 
 | 版本 | 主题 | 状态 |
@@ -102,8 +102,8 @@ dsh web
 | **v0.4.0** | Sleep Mode：空闲四阶段深度维护 | ✅ |
 | **v0.5.0** | 召回融合与记忆可视化：BM25 + 图谱 + 热记忆 | ✅ |
 | **v0.6.0** | 会话生命周期：删会话 ≠ 删记忆 | ✅ |
-| **v0.7.0** | 自进化记忆（heat 热度）✅ 完成 | ✅ 完成 | heat 幂律衰减 + per-type 半衰期 + sleep 热联合双保护 + updated_at 语义修正 + recall_runs injected 标记 + 90 天清理 + 实体热投影；757 测试全绿 |
-| **v0.7.0+** | 兴趣漂移 + 跨 workspace | 🚧 远期 | 更多 heat 信号 + 跨 workspace 共享 |
+| **v0.7.0** | 自进化记忆：heat 幂律衰减 + sleep 双保护 + 实体热投影 | ✅ |
+| **v0.8.0** | 图谱增强：兴趣漂移 + 跨 workspace 共享 | 🚧 计划中（9 月末） |
 
 ## 🧪 本地开发
 
@@ -194,7 +194,7 @@ Works out of the box. Enable these as needed:
 ## 🗺️ Roadmap
 
 ```
-🧬 Gene (v0.3.0) → 🛡️ Audit hardening (v0.3.6–0.3.9) → 💤 Sleep maintenance (v0.4.0) → 🕸️ Recall fusion & graph (v0.5.0) → ✨ Panel enhancements (v0.6.x) → 🌡️ Self-evolving memory (v0.7.0)
+🧬 Gene (v0.3.0) → 🛡️ Audit hardening (v0.3.6–0.3.9) → 💤 Sleep maintenance (v0.4.0) → 🕸️ Recall fusion & graph (v0.5.0) → ✨ Panel enhancements (v0.6.x) → 🌡️ Self-evolving memory (v0.7.0) → 🕸️ Graph enhancement (v0.8.0)
 ```
 
 | Version | Theme | Status |
@@ -203,7 +203,8 @@ Works out of the box. Enable these as needed:
 | **v0.4.0** | Sleep Mode: idle 4-phase deep maintenance | ✅ |
 | **v0.5.0** | Recall fusion & visualization: BM25 + graph + hot memory | ✅ |
 | **v0.6.0** | Session lifecycle: delete session ≠ delete memories | ✅ |
-| **v0.7.0+** | Interest drift + cross-workspace | 🚧 Long-term |
+| **v0.7.0** | Self-evolving memory: heat decay + sleep dual-protection + entity heat projection | ✅ |
+| **v0.8.0** | Graph enhancement: interest drift + cross-workspace sharing | 🚧 Planned (late Sep) |
 
 ## 🧪 Local Development
 

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -285,7 +285,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 | **v0.6.3** | ✅ 完成 | 目录视图 | Tag 文件夹手风琴 + 无标签兜底 + 点击跳详情 + `GET /api/dsh-mneme/directory` 端点 |
 | **v0.6.4** | ✅ 完成 | Tag 加权召回 | query/session tag 交集 boost（×1.15 / ×1.08），`tagBoostEnabled` 默认关 |
 | **v0.7.0** | ✅ 完成 | 自进化记忆 | heat 幂律衰减 + per-type 差异化半衰期（TYPE_DECAY）+ sleep 热联合双保护 + updated_at 语义修正 + recall_runs injected 两档标记 + 90 天清理 + 实体热投影（前端节点大小/明暗）；757 测试全绿 |
-| **v0.7.0+** | 🚀 远期 | 自进化记忆（远期） | 跨 workspace 记忆共享（等 DSH 支持）+ 更多 heat 信号 |
+| **v0.8.0** | 🚧 计划中（9 月末） | 图谱增强 | 兴趣漂移可视化 + 跨 workspace 记忆共享 + 更多 heat 信号 |
 
 > 新能力一律做成**可开关的功能**（配置启用/关闭），默认保守开启、不破坏现有行为。`failure_memories` 表与 autoDream 决策引擎已为后续反思性成长铺好路。
 


### PR DESCRIPTION
README 中英双表路线图更新：v0.7.0 ✅ 已发布，新增 v0.8.0 🚧 计划中（9 月末）。纯文档改动，无代码变更。