### PR TITLE
fix(issue#40,#41): escape prompt-variable braces + overlay close overlap

### DIFF
--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -472,7 +472,11 @@ window.__ModuleLoader__.load({
       // there. This surface reuses the exact MemoryExplorer UI at full size —
       // not a side drawer — so the library stays reachable from any state.
       ".mneme-overlay{position:fixed;inset:0;z-index:1000;display:flex;flex-direction:column;background:var(--dsw-alias-bg-layer-1);animation:mneme-fadein .12s ease-out}",
-      ".mneme-overlaybar{flex:none;display:flex;align-items:center;justify-content:space-between;height:44px;padding:0 12px 0 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
+      // issue #41: overlay 顶栏右侧原本与宿主窗口标题栏的控制按钮（最小化/最大化/关闭）
+      // 落在同一区域——宿主控制按钮浮在 web 内容最上层，抢占了 overlay"关闭"按钮的
+      // 点击热区，导致记忆窗口无法关闭。改为左对齐（标题 + 关闭按钮并排），关闭按钮
+      // 离开右上角宿主控制按钮区，任何窗口尺寸/宿主下都可见可点。
+      ".mneme-overlaybar{flex:none;display:flex;align-items:center;justify-content:flex-start;gap:12px;height:44px;padding:0 12px 0 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
       ".mneme-overlaytitle{font-size:14px;font-weight:600;color:var(--dsw-alias-label-primary)}",
       ".mneme-overlaybody{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}",
       "@keyframes mneme-fadein{from{opacity:0}to{opacity:1}}"

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -22,6 +22,13 @@ export const Config = z.object({
   // "现在几点/周几"。只注入一次（对话开始时），同会话后续渲染不再重复；
   // 关闭时行为与之前完全一致。
   injectTimePrefix: z.boolean().default(false),
+  // 花括号转义（issue #40，默认开）：DSH 核心 interpolate() 会把 `{{name}}`
+  // 当 prompt 变量做严格校验（变量名须匹配 /^[a-z][a-z0-9_]*$/），记忆正文里
+  // 合法的模板语法（如 `{{hl|}}`、`{{挖空}}`、`{{关键词}}`）会因非法变量名
+  // 直接 throw、让整轮对话崩溃。开启后注入边界把 `{{`→`\{\{`、`}}`→`\}\}`，
+  // 文本不再含 `{{`/`}}` 子串，interpolate 不再扫描到，内容保持可读且幂等
+  // （不会二次转义）。关闭后按原样透传。
+  escapePromptVariables: z.boolean().default(true),
   autoDream: z.boolean().default(true),
   dreamThresholdCount: z.natural().min(1).max(1000).default(10),
   dreamThresholdChars: z.natural().min(100).max(100000).default(5000),

--- a/dsh-mneme/lib/inject.js
+++ b/dsh-mneme/lib/inject.js
@@ -75,6 +75,23 @@ export function createInjector(ctx, service, settings, config) {
   const maxItems = config.maxInjectedItems ?? 5;
   const threshold = config.importanceThreshold ?? 3;
 
+  // Prompt-variable escaping (issue #40): DSH's interpolate() treats `{{name}}`
+  // as a prompt variable and strictly validates the name against
+  // /^[a-z][a-z0-9_]*$/ — memory/profile content carrying legal template syntax
+  // (Obsidian-style `{{hl|}}`, `{{挖空}}`, `{{关键词}}`) would hit an illegal
+  // variable name and throw, crashing the whole turn. At the injection boundary
+  // we escape every run of 2+ consecutive braces, inserting a `\` between each
+  // pair, so no `{{`/`}}` substring survives into the prompt: `{{a}}` → `{\{a\}\}`,
+  // and odd runs like `{{{a}}}` (which pair-wise escaping would leave with a
+  // literal `{{`) are handled too. The text keeps its readable template form,
+  // the transform is idempotent (escaped braces are single + `\`, never two
+  // adjacent), and single braces pass through untouched — interpolate only
+  // scans `{{`. Off via config.escapePromptVariables=false (default true).
+  function escapePromptVars(text) {
+    if (config.escapePromptVariables === false) return String(text);
+    return String(text).replace(/[{}]{2,}/g, (run) => run.split("").join("\\"));
+  }
+
   // Time-prefix injection (issue #34): opt-in, off by default. When enabled the
   // current date/time is injected once per conversation — at the first prompt
   // assembly of a new session — so the model can sense what time/day it is.
@@ -134,7 +151,7 @@ export function createInjector(ctx, service, settings, config) {
     for (const r of rounds) hot.add(r);
     const body = hot.getContext();
     if (!body) return "";
-    return `[短期上下文] 最近对话（共 ${rounds.length} 轮）：\n${body}`;
+    return escapePromptVars(`[短期上下文] 最近对话（共 ${rounds.length} 轮）：\n${body}`);
   }
 
   function render(candidates) {
@@ -158,7 +175,7 @@ export function createInjector(ctx, service, settings, config) {
         lines.push(`- [${m.type}] ${verified}${title}`);
       }
     }
-    return lines.join("\n");
+    return escapePromptVars(lines.join("\n"));
   }
 
   // Bug4: the system-prompt render is synchronous, so the semantic query vector
@@ -192,7 +209,7 @@ export function createInjector(ctx, service, settings, config) {
     const lines = ["[用户设置] 来自 dsh-mneme 的用户画像与规则："];
     if (profile) lines.push(`- 用户画像：${profile}`);
     for (const rule of rules) lines.push(`- 规则：${rule}`);
-    return lines.join("\n");
+    return escapePromptVars(lines.join("\n"));
   }
 
   const disposers = [

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -22,6 +22,13 @@ export const Config = z.object({
   // "现在几点/周几"。只注入一次（对话开始时），同会话后续渲染不再重复；
   // 关闭时行为与之前完全一致。
   injectTimePrefix: z.boolean().default(false),
+  // 花括号转义（issue #40，默认开）：DSH 核心 interpolate() 会把 `{{name}}`
+  // 当 prompt 变量做严格校验（变量名须匹配 /^[a-z][a-z0-9_]*$/），记忆正文里
+  // 合法的模板语法（如 `{{hl|}}`、`{{挖空}}`、`{{关键词}}`）会因非法变量名
+  // 直接 throw、让整轮对话崩溃。开启后注入边界把 `{{`→`\{\{`、`}}`→`\}\}`，
+  // 文本不再含 `{{`/`}}` 子串，interpolate 不再扫描到，内容保持可读且幂等
+  // （不会二次转义）。关闭后按原样透传。
+  escapePromptVariables: z.boolean().default(true),
   autoDream: z.boolean().default(true),
   dreamThresholdCount: z.natural().min(1).max(1000).default(10),
   dreamThresholdChars: z.natural().min(100).max(100000).default(5000),

--- a/dsh-mneme/src/inject.js
+++ b/dsh-mneme/src/inject.js
@@ -75,6 +75,23 @@ export function createInjector(ctx, service, settings, config) {
   const maxItems = config.maxInjectedItems ?? 5;
   const threshold = config.importanceThreshold ?? 3;
 
+  // Prompt-variable escaping (issue #40): DSH's interpolate() treats `{{name}}`
+  // as a prompt variable and strictly validates the name against
+  // /^[a-z][a-z0-9_]*$/ — memory/profile content carrying legal template syntax
+  // (Obsidian-style `{{hl|}}`, `{{挖空}}`, `{{关键词}}`) would hit an illegal
+  // variable name and throw, crashing the whole turn. At the injection boundary
+  // we escape every run of 2+ consecutive braces, inserting a `\` between each
+  // pair, so no `{{`/`}}` substring survives into the prompt: `{{a}}` → `{\{a\}\}`,
+  // and odd runs like `{{{a}}}` (which pair-wise escaping would leave with a
+  // literal `{{`) are handled too. The text keeps its readable template form,
+  // the transform is idempotent (escaped braces are single + `\`, never two
+  // adjacent), and single braces pass through untouched — interpolate only
+  // scans `{{`. Off via config.escapePromptVariables=false (default true).
+  function escapePromptVars(text) {
+    if (config.escapePromptVariables === false) return String(text);
+    return String(text).replace(/[{}]{2,}/g, (run) => run.split("").join("\\"));
+  }
+
   // Time-prefix injection (issue #34): opt-in, off by default. When enabled the
   // current date/time is injected once per conversation — at the first prompt
   // assembly of a new session — so the model can sense what time/day it is.
@@ -134,7 +151,7 @@ export function createInjector(ctx, service, settings, config) {
     for (const r of rounds) hot.add(r);
     const body = hot.getContext();
     if (!body) return "";
-    return `[短期上下文] 最近对话（共 ${rounds.length} 轮）：\n${body}`;
+    return escapePromptVars(`[短期上下文] 最近对话（共 ${rounds.length} 轮）：\n${body}`);
   }
 
   function render(candidates) {
@@ -158,7 +175,7 @@ export function createInjector(ctx, service, settings, config) {
         lines.push(`- [${m.type}] ${verified}${title}`);
       }
     }
-    return lines.join("\n");
+    return escapePromptVars(lines.join("\n"));
   }
 
   // Bug4: the system-prompt render is synchronous, so the semantic query vector
@@ -192,7 +209,7 @@ export function createInjector(ctx, service, settings, config) {
     const lines = ["[用户设置] 来自 dsh-mneme 的用户画像与规则："];
     if (profile) lines.push(`- 用户画像：${profile}`);
     for (const rule of rules) lines.push(`- 规则：${rule}`);
-    return lines.join("\n");
+    return escapePromptVars(lines.join("\n"));
   }
 
   const disposers = [

--- a/dsh-mneme/test/config.test.js
+++ b/dsh-mneme/test/config.test.js
@@ -62,3 +62,10 @@ test("showSidebarTrigger is on by default, disabled explicitly (issue #38)", () 
   const off = Config({ showSidebarTrigger: false });
   assert.equal(off.showSidebarTrigger, false, "explicit false hides the trigger");
 });
+
+test("escapePromptVariables is on by default, disabled explicitly (issue #40)", () => {
+  const cfg = Config({});
+  assert.equal(cfg.escapePromptVariables, true, "{{...}} escaping defaults to on (protects interpolate)");
+  const off = Config({ escapePromptVariables: false });
+  assert.equal(off.escapePromptVariables, false, "explicit false passes {{...}} through verbatim");
+});

--- a/dsh-mneme/test/inject.test.js
+++ b/dsh-mneme/test/inject.test.js
@@ -129,3 +129,60 @@ test("injectTimePrefix: same session never re-injects, a new session injects aga
   const third = contexts[0].text({ agent: { session: { id: "s2" } } });
   assert.match(third, /^\[当前时间:/, "a new session injects the prefix again");
 });
+
+test("issue #40: {{...}} in memory content is escaped at the injection boundary", () => {
+  const { contexts, service } = setup();
+  service.saveWithDedupe({ type: "preference", title: "模板记忆", content: "{{hl|highlight}} 和 {{挖空}} {{关键词}}", importance: 5 });
+  const text = contexts[0].text({});
+  assert.ok(text.includes("模板记忆"), "memory still rendered by title");
+  assert.ok(text.includes("{\\{hl|highlight}\\}"), "ASCII template braces escaped");
+  assert.ok(text.includes("{\\{挖空}\\}"), "CJK template braces escaped");
+  assert.ok(!text.includes("{{"), "no raw {{ survives into the prompt");
+  assert.ok(!text.includes("}}"), "no raw }} survives into the prompt");
+});
+
+test("issue #40: odd brace runs like {{{a}}} are escaped too", () => {
+  const { contexts, service } = setup();
+  service.saveWithDedupe({ type: "preference", title: "三层模板", content: "{{{a}}} 和 }}} 结尾", importance: 5 });
+  const text = contexts[0].text({});
+  assert.ok(!text.includes("{{"), "no raw {{ for odd brace runs");
+  assert.ok(!text.includes("}}"), "no raw }} for odd brace runs");
+});
+
+test("issue #40: {{...}} in user profile/rules is escaped", () => {
+  const { contexts, settings } = setup();
+  settings.setProfile("我叫{{名字}}，前端开发者");
+  settings.setRules(["回答时用 {{hl|term}}", "以 }} 结尾的规则"]);
+  const settingsCtx = contexts.find((c) => c.name === "user-settings");
+  const text = settingsCtx.text({});
+  assert.ok(text.includes("{\\{名字}\\}"), "profile braces escaped");
+  assert.ok(text.includes("{\\{hl|term}\\}"), "rule braces escaped");
+  assert.ok(!text.includes("{{"), "no raw {{ in user-settings block");
+  assert.ok(!text.includes("}}"), "no raw }} in user-settings block");
+});
+
+test("issue #40: hot-context rounds with {{...}} are escaped", () => {
+  const { contexts } = setup();
+  const text = contexts[0].text({
+    agent: {
+      session: {
+        id: "s1",
+        events: [
+          { type: "user/message", data: { source: { kind: "user" }, content: ["用 {{hl|你好}} 测试"] } },
+          { type: "assistant/message", data: { source: { kind: "assistant" }, content: ["返回 {{答案}}"] } }
+        ]
+      }
+    }
+  });
+  assert.ok(text.includes("[短期上下文]"), "hot context rendered");
+  assert.ok(!text.includes("{{"), "no raw {{ in hot context");
+  assert.ok(!text.includes("}}"), "no raw }} in hot context");
+});
+
+test("issue #40: escapePromptVariables=false passes {{...}} through verbatim", () => {
+  const { contexts, service } = setup({ escapePromptVariables: false });
+  service.saveWithDedupe({ type: "preference", title: "模板", content: "{{挖空}} 与 {{hl|term}}", importance: 5 });
+  const text = contexts[0].text({});
+  assert.ok(text.includes("{{挖空}}"), "raw braces preserved when escaping disabled");
+  assert.ok(text.includes("{{hl|term}}"), "raw ASCII braces preserved when escaping disabled");
+});


### PR DESCRIPTION
## 修复内容

### issue #40 — 记忆内容含 `{{...}}` 模板语法时整轮崩溃
DSH 核心 `interpolate()` 会把 `{{name}}` 当 prompt 变量严格校验（变量名须匹配 `/^[a-z][a-z0-9_]*$/`），记忆里合法的模板语法（如 `{{hl|}}`、`{{挖空}}`、`{{关键词}}`）因非法变量名直接 throw，整轮失败。

修复：注入边界做 **run-based 花括号转义**（`{{a}}`→`{\{a\}\}`），连续 2+ 个花括号之间插反斜杠，**奇数连续（如 `{{{a}}}`）也不残留字面 `{{`**，`interpolate()` 不再扫描到。覆盖 memory 块 / 短期上下文 / 用户设置三处注入出口，新增配置 `escapePromptVariables`（默认开，关闭时原样透传）。转义幂等、单花括号不受影响。

### issue #41 — 记忆窗口关闭按钮重叠无法关闭
`MemoryOverlay` 全屏覆盖层顶栏右侧的关闭按钮，与宿主窗口标题栏控制按钮（最小化/最大化/关闭）落在同一区域，宿主控制按钮浮在 web 内容最上层，抢走关闭按钮点击热区。

修复：顶栏改为左对齐（标题 + 关闭按钮并排），关闭按钮离开右上角宿主控制按钮区，任何窗口尺寸下都可见可点。

## 验证
- 新增 6 个测试（含 `{{{a}}}` 奇数括号回归）
- 全量 **782/782** 测试通过

Fixes #40, #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)