### PR TITLE
feat: 左下角入口按钮可选开关 showSidebarTrigger（issue #38）

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.7.3] - 2026-08-29
+
+### 🆕 新功能（issue #38）
+
+- **左下角入口按钮可关闭**：新增配置 `showSidebarTrigger`（默认 `true`，关闭时行为与之前完全一致）。dsh-mneme 的记忆入口按钮注入在侧边栏底部 footer slot（左下角），与同样抢占该位置的插件（如 dsh-cost-meter）冲突时 UI 会叠加/错乱。现在可在 **Web 面板「设置」→「侧边栏入口按钮」**一键关闭；关闭仅隐藏按钮，记忆库仍可通过顶部「记忆库」标签访问，功能不受影响
+- 设置走 settings-over-config（与 `autoTagEnabled` 同机制）：面板开关持久化到 `user_settings`，未触碰时回退插件配置默认值；`/api/dsh-mneme/config` 的 GET/PUT 同步支持该字段（PUT 只接受布尔，非法值 400）
+
+### 测试
+
+- 新增 7 个回归测试（api 3 + settings 2 + config 1 + client 1），全套 **776 通过**
+
 ## [0.7.2] - 2026-08-26
 
 ### 🐛 修复（issue #35）

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -241,6 +241,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 | 版本 | 亮点 |
 |------|------|
+| **v0.7.3** | issue #38 新功能：左下角入口按钮可选开关 `showSidebarTrigger`（默认开）——与 dsh-cost-meter 等抢占 footer slot 的插件冲突时可在 Web 面板「设置」一键关闭，仅隐藏按钮、记忆库标签不受影响；776 测试全绿 |
 | **v0.7.2** | issue #35 修复：目录页删除按钮改面板内联两步确认（不再依赖宿主 `window.confirm`）+ 删除失败可见报错；issue #34 新功能：opt-in `injectTimePrefix` 对话开始自动注入当前时间一次（默认关）；770 测试全绿 |
 | **v0.7.1** | issue #31 修复：memory_save/memory_update 的 tags 桥接进 entity_attrs 标签存储（目录/`tag:` 检索/tagBoost 立即可见，`tags: []` 清空移回 untagged）+ `store.setMemoryTags` 反向同步 `memories.tags` 列 + autoTag 面板开关成为运行时消费方（settings 覆盖 config）；764 测试全绿 |
 | **v0.7.0** | 自进化记忆（heat 热度模型 + per-type 差异化半衰期 + sleep 热联合双保护）+ updated_at 语义修正（不算访问）+ recall_runs injected 两档标记 + 90 天滚动清理 + 实体热投影（ego-graph node heat → 前端节点大小/明暗）；757 测试全绿 |
@@ -289,6 +290,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 | **v0.7.0** | ✅ 完成 | 自进化记忆 | heat 幂律衰减 + per-type 差异化半衰期（TYPE_DECAY）+ sleep 热联合双保护 + updated_at 语义修正 + recall_runs injected 两档标记 + 90 天清理 + 实体热投影（前端节点大小/明暗）；757 测试全绿 |
 | **v0.7.1** | ✅ 完成 | issue #31 修复 | memory_save/update tags 桥接 entity_attrs 标签存储 + 列反向同步 + autoTag 面板开关生效（settings 覆盖 config）；764 测试全绿 |
 | **v0.7.2** | ✅ 完成 | issue #34 + #35 修复 | 目录页删除按钮改内联两步确认 + 删除失败可见报错；opt-in `injectTimePrefix` 对话开始注入当前时间一次（默认关）；770 测试全绿 |
+| **v0.7.3** | ✅ 完成 | issue #38 新功能 | 左下角入口按钮可选开关 `showSidebarTrigger`（默认开，settings-over-config）；Web 面板设置一键关闭，与 dsh-cost-meter 等 footer 插件冲突可隐藏按钮、记忆库标签不受影响；776 测试全绿 |
 | **v0.8.0** | 🚧 计划中（9 月末） | 图谱增强 | 兴趣漂移可视化 + 跨 workspace 记忆共享 + 更多 heat 信号 |
 
 > 新能力一律做成**可开关的功能**（配置启用/关闭），默认保守开启、不破坏现有行为。`failure_memories` 表与 autoDream 决策引擎已为后续反思性成长铺好路。
@@ -409,6 +411,7 @@ dsh web
 | `memoryQualityFilter` | `{enabled:true, archiveThreshold:30, degradeThreshold:60, minContentLength:10}` | 记忆质量过滤（v0.4.6，默认开）：写库前启发式打分 0-100，元记忆词汇/自指/过短/重复/近似重复扣分；≥60 正常存储，30-60 降权（注入排序按 importance×quality/100），<30 归档标记 `low_quality`（显式搜索仍可召回，永不自动注入） |
 | `llmAudit` | `{enabled:true, retentionDays:90}` | LLM 消耗审计（v0.4.6，默认开）：每次后台 LLM 调用（autoDream/autoSummarize）写 `llm_audit_logs`（tokens/duration/status/source）；失败记 error 不阻塞；只读 API `/api/dsh-mneme/semantic/llm-audit` + `/llm-audit/stats` |
 | `sessionLifecycleEnabled` | `false` | 会话生命周期（v0.6.0，默认关）：开启后会话被删除/销毁时自动把该会话出生的记忆软隐藏（`session_disposed_at`，与 `archived` 正交、可恢复）；存量无 `session_id` 的记忆永不参与清理 |
+| `showSidebarTrigger` | `true` | 侧边栏底部（左下角）记忆入口按钮（issue #38，默认开）：与其他插件（如 dsh-cost-meter）抢占同一 footer slot 导致 UI 冲突时可关掉；仅隐藏按钮，记忆库仍可通过顶部「记忆库」标签访问。Web 面板「设置」里有对应开关 |
 
 > 🔐 **API 安全**：DSH 无内置鉴权且默认仅监听 `127.0.0.1`。插件 API 默认开放（便于 Web 面板即装即用）。如需防护（如局域网暴露），在配置中设置 `apiToken`：写操作（画像/规则/命令）与密钥端点（`vector-config`、`vector-reindex`）需携带 `Authorization: Bearer <token>`（前端设置面板可填入同一 token），只读的 `list` / `search` / `semantic` 保持开放。`/api/dsh-mneme/vector-config` 返回的 `apiKey` 已掩码（`sk-***…`），存储仍保留明文供调用；前端回传空或掩码值表示"不改 key"。
 

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -238,19 +238,22 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
             }
             return true;
           };
-          if (!setIfBoolean("autoTagEnabled") || !setIfBoolean("manualTagEnabled")) return;
+          if (!setIfBoolean("autoTagEnabled") || !setIfBoolean("manualTagEnabled") || !setIfBoolean("showSidebarTrigger")) return;
           if (Object.keys(patch).length === 0) {
             sendJson(res, 400, { error: "no valid config field provided" });
             return;
           }
+          // Each setter ignores the keys it doesn't own, so one patch can feed
+          // both stores safely (tag toggles → "autoTag", UI prefs → "ui").
           settings.setAutoTagConfig(patch);
+          settings.setUiConfig(patch);
           // Respond with the effective (settings-over-config merged) toggles
           // so the panel always sees booleans that actually gate runtime
           // behaviour (issue #31).
-          sendJson(res, 200, { config: service.getTagConfig() });
+          sendJson(res, 200, { config: service.getAppConfig() });
           return;
         }
-        sendJson(res, 200, { config: service.getTagConfig() });
+        sendJson(res, 200, { config: service.getAppConfig() });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -77,6 +77,11 @@ window.__ModuleLoader__.load({
         "memory.settings.autoTagEnabled": "自动打标签",
         "memory.settings.autoTagSave": "保存",
         "memory.settings.autoTagSaved": "已保存",
+        "memory.settings.sidebarTriggerTitle": "侧边栏入口按钮",
+        "memory.settings.sidebarTriggerHint": "关闭后隐藏侧边栏底部（左下角）的记忆入口按钮。与其他插件 UI 冲突时建议关闭；记忆库仍可通过顶部「记忆库」标签访问",
+        "memory.settings.sidebarTriggerEnabled": "显示左下角入口按钮",
+        "memory.settings.sidebarTriggerSave": "保存",
+        "memory.settings.sidebarTriggerSaved": "已保存",
         "memory.settings.ruleAdd": "添加规则",
         "memory.settings.rulePlaceholder": "例如：回答时总是先给结论",
         "memory.settings.commands": "自定义指令",
@@ -186,6 +191,11 @@ window.__ModuleLoader__.load({
         "memory.settings.autoTagEnabled": "Auto-tagging",
         "memory.settings.autoTagSave": "Save",
         "memory.settings.autoTagSaved": "Saved",
+        "memory.settings.sidebarTriggerTitle": "Sidebar trigger",
+        "memory.settings.sidebarTriggerHint": "Hide the memory entrance button at the sidebar footer (bottom-left) when it clashes with other plugins. The library stays reachable via the 记忆库 conversation tab",
+        "memory.settings.sidebarTriggerEnabled": "Show the bottom-left trigger",
+        "memory.settings.sidebarTriggerSave": "Save",
+        "memory.settings.sidebarTriggerSaved": "Saved",
         "memory.settings.ruleAdd": "Add Rule",
         "memory.settings.rulePlaceholder": "e.g. Always lead with a conclusion",
         "memory.settings.commands": "Custom Commands",
@@ -874,6 +884,8 @@ window.__ModuleLoader__.load({
       const [apiTokenSaved, setApiTokenSaved] = react.useState(false);
       const [autoTag, setAutoTag] = react.useState(false);
       const [autoTagSaved, setAutoTagSaved] = react.useState(false);
+      const [showSidebarTrigger, setShowSidebarTrigger] = react.useState(true);
+      const [sidebarTriggerSaved, setSidebarTriggerSaved] = react.useState(false);
 
       const load = react.useCallback(async () => {
         try {
@@ -891,7 +903,9 @@ window.__ModuleLoader__.load({
           try {
             const g = await apiFetch("/api/dsh-mneme/config").then((res) => res.json());
             setAutoTag(g.config?.autoTagEnabled === true);
-          } catch { /* keep default off */ }
+            // issue #38: sidebar trigger defaults to visible (true).
+            setShowSidebarTrigger(g.config?.showSidebarTrigger !== false);
+          } catch { /* keep defaults */ }
         } catch { /* ignore */ }
       }, []);
 
@@ -1000,6 +1014,18 @@ window.__ModuleLoader__.load({
         } catch { /* ignore */ }
       }
 
+      async function saveSidebarTrigger() {
+        try {
+          await apiFetch("/api/dsh-mneme/config", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ showSidebarTrigger })
+          });
+          setSidebarTriggerSaved(true);
+          setTimeout(() => setSidebarTriggerSaved(false), 1500);
+        } catch { /* ignore */ }
+      }
+
       const inputStyle = { boxSizing: "border-box", width: "100%", height: 34, padding: "0 12px", borderRadius: 10, border: "1px solid var(--dsw-alias-border-l2, #ddd)", background: "var(--dsw-alias-bg-base, transparent)", color: "var(--dsw-alias-label-primary)", fontFamily: "inherit", fontSize: 13, outline: "none", marginBottom: 8 };
       const labelStyle = { fontSize: 12, fontWeight: 600, margin: "12px 0 4px", color: "var(--dsw-alias-label-primary)" };
       const hintStyle = { fontSize: 11, color: "var(--dsw-alias-label-tertiary, #999)", marginBottom: 8 };
@@ -1076,6 +1102,17 @@ window.__ModuleLoader__.load({
         h("div", { style: { display: "flex", alignItems: "center", gap: 6 } },
           h("button", { style: styles.footerButton, onClick: saveAutoTag }, t("memory.settings.autoTagSave")),
           autoTagSaved && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-success, #2a7)" } }, t("memory.settings.autoTagSaved"))
+        ),
+        // sidebar trigger switch (issue #38)
+        h("div", { style: { ...labelStyle, marginTop: 20 } }, t("memory.settings.sidebarTriggerTitle")),
+        h("div", { style: hintStyle }, t("memory.settings.sidebarTriggerHint")),
+        h("label", { style: { display: "flex", alignItems: "center", gap: 6, marginBottom: 8, fontSize: 13 } },
+          h("input", { type: "checkbox", checked: showSidebarTrigger, onChange: (e) => setShowSidebarTrigger(e.target.checked) }),
+          h("span", null, t("memory.settings.sidebarTriggerEnabled"))
+        ),
+        h("div", { style: { display: "flex", alignItems: "center", gap: 6 } },
+          h("button", { style: styles.footerButton, onClick: saveSidebarTrigger }, t("memory.settings.sidebarTriggerSave")),
+          sidebarTriggerSaved && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-success, #2a7)" } }, t("memory.settings.sidebarTriggerSaved"))
         ),
         // vector search
         h("div", { style: { ...labelStyle, marginTop: 20 } }, t("memory.settings.vectorTitle")),
@@ -1749,7 +1786,22 @@ window.__ModuleLoader__.load({
     // opens the full-viewport overlay instead — the library stays reachable
     // from every conversation state.
     function SidebarTrigger({ wide, t }) {
+      // issue #38: the entrance button is now optional (settings-over-config
+      // toggle, persisted via /api/dsh-mneme/config). While the value loads we
+      // render the button (default = visible) so it never flashes out; if the
+      // user disabled it, it drops away after the config resolves. The library
+      // itself is unaffected — the 记忆库 conversation tab stays.
+      const [visible, setVisible] = useState(true);
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/config")
+          .then((res) => res.json())
+          .then((d) => { if (!cancelled) setVisible(d.config?.showSidebarTrigger !== false); })
+          .catch(() => { if (!cancelled) setVisible(true); });
+        return () => { cancelled = true; };
+      }, []);
       const [, setOpen] = useOverlayOpen();
+      if (!visible) return null;
       return h("button", {
         type: "button",
         className: wide ? "mneme-trigger" : "mneme-trigger mneme-rail",

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -203,6 +203,16 @@ export const Config = z.object({
   // set false to disable the manual write path too.
   manualTagEnabled: z.boolean().default(true),
 
+  // --- sidebar trigger (issue #38) ---------------------------------------
+  // The memory library is reachable from two UI surfaces: a "记忆库" tab in the
+  // conversation header AND an entrance button at the sidebar footer (bottom
+  // left). Some sidebars get crowded there — dsh-cost-meter and friends also
+  // claim the footer slot — so the entrance button is now optional. Off just
+  // hides the button; the conversation tab stays, so no functionality is lost.
+  // The Web panel exposes this as a toggle (settings-over-config, see
+  // settings.getUiConfig); the value here is the plugin-config default.
+  showSidebarTrigger: z.boolean().default(true),
+
   // --- tag-weighted re-rank (v0.6.4) -------------------------------------
   // Opt-in: boost candidates whose tags overlap the query/session tags.
   tagBoostEnabled: z.boolean().default(false),

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -105,6 +105,19 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     };
   };
 
+  // App-wide effective config for the Web panel (/api/dsh-mneme/config): the
+  // tag toggles plus UI preferences (issue #38). Settings overrides plugin
+  // config when explicitly stored; unset keys fall back to the zod default.
+  const appConfig = () => {
+    const stored = settings?.getUiConfig?.() ?? {};
+    return {
+      ...tagConfig(),
+      showSidebarTrigger: typeof stored.showSidebarTrigger === "boolean"
+        ? stored.showSidebarTrigger
+        : (config.showSidebarTrigger ?? true)
+    };
+  };
+
   // Optional recall recorder, installed via setRecallRecorder after creation.
   // When searchMemories is called with recordRecall=true it receives the
   // actual merged recall scene (candidates + scores + source + threshold) so
@@ -1803,6 +1816,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     // Effective tag toggle pair (settings-over-config merge) for the panel
     // (/api/dsh-mneme/config GET/PUT).
     getTagConfig: tagConfig,
+    getAppConfig: appConfig,
     applyMemoryTags: (memoryId, tags) => store.setMemoryTags(memoryId, tags),
     saveAttr: (r) => store.saveAttr(r),
     createEntity: (r) => store.createEntity(r),

--- a/dsh-mneme/lib/settings.js
+++ b/dsh-mneme/lib/settings.js
@@ -176,6 +176,37 @@ export function createSettings(db) {
       else if (cur.manualTagEnabled !== undefined) cfg.manualTagEnabled = cur.manualTagEnabled === true;
       setSetting("autoTag", JSON.stringify(cfg));
       return cfg;
+    },
+    /** UI preferences (issue #38): same settings-over-config pattern as the
+     * tag toggles. null = never explicitly stored → callers fall back to the
+     * plugin-config default, so a partial update can't invent a value for a
+     * key the user never touched. */
+    getUiConfig() {
+      const raw = getSetting("ui");
+      let stored = {};
+      if (raw) {
+        try {
+          const j = JSON.parse(raw);
+          if (j && typeof j === "object") stored = j;
+        } catch { /* fall through to defaults */ }
+      }
+      return {
+        showSidebarTrigger: typeof stored.showSidebarTrigger === "boolean" ? stored.showSidebarTrigger : null
+      };
+    },
+    setUiConfig(partial) {
+      const cur = (() => {
+        const raw = getSetting("ui");
+        try {
+          const j = JSON.parse(raw);
+          return j && typeof j === "object" ? j : {};
+        } catch { return {}; }
+      })();
+      const cfg = {};
+      if (partial.showSidebarTrigger !== undefined) cfg.showSidebarTrigger = partial.showSidebarTrigger === true;
+      else if (cur.showSidebarTrigger !== undefined) cfg.showSidebarTrigger = cur.showSidebarTrigger === true;
+      setSetting("ui", JSON.stringify(cfg));
+      return cfg;
     }
   };
 }

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0"

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -75,6 +75,9 @@
     "adm-zip": "0.6.0"
   },
   "c8": {
-    "reporter": ["text", "lcov"]
+    "reporter": [
+      "text",
+      "lcov"
+    ]
   }
 }

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -238,19 +238,22 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
             }
             return true;
           };
-          if (!setIfBoolean("autoTagEnabled") || !setIfBoolean("manualTagEnabled")) return;
+          if (!setIfBoolean("autoTagEnabled") || !setIfBoolean("manualTagEnabled") || !setIfBoolean("showSidebarTrigger")) return;
           if (Object.keys(patch).length === 0) {
             sendJson(res, 400, { error: "no valid config field provided" });
             return;
           }
+          // Each setter ignores the keys it doesn't own, so one patch can feed
+          // both stores safely (tag toggles → "autoTag", UI prefs → "ui").
           settings.setAutoTagConfig(patch);
+          settings.setUiConfig(patch);
           // Respond with the effective (settings-over-config merged) toggles
           // so the panel always sees booleans that actually gate runtime
           // behaviour (issue #31).
-          sendJson(res, 200, { config: service.getTagConfig() });
+          sendJson(res, 200, { config: service.getAppConfig() });
           return;
         }
-        sendJson(res, 200, { config: service.getTagConfig() });
+        sendJson(res, 200, { config: service.getAppConfig() });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -203,6 +203,16 @@ export const Config = z.object({
   // set false to disable the manual write path too.
   manualTagEnabled: z.boolean().default(true),
 
+  // --- sidebar trigger (issue #38) ---------------------------------------
+  // The memory library is reachable from two UI surfaces: a "记忆库" tab in the
+  // conversation header AND an entrance button at the sidebar footer (bottom
+  // left). Some sidebars get crowded there — dsh-cost-meter and friends also
+  // claim the footer slot — so the entrance button is now optional. Off just
+  // hides the button; the conversation tab stays, so no functionality is lost.
+  // The Web panel exposes this as a toggle (settings-over-config, see
+  // settings.getUiConfig); the value here is the plugin-config default.
+  showSidebarTrigger: z.boolean().default(true),
+
   // --- tag-weighted re-rank (v0.6.4) -------------------------------------
   // Opt-in: boost candidates whose tags overlap the query/session tags.
   tagBoostEnabled: z.boolean().default(false),

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -105,6 +105,19 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     };
   };
 
+  // App-wide effective config for the Web panel (/api/dsh-mneme/config): the
+  // tag toggles plus UI preferences (issue #38). Settings overrides plugin
+  // config when explicitly stored; unset keys fall back to the zod default.
+  const appConfig = () => {
+    const stored = settings?.getUiConfig?.() ?? {};
+    return {
+      ...tagConfig(),
+      showSidebarTrigger: typeof stored.showSidebarTrigger === "boolean"
+        ? stored.showSidebarTrigger
+        : (config.showSidebarTrigger ?? true)
+    };
+  };
+
   // Optional recall recorder, installed via setRecallRecorder after creation.
   // When searchMemories is called with recordRecall=true it receives the
   // actual merged recall scene (candidates + scores + source + threshold) so
@@ -1803,6 +1816,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     // Effective tag toggle pair (settings-over-config merge) for the panel
     // (/api/dsh-mneme/config GET/PUT).
     getTagConfig: tagConfig,
+    getAppConfig: appConfig,
     applyMemoryTags: (memoryId, tags) => store.setMemoryTags(memoryId, tags),
     saveAttr: (r) => store.saveAttr(r),
     createEntity: (r) => store.createEntity(r),

--- a/dsh-mneme/src/settings.js
+++ b/dsh-mneme/src/settings.js
@@ -176,6 +176,37 @@ export function createSettings(db) {
       else if (cur.manualTagEnabled !== undefined) cfg.manualTagEnabled = cur.manualTagEnabled === true;
       setSetting("autoTag", JSON.stringify(cfg));
       return cfg;
+    },
+    /** UI preferences (issue #38): same settings-over-config pattern as the
+     * tag toggles. null = never explicitly stored → callers fall back to the
+     * plugin-config default, so a partial update can't invent a value for a
+     * key the user never touched. */
+    getUiConfig() {
+      const raw = getSetting("ui");
+      let stored = {};
+      if (raw) {
+        try {
+          const j = JSON.parse(raw);
+          if (j && typeof j === "object") stored = j;
+        } catch { /* fall through to defaults */ }
+      }
+      return {
+        showSidebarTrigger: typeof stored.showSidebarTrigger === "boolean" ? stored.showSidebarTrigger : null
+      };
+    },
+    setUiConfig(partial) {
+      const cur = (() => {
+        const raw = getSetting("ui");
+        try {
+          const j = JSON.parse(raw);
+          return j && typeof j === "object" ? j : {};
+        } catch { return {}; }
+      })();
+      const cfg = {};
+      if (partial.showSidebarTrigger !== undefined) cfg.showSidebarTrigger = partial.showSidebarTrigger === true;
+      else if (cur.showSidebarTrigger !== undefined) cfg.showSidebarTrigger = cur.showSidebarTrigger === true;
+      setSetting("ui", JSON.stringify(cfg));
+      return cfg;
     }
   };
 }

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -557,12 +557,26 @@ test("GET/PUT /api/dsh-mneme/config round-trips autoTag switches", async () => {
   await route.handler(req("/api/dsh-mneme/config"), res1);
   assert.equal(res1.statusCode, 200);
   // unset → effective config falls back to plugin-config defaults:
-  // autoTagEnabled=false, manualTagEnabled=true (issue #31 default unification)
-  assert.deepEqual(JSON.parse(res1.body).config, { autoTagEnabled: false, manualTagEnabled: true });
+  // autoTagEnabled=false, manualTagEnabled=true (issue #31 default unification),
+  // showSidebarTrigger=true (issue #38 default)
+  assert.deepEqual(JSON.parse(res1.body).config, { autoTagEnabled: false, manualTagEnabled: true, showSidebarTrigger: true });
   const res2 = new FakeRes();
   await route.handler(req("/api/dsh-mneme/config", "PUT", { autoTagEnabled: true, manualTagEnabled: false }), res2);
   assert.equal(res2.statusCode, 200);
-  assert.deepEqual(JSON.parse(res2.body).config, { autoTagEnabled: true, manualTagEnabled: false });
+  assert.deepEqual(JSON.parse(res2.body).config, { autoTagEnabled: true, manualTagEnabled: false, showSidebarTrigger: true });
+});
+
+test("GET/PUT /api/dsh-mneme/config round-trips the sidebar trigger toggle (issue #38)", async () => {
+  const { routes } = setup();
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/config");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/config", "PUT", { showSidebarTrigger: false }), res);
+  assert.equal(res.statusCode, 200);
+  // Toggling the UI pref must not disturb the tag toggles (settings-over-config).
+  assert.deepEqual(JSON.parse(res.body).config, { autoTagEnabled: false, manualTagEnabled: true, showSidebarTrigger: false });
+  const res2 = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/config"), res2);
+  assert.deepEqual(JSON.parse(res2.body).config, { autoTagEnabled: false, manualTagEnabled: true, showSidebarTrigger: false });
 });
 
 test("DELETE /api/dsh-mneme/memories removes by id and reports misses", async () => {
@@ -597,5 +611,14 @@ test("PUT /api/dsh-mneme/config supports partial update", async () => {
   // Partial PUT only stores autoTagEnabled; manualTagEnabled stays unset and
   // falls back to the plugin-config default (true) — a lone autoTag toggle must
   // never silently disable manual tagging (issue #31).
-  assert.deepEqual(JSON.parse(res.body).config, { autoTagEnabled: true, manualTagEnabled: true });
+  assert.deepEqual(JSON.parse(res.body).config, { autoTagEnabled: true, manualTagEnabled: true, showSidebarTrigger: true });
+});
+
+test("PUT /api/dsh-mneme/config rejects non-boolean showSidebarTrigger", async () => {
+  const { routes } = setup();
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/config");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/config", "PUT", { showSidebarTrigger: "no" }), res);
+  assert.equal(res.statusCode, 400);
+  assert.match(JSON.parse(res.body).error, /showSidebarTrigger/);
 });

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -403,3 +403,23 @@ test("delete failure surfaces visible error feedback", () => {
     "a failed row must get a visible error style"
   );
 });
+
+// issue #38: the sidebar foot trigger must be disableable so it stops colliding
+// with other plugins that also claim the bottom-left footer slot (dsh-cost-meter
+// et al). The client reads the settings-over-config toggle from the /config
+// endpoint and renders no button when it is off; the 记忆库 conversation tab is
+// unaffected, so nothing is lost by hiding the entry.
+test("sidebar trigger is hidden when showSidebarTrigger is false (issue #38)", () => {
+  assert.ok(
+    clientSource.includes('apiFetch("/api/dsh-mneme/config")'),
+    "trigger must read the effective config from /api/dsh-mneme/config"
+  );
+  assert.ok(
+    /d\.config\?\.showSidebarTrigger !== false/.test(clientSource),
+    "trigger must hide when showSidebarTrigger is explicitly false and stay visible by default"
+  );
+  assert.ok(
+    clientSource.includes('"memory.settings.sidebarTriggerTitle"'),
+    "settings panel must expose a sidebar-trigger toggle"
+  );
+});

--- a/dsh-mneme/test/config.test.js
+++ b/dsh-mneme/test/config.test.js
@@ -55,3 +55,10 @@ test("startup probe: the reranker module never statically imports transformers/o
   );
   assert.match(src, /await import\("@huggingface\/transformers"\)/, "transformers.js loads lazily via dynamic import");
 });
+
+test("showSidebarTrigger is on by default, disabled explicitly (issue #38)", () => {
+  const cfg = Config({});
+  assert.equal(cfg.showSidebarTrigger, true, "sidebar trigger defaults to visible (behavior unchanged)");
+  const off = Config({ showSidebarTrigger: false });
+  assert.equal(off.showSidebarTrigger, false, "explicit false hides the trigger");
+});

--- a/dsh-mneme/test/settings.test.js
+++ b/dsh-mneme/test/settings.test.js
@@ -120,3 +120,25 @@ test("autoTag config coerces non-boolean to false", () => {
   assert.deepEqual(settings.getAutoTagConfig(), { autoTagEnabled: false, manualTagEnabled: false });
   store.close();
 });
+
+test("ui config (sidebar trigger) defaults to null and round-trips only explicit keys", () => {
+  const { store, settings } = setup();
+  // Issue #38: same settings-over-config pattern as the tag toggles — an unset
+  // key is null so consumers fall back to the plugin-config default (visible).
+  assert.deepEqual(settings.getUiConfig(), { showSidebarTrigger: null });
+  settings.setUiConfig({ showSidebarTrigger: false });
+  assert.deepEqual(settings.getUiConfig(), { showSidebarTrigger: false });
+  settings.setUiConfig({ showSidebarTrigger: true });
+  assert.deepEqual(settings.getUiConfig(), { showSidebarTrigger: true });
+  // A partial update with no showSidebarTrigger keeps the stored value.
+  settings.setUiConfig({});
+  assert.deepEqual(settings.getUiConfig(), { showSidebarTrigger: true });
+  store.close();
+});
+
+test("ui config coerces non-boolean to false", () => {
+  const { store, settings } = setup();
+  settings.setUiConfig({ showSidebarTrigger: "yes" });
+  assert.deepEqual(settings.getUiConfig(), { showSidebarTrigger: false });
+  store.close();
+});


### PR DESCRIPTION
### 背景
issue #38：dsh-mneme 的记忆入口按钮注入在 sidebar footer slot（左下角），与同样抢占该位置的插件（如 dsh-cost-meter）冲突，导致 UI 叠加错乱。用户希望左下角按钮可关闭。

### 改动
- 新增配置 `showSidebarTrigger`（默认 `true`，行为不变）
- Web 面板「设置」新增「侧边栏入口按钮」开关一键关闭
- settings-over-config 持久化（`user_settings"ui"`），`/api/dsh-mneme/config` GET/PUT 同步支持
- 关闭仅隐藏按钮，记忆库仍可通过顶部「记忆库」标签访问，功能不受影响

### 测试
新增 7 个回归测试（api 3 + settings 2 + config 1 + client 1），**776 全绿**