### PR TITLE
feat(v0.7.5): 分层记忆类型 user/fact + Web 总览视图 + stats 端点

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.7.5] - 2026-09-02
+
+### 🆕 新功能：分层记忆类型 user/fact
+
+- 借鉴 meow-memory 的七层分层概念，贴合 dsh-mneme 单表 `memories` + `type` 字段架构，只补最轻量的两个分层，不动表结构：
+  - **`user`** — 用户画像（身份/背景/偏好档案）
+  - **`fact`** — 原子事实（不随时间漂移的客观事实）
+- 全链路打通：`store.TYPES` / `tools` 工具枚举与描述 / `summarize` VALID 集合与提炼 prompt / `quality-filter` 标签 / `mirror` 镜像文件（`user.md` / `facts.md`）/ `service.INJECT_TYPES` 注入（user 与 preference 同级常注入，fact 按重要性阈值注入）
+- Web 面板「总览」视图：记忆分层卡片（六类型+summary/pattern）+ 用户画像卡 + 类型分布面板 + 近 7 天创建趋势
+
+### 🆕 新功能：stats 统计端点
+
+- `GET /api/dsh-mneme/stats?days=N`：按类型分布 + 近 N 天（默认 7，夹紧 1..30）逐日创建趋势，SQL 聚合不受 list 50 条限制，排除归档/遗忘/会话销毁
+
+### 🔧 复验修复（kimi-k2.7-code）
+
+- `days` 参数整数化：`?days=7.5` 不再产生 8 个趋势点（`parseInt` 夹紧 + store 层防御）
+- store 单次 `Date.now()` 读取，避免趋势窗口跨天边界不一致
+- 前端趋势图 0 值天渲染 0 高度柱（不再伪装成有数据）；INJECT_TYPES 注入注释说明"常注入 vs 按重要性阈值"
+
+### 测试
+
+- 新增 8 个测试（分层类型/镜像/提炼/list 过滤/stats 分布+趋势/归档遗忘排除/days 夹紧与整数化），全套 **790 通过**
+
 ## [0.7.4] - 2026-09-01
 
 ### 🐛 修复（issue #40）

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -41,8 +41,8 @@ dsh web
 ### 记忆存储（SQLite + Markdown 镜像）
 
 - **SQLite 主存储**：`~/.dsh/memory/memory.db`，`node:sqlite` 内置，零原生依赖
-- **Markdown 镜像**：`preferences.md` / `projects.md` / `decisions.md` / `history.md` / `summary.md`，人类可读、可手工编辑（**人工修改优先**合并回库）
-- **4+1 种记忆类型**：`preference`（偏好）/ `project`（项目）/ `decision`（决策）/ `history`（历史）/ `summary`（总览）
+- **Markdown 镜像**：`preferences.md` / `projects.md` / `decisions.md` / `history.md` / `summary.md` / `user.md` / `facts.md`，人类可读、可手工编辑（**人工修改优先**合并回库）
+- **8 种记忆类型**：用户可存 6 种（`preference` 偏好 / `project` 项目 / `decision` 决策 / `history` 历史 / `user` 用户画像 / `fact` 原子事实）+ AI 自动生成 2 种（`summary` 会话总览 / `pattern` 模式）（v0.7.5 起新增 user/fact 两个轻量分层，单表 `type` 字段扩展，不动表结构）
 - **镜像同步状态机（v0.3.6+）**：mirror 与主库强一致，用 `generation`（期望轮次）/ `applied_generation`（已应用轮次）建模同步债务
   - 业务写操作在**自身事务内原子递增** desired generation——崩溃在 COMMIT 后、渲染前，重启也能凭 durable 债务恢复，绝不静默跳过（v0.3.8）
   - `generation` 用 SQLite 原子语句递增，多进程并发零丢失；带 `CHECK` 上界，负数/溢出拒绝
@@ -241,6 +241,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 | 版本 | 亮点 |
 |------|------|
+| **v0.7.5** | 分层记忆类型：新增 `user`（用户画像）/`fact`（原子事实）轻量记忆类型（单表 `type` 扩展，不动 schema）+ Web 面板「总览」视图（记忆分层卡片 + 用户画像卡 + 类型分布 + 近 7 天趋势）+ `/api/dsh-mneme/stats` 统计端点；kimi-k2.7-code 复验（days 整数化等）；790 测试全绿 |
 | **v0.7.4** | issue #40 修复：记忆内容含 `{{...}}` 模板语法时整轮崩溃（注入边界 run-based 花括号转义 `{{a}}`→`{\{a\}\}`，奇数连续如 `{{{a}}}` 也不残留字面 `{{`；新增 `escapePromptVariables` 配置默认开）；issue #41 修复：记忆窗口关闭按钮与宿主窗口控制按钮重叠无法点击（顶栏左对齐，关闭按钮离开右上角宿主控制区）；782 测试全绿 |
 | **v0.7.3** | issue #38 新功能：左下角入口按钮可选开关 `showSidebarTrigger`（默认开）——与 dsh-cost-meter 等抢占 footer slot 的插件冲突时可在 Web 面板「设置」一键关闭，仅隐藏按钮、记忆库标签不受影响；776 测试全绿 |
 | **v0.7.2** | issue #35 修复：目录页删除按钮改面板内联两步确认（不再依赖宿主 `window.confirm`）+ 删除失败可见报错；issue #34 新功能：opt-in `injectTimePrefix` 对话开始自动注入当前时间一次（默认关）；770 测试全绿 |
@@ -293,6 +294,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 | **v0.7.2** | ✅ 完成 | issue #34 + #35 修复 | 目录页删除按钮改内联两步确认 + 删除失败可见报错；opt-in `injectTimePrefix` 对话开始注入当前时间一次（默认关）；770 测试全绿 |
 | **v0.7.3** | ✅ 完成 | issue #38 新功能 | 左下角入口按钮可选开关 `showSidebarTrigger`（默认开，settings-over-config）；Web 面板设置一键关闭，与 dsh-cost-meter 等 footer 插件冲突可隐藏按钮、记忆库标签不受影响；776 测试全绿 |
 | **v0.7.4** | ✅ 完成 | issue #40 + #41 修复 | 注入边界 run-based 花括号转义（`{{a}}`→`{\{a\}\}`、奇数连续如 `{{{a}}}` 不残留字面，`escapePromptVariables` 默认开）+ 记忆窗口顶栏左对齐、关闭按钮避开宿主窗口控制按钮区；782 测试全绿 |
+| **v0.7.5** | ✅ 完成 | 分层记忆类型 + 总览视图 | 借鉴 meow-memory 分层概念、贴合单表架构：新增 `user`（用户画像）/`fact`（原子事实）类型，注入/镜像/梦境/质量过滤全链路打通；Web 面板「总览」视图（分层卡片 + 用户画像卡 + 类型分布 + 近 7 天趋势）；`/api/dsh-mneme/stats` 端点；kimi-k2.7-code 复验；790 测试全绿 |
 | **v0.8.0** | 🚧 计划中（9 月末） | 图谱增强 | 兴趣漂移可视化 + 跨 workspace 记忆共享 + 更多 heat 信号 |
 
 > 新能力一律做成**可开关的功能**（配置启用/关闭），默认保守开启、不破坏现有行为。`failure_memories` 表与 autoDream 决策引擎已为后续反思性成长铺好路。

--- a/dsh-mneme/docs/MIGRATION.md
+++ b/dsh-mneme/docs/MIGRATION.md
@@ -61,7 +61,7 @@
 
 ### 1.2 Markdown 镜像
 
-- 五个 `.md` 镜像文件（`preferences.md` / `projects.md` / `decisions.md` / `history.md` / `summary.md`）格式不变，双向同步、人工优先的规则不变
+- 七个 `.md` 镜像文件（`preferences.md` / `projects.md` / `decisions.md` / `history.md` / `summary.md` / `user.md` / `facts.md`）格式不变，双向同步、人工优先的规则不变（v0.7.5 起新增 user/fact 两个分层镜像）
 - 升级后首次启动仍执行"读取人工编辑 → 合并回库"，无竞态（先全量读取再统一合并）
 
 ### 1.3 dream_runs 审计表

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -98,6 +98,21 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
 
   register({
     kind: "exact",
+    path: "/api/dsh-mneme/stats",
+    handler(req, res) {
+      try {
+        const url = new URL(req.url, "http://localhost");
+        const raw = url.searchParams.get("days");
+        const days = Math.min(30, Math.max(1, parseInt(raw ?? "7", 10) || 7));
+        sendJson(res, 200, service.stats({ days }));
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  register({
+    kind: "exact",
     path: "/api/dsh-mneme/search",
     handler(req, res) {
       try {

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -65,6 +65,8 @@ window.__ModuleLoader__.load({
         "memory.tab.project": "项目",
         "memory.tab.decision": "决策",
         "memory.tab.history": "历史",
+        "memory.tab.user": "用户",
+        "memory.tab.fact": "事实",
         "memory.settings.title": "记忆库设置",
         "memory.settings.profile": "用户画像",
         "memory.settings.profileHint": "描述你自己（角色、背景、偏好），Agent 会在每轮遵循",
@@ -100,6 +102,7 @@ window.__ModuleLoader__.load({
         "memory.explorer.tabGraph": "图谱",
         "memory.explorer.tabDirectory": "目录",
         "memory.explorer.tabSettings": "设置",
+        "memory.explorer.tabOverview": "总览",
         "memory.explorer.search": "搜索标题或内容…",
         "memory.explorer.searchTitle": "语义检索",
         "memory.explorer.types": "分类",
@@ -122,6 +125,14 @@ window.__ModuleLoader__.load({
         "memory.explorer.importance": "重要性",
         "memory.explorer.topK": "返回数量",
         "memory.explorer.topKOption": "返回 {n} 条",
+        "memory.overview.empty": "还没有记忆。开始对话后 Agent 会自动沉淀记忆，这里会展示分层总览",
+        "memory.overview.profileEmpty": "暂无用户画像记忆，可在对话中让 AI 记录",
+        "memory.overview.distribution": "类型分布",
+        "memory.overview.layers": "记忆分层",
+        "memory.overview.trend": "近 7 天趋势",
+        "memory.overview.none": "暂无",
+        "memory.overview.badgeInject": "常注入",
+        "memory.overview.badgeImportance": "按重要性",
         "memory.directory.untagged": "无标签",
         "memory.directory.loading": "加载中…",
         "memory.directory.empty": "暂无记忆条目",
@@ -179,6 +190,8 @@ window.__ModuleLoader__.load({
         "memory.tab.project": "Projects",
         "memory.tab.decision": "Decisions",
         "memory.tab.history": "History",
+        "memory.tab.user": "User",
+        "memory.tab.fact": "Facts",
         "memory.settings.title": "Memory Settings",
         "memory.settings.profile": "User Profile",
         "memory.settings.profileHint": "Describe yourself — the agent follows this every turn",
@@ -214,6 +227,7 @@ window.__ModuleLoader__.load({
         "memory.explorer.tabGraph": "Graph",
         "memory.explorer.tabDirectory": "Directory",
         "memory.explorer.tabSettings": "Settings",
+        "memory.explorer.tabOverview": "Overview",
         "memory.explorer.search": "Search title or content…",
         "memory.explorer.searchTitle": "Semantic Search",
         "memory.explorer.types": "Types",
@@ -236,6 +250,14 @@ window.__ModuleLoader__.load({
         "memory.explorer.importance": "Importance",
         "memory.explorer.topK": "Results limit",
         "memory.explorer.topKOption": "Return {n}",
+        "memory.overview.empty": "No memories yet. Once you chat, the agent starts saving memories and the layered overview appears here",
+        "memory.overview.profileEmpty": "No user-profile memories yet — ask the agent to remember things about you in chat",
+        "memory.overview.distribution": "By Type",
+        "memory.overview.layers": "Memory Layers",
+        "memory.overview.trend": "Last 7 days",
+        "memory.overview.none": "None",
+        "memory.overview.badgeInject": "Auto-inject",
+        "memory.overview.badgeImportance": "By importance",
         "memory.directory.untagged": "Untagged",
         "memory.directory.loading": "Loading…",
         "memory.directory.empty": "No memories yet",
@@ -466,6 +488,32 @@ window.__ModuleLoader__.load({
       // --- settings sub-view ---
       ".mneme-xsettings{flex:1;min-height:0;overflow-y:auto;padding:24px 24px 48px}",
       ".mneme-xsettings-inner{max-width:640px}",
+      // --- overview sub-view (layered stats dashboard, .mneme-ov-* only) ---
+      ".mneme-ov-wrap{flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column;gap:12px;padding:12px 16px 28px}",
+      ".mneme-ov-profile{gap:8px}",
+      ".mneme-ov-prow{display:flex;flex-direction:column;gap:2px;padding:4px 0;border-top:1px solid var(--dsw-alias-border-l1)}",
+      ".mneme-ov-prow:first-of-type{border-top:none}",
+      ".mneme-ov-ptitle{font-size:13px;font-weight:600;line-height:18px;color:var(--dsw-alias-label-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+      ".mneme-ov-ppreview{font-size:12px;line-height:17px;color:var(--dsw-alias-label-tertiary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+      ".mneme-ov-dist{display:flex;flex-direction:column;gap:6px}",
+      ".mneme-ov-distrow{display:flex;align-items:center;gap:8px}",
+      ".mneme-ov-distlabel{flex:none;width:76px;font-size:12px;line-height:16px;color:var(--dsw-alias-label-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+      ".mneme-ov-distcount{flex:none;width:34px;font-size:12px;line-height:16px;color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums;text-align:right}",
+      ".mneme-ov-disttrack{flex:1;min-width:0;height:8px;border-radius:4px;background:var(--dsw-alias-border-l2)}",
+      ".mneme-ov-distbar{height:100%;min-width:2px;border-radius:4px;background:var(--dsw-alias-state-business-primary)}",
+      ".mneme-ov-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:10px}",
+      ".mneme-ov-tile{box-sizing:border-box;text-align:left;border:none;cursor:pointer;font-family:inherit;gap:6px;overflow:hidden}",
+      ".mneme-ov-tile:hover{background:var(--dsw-alias-interactive-bg-hover)}",
+      ".mneme-ov-tilehead{display:flex;align-items:center;gap:6px}",
+      ".mneme-ov-tiletitle{min-width:0;font-size:13px;font-weight:600;line-height:18px;color:var(--dsw-alias-label-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+      ".mneme-ov-tilecount{flex:none;margin-left:auto;font-size:12px;line-height:16px;color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums}",
+      ".mneme-ov-badge{flex:none;font-size:11px;line-height:16px;padding:0 6px;border-radius:8px;background:color-mix(in srgb,var(--dsw-alias-state-business-primary) 12%,transparent);color:var(--dsw-alias-state-business-primary)}",
+      ".mneme-ov-badge--dim{background:var(--dsw-alias-interactive-bg-hover);color:var(--dsw-alias-label-tertiary)}",
+      ".mneme-ov-tilelatest{font-size:12px;line-height:17px;color:var(--dsw-alias-label-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+      ".mneme-ov-trend{display:flex;align-items:flex-end;gap:8px;padding:8px 4px 0}",
+      ".mneme-ov-trendcol{flex:1;min-width:0;display:flex;flex-direction:column;align-items:center;gap:4px}",
+      ".mneme-ov-trendbar{width:min(100%,30px);border-radius:4px 4px 0 0;background:var(--dsw-alias-state-business-primary)}",
+      ".mneme-ov-trenddate{font-size:10px;line-height:12px;color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums;white-space:nowrap}",
       // --- hero fallback: full-viewport memory library when no tab ring exists ---
       // The host hides the whole conversation tab ring while a session is
       // blank (hero screen), so the sidebar entry cannot activate the tab
@@ -1371,10 +1419,139 @@ window.__ModuleLoader__.load({
       );
     }
 
-    const EXPLORER_TYPES = ["preference", "project", "decision", "summary", "history"];
+    // --- Overview sub-view (layered stats dashboard) ---
+    // Card grid of every memory type (fixed display order, strays appended
+    // alphabetically), plus a user-profile card, a CSS-only type distribution
+    // bar chart and a 7-day creation trend. Data comes from /stats; each tile
+    // probes /list?type=X&limit=1 for a representative latest title (the list
+    // API sorts importance-first, so limit=1 is the type's most prominent row).
+    const OVERVIEW_TYPE_ORDER = ["preference", "project", "decision", "history", "user", "fact", "summary", "pattern"];
+    // Injection-priority tiers from service.js (summary > preference/user >
+    // importance): these layers ride into nearly every prompt.
+    const OVERVIEW_INJECT_TYPES = ["summary", "user", "preference"];
+
+    function OverviewPanel({ t, onPickType }) {
+      const [stats, setStats] = useState(null); // null = loading
+      const [profile, setProfile] = useState(null); // user-type memories (list card)
+      const [latest, setLatest] = useState({}); // type -> representative memory | null
+
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/stats?days=7")
+          .then((r) => (r.ok ? r.json() : null))
+          .then((d) => { if (!cancelled) setStats(d && d.byType ? d : { byType: {}, total: 0, recent: [] }); })
+          .catch(() => { if (!cancelled) setStats({ byType: {}, total: 0, recent: [] }); });
+        apiFetch("/api/dsh-mneme/list?type=user&limit=20")
+          .then((r) => (r.ok ? r.json() : { items: [] }))
+          .then((d) => { if (!cancelled) setProfile(Array.isArray(d.items) ? d.items : []); })
+          .catch(() => { if (!cancelled) setProfile([]); });
+        return () => { cancelled = true; };
+      }, []);
+
+      const byType = stats ? stats.byType : {};
+      const gridTypes = stats
+        ? OVERVIEW_TYPE_ORDER.filter((k) => byType[k]).concat(
+            Object.keys(byType).filter((k) => !OVERVIEW_TYPE_ORDER.includes(k)).sort())
+        : [];
+
+      // Representative-latest probe, one small request per visible layer.
+      // Derived purely from stats, so [stats] is the full dependency set.
+      useEffect(() => {
+        if (!stats || gridTypes.length === 0) return;
+        let cancelled = false;
+        Promise.all(gridTypes.map((k) =>
+          apiFetch(`/api/dsh-mneme/list?type=${encodeURIComponent(k)}&limit=1`)
+            .then((r) => (r.ok ? r.json() : { items: [] }))
+            .then((d) => [k, (Array.isArray(d.items) && d.items[0]) || null])
+            .catch(() => [k, null])
+        )).then((pairs) => { if (!cancelled) setLatest(Object.fromEntries(pairs)); });
+        return () => { cancelled = true; };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [stats]);
+
+      if (!stats) return h("div", { className: "mneme-ov-wrap" }, h("div", { className: "mneme-hint" }, t("memory.directory.loading")));
+      if (stats.total === 0) return h("div", { className: "mneme-ov-wrap" }, h("div", { className: "mneme-hint" }, t("memory.overview.empty")));
+
+      const distRow = (key) => {
+        const count = byType[key] || 0;
+        const pct = stats.total > 0 ? Math.round((count / stats.total) * 100) : 0;
+        return h("div", { key, className: "mneme-ov-distrow" },
+          h("span", { className: "mneme-ov-distlabel" }, typeLabel(t, key)),
+          h("span", { className: "mneme-ov-distcount" }, String(count)),
+          h("div", { className: "mneme-ov-disttrack" },
+            h("div", { className: "mneme-ov-distbar", style: { width: `${pct}%` } }))
+        );
+      };
+
+      const tile = (key) => {
+        const inject = OVERVIEW_INJECT_TYPES.includes(key);
+        const last = latest[key];
+        return h("button", {
+          key,
+          type: "button",
+          className: "mneme-card mneme-ov-tile",
+          title: t("memory.card.open"),
+          onClick: () => onPickType && onPickType(key)
+        },
+          h("div", { className: "mneme-ov-tilehead" },
+            h("span", { className: "mneme-ov-tiletitle" }, typeLabel(t, key)),
+            h("span", { className: inject ? "mneme-ov-badge" : "mneme-ov-badge mneme-ov-badge--dim" },
+              inject ? t("memory.overview.badgeInject") : t("memory.overview.badgeImportance")),
+            h("span", { className: "mneme-ov-tilecount" }, String(byType[key] || 0))
+          ),
+          h("div", { className: "mneme-ov-tilelatest" },
+            (last && (last.title || (last.content || "").slice(0, 40))) || t("memory.overview.none"))
+        );
+      };
+
+      // Trend bars scale to the busiest day; heights are fixed px so they do
+      // not depend on percentage resolution inside the flex columns.
+      const recent = Array.isArray(stats.recent) ? stats.recent : [];
+      const maxTrend = Math.max(1, ...recent.map((d) => d.count || 0));
+      const trendCol = (d) => {
+        const count = d.count || 0;
+        const px = count > 0 ? 6 + Math.round((count / maxTrend) * 90) : 0;
+        return h("div", {
+          key: d.date,
+          className: "mneme-ov-trendcol",
+          title: `${d.date} · ${t("memory.explorer.count").replace("{n}", String(count))}`
+        },
+          h("div", { className: "mneme-ov-trendbar", style: { height: `${px}px` } }),
+          h("div", { className: "mneme-ov-trenddate" }, (d.date || "").slice(5)) // MM-DD
+        );
+      };
+
+      return h("div", { className: "mneme-ov-wrap" },
+        h("div", { className: "mneme-card mneme-ov-profile", role: "region", "aria-label": t("memory.settings.profile") },
+          h("div", { className: "mneme-xcolhead" }, t("memory.settings.profile")),
+          profile === null
+            ? h("div", { className: "mneme-ov-ppreview" }, t("memory.directory.loading"))
+            : profile.length === 0
+              ? h("div", { className: "mneme-ov-ppreview" }, t("memory.overview.profileEmpty"))
+              : profile.map((m) => h("div", { key: m.id, className: "mneme-ov-prow" },
+                  h("span", { className: "mneme-ov-ptitle" }, m.title || "—"),
+                  h("span", { className: "mneme-ov-ppreview" }, (m.content_preview || m.content || "").slice(0, 100))
+                ))
+        ),
+        h("div", { className: "mneme-card", role: "region", "aria-label": t("memory.overview.distribution") },
+          h("div", { className: "mneme-xcolhead" }, t("memory.overview.distribution")),
+          h("div", { className: "mneme-ov-dist" }, gridTypes.map(distRow))
+        ),
+        h("div", { className: "mneme-xcolhead" }, t("memory.overview.layers")),
+        h("div", { className: "mneme-ov-grid" }, gridTypes.map(tile)),
+        h("div", { className: "mneme-card", role: "region", "aria-label": t("memory.overview.trend") },
+          h("div", { className: "mneme-xcolhead" }, t("memory.overview.trend")),
+          recent.length === 0
+            ? h("div", { className: "mneme-ov-tilelatest" }, t("memory.overview.none"))
+            : h("div", { className: "mneme-ov-trend" }, recent.map(trendCol))
+        )
+      );
+    }
+
+    const EXPLORER_TYPES = ["preference", "project", "decision", "summary", "history", "user", "fact"];
 
     function MemoryExplorer({ t }) {
-      const [view, setView] = useState("memory"); // memory | directory | graph | settings
+      const [view, setView] = useState("memory"); // memory | overview | directory | graph | settings
       const [items, setItems] = useState([]);
       const [loading, setLoading] = useState(true);
       const [type, setType] = useState("all");
@@ -1586,8 +1763,15 @@ window.__ModuleLoader__.load({
         setView("graph");
       };
 
+      // Overview tile click: dive into the memory view filtered to that layer.
+      const pickLayerType = (key) => {
+        setType(key);
+        setView("memory");
+      };
+
       const subviews = [
         { key: "memory", label: t("memory.explorer.tabMemory") },
+        { key: "overview", label: t("memory.explorer.tabOverview") },
         { key: "directory", label: t("memory.explorer.tabDirectory") },
         { key: "graph", label: t("memory.explorer.tabGraph") },
         { key: "settings", label: t("memory.explorer.tabSettings") }
@@ -1776,6 +1960,7 @@ window.__ModuleLoader__.load({
             )
           )
         ),
+        view === "overview" && h(OverviewPanel, { t, onPickType: pickLayerType }),
         view === "directory" && h(DirectoryPanel, { t, onJump: jumpToMemory, collapsed: dirCollapsed, setCollapsed: setDirCollapsed }),
         view === "graph" && h(GraphPanel, { t, focusEntity: graphFocus, onJumpMemory: jumpToMemory }),
         view === "settings" && h("div", { className: "mneme-xsettings" },

--- a/dsh-mneme/lib/mirror.js
+++ b/dsh-mneme/lib/mirror.js
@@ -7,7 +7,9 @@ export const TYPE_FILE = {
   project: "projects.md",
   decision: "decisions.md",
   history: "history.md",
-  summary: "summary.md"
+  summary: "summary.md",
+  user: "user.md",
+  fact: "facts.md"
 };
 
 const ESCAPE = /([\\`*_[\]{}()#+.!|>~-])/g;

--- a/dsh-mneme/lib/quality-filter.js
+++ b/dsh-mneme/lib/quality-filter.js
@@ -34,7 +34,9 @@ const TYPE_LABELS = {
   decision: ["decision", "决策", "决定"],
   history: ["history", "历史", "事件"],
   summary: ["summary", "总结", "摘要", "总览"],
-  pattern: ["pattern", "模式", "规律"]
+  pattern: ["pattern", "模式", "规律"],
+  user: ["user", "用户"],
+  fact: ["fact", "事实", "原子事实"]
 };
 
 /** Normalized bigram-overlap similarity in [0,1]; 0 for tiny/empty inputs. */

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -7,7 +7,7 @@ import { parseWikiLinks } from "./parser/wiki-link.js";
 import { extractQueryTags, applyTagBoost } from "./search/tag-boost.js";
 import { computeHeat } from "./heat.js";
 
-const INJECT_TYPES = new Set(["preference", "project", "decision", "summary"]);
+const INJECT_TYPES = new Set(["preference", "project", "decision", "summary", "user", "fact"]);
 
 // Epistemic trust weights (v0.4.5): when config.trustEpistemicWeighting is on,
 // each recall candidate's existing score is multiplied by the weight of its
@@ -1047,12 +1047,15 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     // (quality_score null) count as 100 (weight 1), so legacy stores keep their
     // exact summary>preference>importance ordering.
     const qualityWeight = (m) => (m.quality_score != null ? m.quality_score / 100 : 1);
+    // summary/user/preference are injected regardless of importance (context
+    // layers); every other INJECT_TYPES type (e.g. fact) only when
+    // importance >= threshold — the frontend "常注入" badge maps to this split.
     const items = store.list({ limit: 200, includeForgotten: false })
       .filter((m) => !m.archived && INJECT_TYPES.has(m.type) && !m.forgotten &&
-        (m.type === "summary" || m.type === "preference" || m.importance >= threshold))
+        (m.type === "summary" || m.type === "preference" || m.type === "user" || m.importance >= threshold))
       .sort((a, b) => {
-        const pa = a.type === "summary" ? 0 : a.type === "preference" ? 1 : 2;
-        const pb = b.type === "summary" ? 0 : b.type === "preference" ? 1 : 2;
+        const pa = a.type === "summary" ? 0 : (a.type === "preference" || a.type === "user") ? 1 : 2;
+        const pb = b.type === "summary" ? 0 : (b.type === "preference" || b.type === "user") ? 1 : 2;
         return pa - pb || (b.importance * qualityWeight(b)) - (a.importance * qualityWeight(a));
       });
     let candidates = items;
@@ -1068,7 +1071,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
           const hits = vectorIndex.search(queryVector, { limit: maxItems * 2, threshold: 0 });
           for (const m of hits) {
             if (m && !m.archived && INJECT_TYPES.has(m.type) && !m.forgotten &&
-              (m.type === "summary" || m.type === "preference" || m.importance >= threshold)) {
+              (m.type === "summary" || m.type === "preference" || m.type === "user" || m.importance >= threshold)) {
               semanticItems.push(m);
             }
           }
@@ -1606,6 +1609,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     list: (o) => store.list(o),
     all: () => store.all(),
     count: (type, opts) => store.count(type, opts),
+    stats: (opts) => store.stats(opts),
     getById: (id) => store.getById(id),
     remove: (id) => {
       store.remove(id);

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -242,7 +242,7 @@ CREATE TABLE IF NOT EXISTS mirror_state (
 );
 `;
 
-const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern"]);
+const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern", "user", "fact"]);
 
 // Epistemic status: what kind of evidence a memory rests on. Defaults to
 // 'subjective' so legacy rows (and rows without any signal) stay compatible.
@@ -657,6 +657,39 @@ export function createStore(path) {
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
     return db.prepare(`SELECT count(*) AS c FROM memories ${where}`).get(...params).c;
+  }
+
+  /**
+   * Aggregated stats for the Web panel layered overview: per-type distribution
+   * plus a recent daily creation trend. Counts live (non-forgotten /
+   * non-archived / not session-disposed) memories only, matching `count`.
+   * created_at is ISO TEXT, so date strings compare lexicographically.
+   */
+  function stats({ days = 7 } = {}) {
+    const LIVE = "forgotten = 0 AND archived = 0 AND session_disposed_at IS NULL";
+    // Clamp + integer-coerce so fractional strings (e.g. ?days=7.5) can't
+    // produce ragged trend windows (kimi-k2.7-code 复验 S2).
+    days = Math.min(30, Math.max(1, Math.floor(Number(days) || 7)));
+    const now = Date.now(); // single clock read so the window doesn't span a day boundary
+    const byType = db.prepare(
+      `SELECT type, count(*) AS c FROM memories WHERE ${LIVE} GROUP BY type`
+    ).all();
+    const byTypeCounts = {};
+    for (const row of byType) byTypeCounts[row.type] = row.c;
+    const since = new Date(now - (days - 1) * 86400000).toISOString().slice(0, 10);
+    const trend = db.prepare(
+      `SELECT substr(created_at, 1, 10) AS d, count(*) AS c FROM memories
+       WHERE ${LIVE} AND created_at >= ? GROUP BY d ORDER BY d`
+    ).all(since);
+    const trendCounts = {};
+    for (const row of trend) trendCounts[row.d] = row.c;
+    const recent = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(now - i * 86400000).toISOString().slice(0, 10);
+      recent.push({ date: d, count: trendCounts[d] ?? 0 });
+    }
+    const total = Object.values(byTypeCounts).reduce((s, n) => s + n, 0);
+    return { byType: byTypeCounts, total, recent, days };
   }
 
   function getById(id) {
@@ -2175,6 +2208,7 @@ export function createStore(path) {
   return {
     db,
     count,
+    stats,
     getById,
     save,
     update,

--- a/dsh-mneme/lib/summarize.js
+++ b/dsh-mneme/lib/summarize.js
@@ -1,7 +1,7 @@
 import { BlockAssembler, createUserMessage } from "@deepseek-ai/dsh-llm";
 
 const SUMMARY_PROMPT = `你是记忆库提炼助手。根据下面的会话内容，提炼 2-3 条值得跨会话记住的记忆。
-只输出 JSON 数组，每项形如 {"type":"preference|project|decision|history","title":"简短标题","content":"一句话内容","importance":1-5}。
+只输出 JSON 数组，每项形如 {"type":"preference|project|decision|history|user|fact","title":"简短标题","content":"一句话内容","importance":1-5}。
 不要输出任何其他文字。`;
 
 /** Extract a JSON array from LLM output that may contain prose around it. */
@@ -17,7 +17,7 @@ export function parseSummaryJson(raw) {
     return [];
   }
   if (!Array.isArray(arr)) return [];
-  const VALID = new Set(["preference", "project", "decision", "history"]);
+  const VALID = new Set(["preference", "project", "decision", "history", "user", "fact"]);
   return arr.filter(
     (item) =>
       item &&

--- a/dsh-mneme/lib/tools.js
+++ b/dsh-mneme/lib/tools.js
@@ -192,7 +192,7 @@ export function createTools(ctx, service, config, embedder) {
         "Call this when the user states a durable preference, a project decision is made, or a lesson is learned. " +
         "Merges into an existing entry of the same type when the title matches.",
       parameters: {
-        type: { type: "string", required: true, enum: ["preference", "project", "decision", "history"], description: "preference=user profile; project=project knowledge/state; decision=key decision; history=conversation summary" },
+        type: { type: "string", required: true, enum: ["preference", "project", "decision", "history", "user", "fact"], description: "preference=user preference; project=project knowledge/state; decision=key decision; history=conversation summary; user=user profile (background/identity); fact=atomic factual statement" },
         title: { type: "string", required: true, description: "Short unique title" },
         content: { type: "string", required: true, description: "Memory body" },
         tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
@@ -266,7 +266,7 @@ export function createTools(ctx, service, config, embedder) {
       name: "memory_list",
       description: "List at most 50 memory entries by type, high-importance first, then newest, paginated. Set include_archived=true to also list archived (hidden) entries so they can be located and restored. The JSONL summary reports returned/shown/omitted, offset/total/next_offset, and each rendered entry's exact id, type, title, importance, updated_at, tags, and truncated content_preview.",
       parameters: {
-        type: { type: "string", enum: ["preference", "project", "decision", "history"], description: "Filter by type; omit for all" },
+        type: { type: "string", enum: ["preference", "project", "decision", "history", "user", "fact"], description: "Filter by type; omit for all" },
         limit: { type: "integer", description: "Page size (default and maximum 50; nonpositive values use 50)" },
         offset: { type: "integer", description: "Page offset (default 0)" },
         include_archived: { type: "boolean", description: "Include archived (hidden) entries so they can be found and restored (default false)" }
@@ -305,7 +305,7 @@ export function createTools(ctx, service, config, embedder) {
         id: { type: "string", required: true, description: "Memory id" },
         title: { type: "string" },
         content: { type: "string" },
-        type: { type: "string", enum: ["preference", "project", "decision", "history"] },
+        type: { type: "string", enum: ["preference", "project", "decision", "history", "user", "fact"] },
         tags: { type: "array", items: { type: "string" } },
         importance: { type: "integer", description: "1-5" },
         reason: { type: "string", description: "Optional context for the correction (what the user actually said/wanted), recorded for reflection" }

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0"

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -98,6 +98,21 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
 
   register({
     kind: "exact",
+    path: "/api/dsh-mneme/stats",
+    handler(req, res) {
+      try {
+        const url = new URL(req.url, "http://localhost");
+        const raw = url.searchParams.get("days");
+        const days = Math.min(30, Math.max(1, parseInt(raw ?? "7", 10) || 7));
+        sendJson(res, 200, service.stats({ days }));
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  register({
+    kind: "exact",
     path: "/api/dsh-mneme/search",
     handler(req, res) {
       try {

--- a/dsh-mneme/src/mirror.js
+++ b/dsh-mneme/src/mirror.js
@@ -7,7 +7,9 @@ export const TYPE_FILE = {
   project: "projects.md",
   decision: "decisions.md",
   history: "history.md",
-  summary: "summary.md"
+  summary: "summary.md",
+  user: "user.md",
+  fact: "facts.md"
 };
 
 const ESCAPE = /([\\`*_[\]{}()#+.!|>~-])/g;

--- a/dsh-mneme/src/quality-filter.js
+++ b/dsh-mneme/src/quality-filter.js
@@ -34,7 +34,9 @@ const TYPE_LABELS = {
   decision: ["decision", "决策", "决定"],
   history: ["history", "历史", "事件"],
   summary: ["summary", "总结", "摘要", "总览"],
-  pattern: ["pattern", "模式", "规律"]
+  pattern: ["pattern", "模式", "规律"],
+  user: ["user", "用户"],
+  fact: ["fact", "事实", "原子事实"]
 };
 
 /** Normalized bigram-overlap similarity in [0,1]; 0 for tiny/empty inputs. */

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -7,7 +7,7 @@ import { parseWikiLinks } from "./parser/wiki-link.js";
 import { extractQueryTags, applyTagBoost } from "./search/tag-boost.js";
 import { computeHeat } from "./heat.js";
 
-const INJECT_TYPES = new Set(["preference", "project", "decision", "summary"]);
+const INJECT_TYPES = new Set(["preference", "project", "decision", "summary", "user", "fact"]);
 
 // Epistemic trust weights (v0.4.5): when config.trustEpistemicWeighting is on,
 // each recall candidate's existing score is multiplied by the weight of its
@@ -1047,12 +1047,15 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     // (quality_score null) count as 100 (weight 1), so legacy stores keep their
     // exact summary>preference>importance ordering.
     const qualityWeight = (m) => (m.quality_score != null ? m.quality_score / 100 : 1);
+    // summary/user/preference are injected regardless of importance (context
+    // layers); every other INJECT_TYPES type (e.g. fact) only when
+    // importance >= threshold — the frontend "常注入" badge maps to this split.
     const items = store.list({ limit: 200, includeForgotten: false })
       .filter((m) => !m.archived && INJECT_TYPES.has(m.type) && !m.forgotten &&
-        (m.type === "summary" || m.type === "preference" || m.importance >= threshold))
+        (m.type === "summary" || m.type === "preference" || m.type === "user" || m.importance >= threshold))
       .sort((a, b) => {
-        const pa = a.type === "summary" ? 0 : a.type === "preference" ? 1 : 2;
-        const pb = b.type === "summary" ? 0 : b.type === "preference" ? 1 : 2;
+        const pa = a.type === "summary" ? 0 : (a.type === "preference" || a.type === "user") ? 1 : 2;
+        const pb = b.type === "summary" ? 0 : (b.type === "preference" || b.type === "user") ? 1 : 2;
         return pa - pb || (b.importance * qualityWeight(b)) - (a.importance * qualityWeight(a));
       });
     let candidates = items;
@@ -1068,7 +1071,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
           const hits = vectorIndex.search(queryVector, { limit: maxItems * 2, threshold: 0 });
           for (const m of hits) {
             if (m && !m.archived && INJECT_TYPES.has(m.type) && !m.forgotten &&
-              (m.type === "summary" || m.type === "preference" || m.importance >= threshold)) {
+              (m.type === "summary" || m.type === "preference" || m.type === "user" || m.importance >= threshold)) {
               semanticItems.push(m);
             }
           }
@@ -1606,6 +1609,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     list: (o) => store.list(o),
     all: () => store.all(),
     count: (type, opts) => store.count(type, opts),
+    stats: (opts) => store.stats(opts),
     getById: (id) => store.getById(id),
     remove: (id) => {
       store.remove(id);

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -242,7 +242,7 @@ CREATE TABLE IF NOT EXISTS mirror_state (
 );
 `;
 
-const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern"]);
+const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern", "user", "fact"]);
 
 // Epistemic status: what kind of evidence a memory rests on. Defaults to
 // 'subjective' so legacy rows (and rows without any signal) stay compatible.
@@ -657,6 +657,39 @@ export function createStore(path) {
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
     return db.prepare(`SELECT count(*) AS c FROM memories ${where}`).get(...params).c;
+  }
+
+  /**
+   * Aggregated stats for the Web panel layered overview: per-type distribution
+   * plus a recent daily creation trend. Counts live (non-forgotten /
+   * non-archived / not session-disposed) memories only, matching `count`.
+   * created_at is ISO TEXT, so date strings compare lexicographically.
+   */
+  function stats({ days = 7 } = {}) {
+    const LIVE = "forgotten = 0 AND archived = 0 AND session_disposed_at IS NULL";
+    // Clamp + integer-coerce so fractional strings (e.g. ?days=7.5) can't
+    // produce ragged trend windows (kimi-k2.7-code 复验 S2).
+    days = Math.min(30, Math.max(1, Math.floor(Number(days) || 7)));
+    const now = Date.now(); // single clock read so the window doesn't span a day boundary
+    const byType = db.prepare(
+      `SELECT type, count(*) AS c FROM memories WHERE ${LIVE} GROUP BY type`
+    ).all();
+    const byTypeCounts = {};
+    for (const row of byType) byTypeCounts[row.type] = row.c;
+    const since = new Date(now - (days - 1) * 86400000).toISOString().slice(0, 10);
+    const trend = db.prepare(
+      `SELECT substr(created_at, 1, 10) AS d, count(*) AS c FROM memories
+       WHERE ${LIVE} AND created_at >= ? GROUP BY d ORDER BY d`
+    ).all(since);
+    const trendCounts = {};
+    for (const row of trend) trendCounts[row.d] = row.c;
+    const recent = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(now - i * 86400000).toISOString().slice(0, 10);
+      recent.push({ date: d, count: trendCounts[d] ?? 0 });
+    }
+    const total = Object.values(byTypeCounts).reduce((s, n) => s + n, 0);
+    return { byType: byTypeCounts, total, recent, days };
   }
 
   function getById(id) {
@@ -2175,6 +2208,7 @@ export function createStore(path) {
   return {
     db,
     count,
+    stats,
     getById,
     save,
     update,

--- a/dsh-mneme/src/summarize.js
+++ b/dsh-mneme/src/summarize.js
@@ -1,7 +1,7 @@
 import { BlockAssembler, createUserMessage } from "@deepseek-ai/dsh-llm";
 
 const SUMMARY_PROMPT = `你是记忆库提炼助手。根据下面的会话内容，提炼 2-3 条值得跨会话记住的记忆。
-只输出 JSON 数组，每项形如 {"type":"preference|project|decision|history","title":"简短标题","content":"一句话内容","importance":1-5}。
+只输出 JSON 数组，每项形如 {"type":"preference|project|decision|history|user|fact","title":"简短标题","content":"一句话内容","importance":1-5}。
 不要输出任何其他文字。`;
 
 /** Extract a JSON array from LLM output that may contain prose around it. */
@@ -17,7 +17,7 @@ export function parseSummaryJson(raw) {
     return [];
   }
   if (!Array.isArray(arr)) return [];
-  const VALID = new Set(["preference", "project", "decision", "history"]);
+  const VALID = new Set(["preference", "project", "decision", "history", "user", "fact"]);
   return arr.filter(
     (item) =>
       item &&

--- a/dsh-mneme/src/tools.js
+++ b/dsh-mneme/src/tools.js
@@ -192,7 +192,7 @@ export function createTools(ctx, service, config, embedder) {
         "Call this when the user states a durable preference, a project decision is made, or a lesson is learned. " +
         "Merges into an existing entry of the same type when the title matches.",
       parameters: {
-        type: { type: "string", required: true, enum: ["preference", "project", "decision", "history"], description: "preference=user profile; project=project knowledge/state; decision=key decision; history=conversation summary" },
+        type: { type: "string", required: true, enum: ["preference", "project", "decision", "history", "user", "fact"], description: "preference=user preference; project=project knowledge/state; decision=key decision; history=conversation summary; user=user profile (background/identity); fact=atomic factual statement" },
         title: { type: "string", required: true, description: "Short unique title" },
         content: { type: "string", required: true, description: "Memory body" },
         tags: { type: "array", items: { type: "string" }, description: "Optional tags" },
@@ -266,7 +266,7 @@ export function createTools(ctx, service, config, embedder) {
       name: "memory_list",
       description: "List at most 50 memory entries by type, high-importance first, then newest, paginated. Set include_archived=true to also list archived (hidden) entries so they can be located and restored. The JSONL summary reports returned/shown/omitted, offset/total/next_offset, and each rendered entry's exact id, type, title, importance, updated_at, tags, and truncated content_preview.",
       parameters: {
-        type: { type: "string", enum: ["preference", "project", "decision", "history"], description: "Filter by type; omit for all" },
+        type: { type: "string", enum: ["preference", "project", "decision", "history", "user", "fact"], description: "Filter by type; omit for all" },
         limit: { type: "integer", description: "Page size (default and maximum 50; nonpositive values use 50)" },
         offset: { type: "integer", description: "Page offset (default 0)" },
         include_archived: { type: "boolean", description: "Include archived (hidden) entries so they can be found and restored (default false)" }
@@ -305,7 +305,7 @@ export function createTools(ctx, service, config, embedder) {
         id: { type: "string", required: true, description: "Memory id" },
         title: { type: "string" },
         content: { type: "string" },
-        type: { type: "string", enum: ["preference", "project", "decision", "history"] },
+        type: { type: "string", enum: ["preference", "project", "decision", "history", "user", "fact"] },
         tags: { type: "array", items: { type: "string" } },
         importance: { type: "integer", description: "1-5" },
         reason: { type: "string", description: "Optional context for the correction (what the user actually said/wanted), recorded for reflection" }

--- a/dsh-mneme/test/layered-types-stats.test.js
+++ b/dsh-mneme/test/layered-types-stats.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { createStore } from "../src/store.js";
+import { createService } from "../src/service.js";
+import { createApi } from "../src/api.js";
+import { createSettings } from "../src/settings.js";
+import { TYPE_FILE } from "../src/mirror.js";
+import { parseSummaryJson } from "../src/summarize.js";
+
+// v0.8.x: layered memory types (user / fact) + Web panel stats endpoint.
+// user = user profile (background/identity), fact = atomic factual statement.
+// Both ride the existing single-table `memories` design — only the type enum
+// and downstream lists (mirror / tools / summarize / inject) were extended.
+
+class FakeRes extends EventEmitter {
+  constructor() { super(); this.statusCode = 200; this.body = ""; }
+  writeHead(code, headers) { this.statusCode = code; this.headers = headers; return this; }
+  end(text) { this.body = text ?? ""; this.emit("end"); return this; }
+}
+
+function req(path, method = "GET", body = null) {
+  const r = new EventEmitter();
+  r.url = path;
+  r.method = method;
+  r.headers = {};
+  if (body !== null) {
+    process.nextTick(() => {
+      r.emit("data", Buffer.from(JSON.stringify(body)));
+      r.emit("end");
+    });
+  }
+  return r;
+}
+
+function setup() {
+  const store = createStore(":memory:");
+  const settings = createSettings(store.db);
+  const service = createService({ store, mirror: null, config: {}, settings });
+  const commands = { add: () => {}, remove: () => {}, list: () => [] };
+  const routes = [];
+  const ctx = {
+    webServer: {
+      register(route) { routes.push(route); return () => {}; }
+    }
+  };
+  createApi(ctx, service, settings, commands, undefined, undefined, "");
+  const handler = (path) => routes.find((r) => r.path === path)?.handler;
+  return { store, service, handler };
+}
+
+test("user/fact are valid memory types for saveWithDedupe", () => {
+  const { service } = setup();
+  const a = service.saveWithDedupe({ type: "user", title: "桉桉", content: "湖南工业大学学生，考研公共管理学", importance: 5 });
+  const b = service.saveWithDedupe({ type: "fact", title: "服务器地址", content: "云服务器 Ubuntu 22.04", importance: 3 });
+  assert.equal(a.memory.type, "user");
+  assert.equal(b.memory.type, "fact");
+  assert.equal(service.count("user"), 1);
+  assert.equal(service.count("fact"), 1);
+});
+
+test("mirror TYPE_FILE covers user/fact layers", () => {
+  assert.equal(TYPE_FILE.user, "user.md");
+  assert.equal(TYPE_FILE.fact, "facts.md");
+});
+
+test("autoSummarize accepts user/fact types", () => {
+  const parsed = parseSummaryJson(
+    '[{"type":"user","title":"用户城市","content":"湖南株洲","importance":4},{"type":"fact","title":"端口","content":"23334","importance":3}]'
+  );
+  assert.equal(parsed.length, 2);
+  assert.deepEqual(parsed.map((i) => i.type), ["user", "fact"]);
+  // legacy types still pass, unknown types rejected
+  const mixed = parseSummaryJson(
+    '[{"type":"preference","title":"语言","content":"中文","importance":2},{"type":"nonsense","title":"x","content":"y","importance":1}]'
+  );
+  assert.equal(mixed.length, 1);
+  assert.equal(mixed[0].type, "preference");
+});
+
+test("GET /api/dsh-mneme/list?type=user filters the new layer", async () => {
+  const { service, handler } = setup();
+  service.saveWithDedupe({ type: "user", title: "桉桉", content: "用户画像", importance: 5 });
+  service.saveWithDedupe({ type: "fact", title: "事实", content: "原子事实", importance: 3 });
+  const res = new FakeRes();
+  await handler("/api/dsh-mneme/list")?.({ url: "/api/dsh-mneme/list?type=user" }, res);
+  const data = JSON.parse(res.body);
+  assert.equal(res.statusCode, 200);
+  assert.equal(data.total, 1);
+  assert.equal(data.items[0].type, "user");
+});
+
+test("GET /api/dsh-mneme/stats returns byType distribution + recent trend", async () => {
+  const { service, handler } = setup();
+  service.saveWithDedupe({ type: "user", title: "桉桉", content: "用户画像", importance: 5 });
+  service.saveWithDedupe({ type: "fact", title: "事实1", content: "原子事实", importance: 3 });
+  service.saveWithDedupe({ type: "fact", title: "事实2", content: "另一个事实", importance: 2 });
+  service.saveWithDedupe({ type: "preference", title: "语言", content: "中文", importance: 2 });
+  const res = new FakeRes();
+  await handler("/api/dsh-mneme/stats")?.({ url: "/api/dsh-mneme/stats?days=7" }, res);
+  const data = JSON.parse(res.body);
+  assert.equal(res.statusCode, 200);
+  assert.equal(data.byType.user, 1);
+  assert.equal(data.byType.fact, 2);
+  assert.equal(data.byType.preference, 1);
+  assert.equal(data.total, 4);
+  // 7-day trend covers today (the only day with live rows)
+  assert.equal(data.recent.length, 7);
+  const today = new Date().toISOString().slice(0, 10);
+  assert.equal(data.recent[6].date, today);
+  assert.equal(data.recent[6].count, 4);
+});
+
+test("stats excludes archived/forgotten memories", async () => {
+  const { service, handler } = setup();
+  const a = service.saveWithDedupe({ type: "user", title: "桉桉", content: "用户画像", importance: 5 });
+  const b = service.saveWithDedupe({ type: "fact", title: "事实", content: "原子事实", importance: 3 });
+  service.setArchived(a.memory.id, true);
+  service.setForget(b.memory.id, true);
+  const res = new FakeRes();
+  await handler("/api/dsh-mneme/stats")?.({ url: "/api/dsh-mneme/stats?days=7" }, res);
+  const data = JSON.parse(res.body);
+  assert.equal(data.total, 0);
+});
+
+test("stats clamps days to 1..30", async () => {
+  const { handler } = setup();
+  const res = new FakeRes();
+  await handler("/api/dsh-mneme/stats")?.({ url: "/api/dsh-mneme/stats?days=999" }, res);
+  const data = JSON.parse(res.body);
+  assert.equal(res.statusCode, 200);
+  assert.equal(data.recent.length, 30);
+});
+
+test("stats coerces fractional days to integer (kimi S2)", async () => {
+  const { service, handler } = setup();
+  service.saveWithDedupe({ type: "fact", title: "事实", content: "原子事实", importance: 3 });
+  const res = new FakeRes();
+  await handler("/api/dsh-mneme/stats")?.({ url: "/api/dsh-mneme/stats?days=7.5" }, res);
+  const data = JSON.parse(res.body);
+  assert.equal(data.recent.length, 7); // floor(7.5) → 7, never a ragged 8
+  assert.equal(data.days, 7);
+  assert.equal(data.byType.fact, 1);
+});


### PR DESCRIPTION
## 变更内容

借鉴 meow-memory 分层概念，贴合 dsh-mneme 单表架构，新增两个轻量分层记忆类型 + 可视化总览视图。

### 🆕 user/fact 分层类型
- `user`（用户画像）+ `fact`（原子事实），单表 `type` 字段扩展，**不动表结构**
- 注入（user 与 preference 同级常注入，fact 按重要性阈值）、镜像（`user.md`/`facts.md`）、提炼、质量过滤、工具枚举全链路打通

### 🆕 Web「总览」视图
- 记忆分层卡片 + 用户画像卡 + 类型分布面板 + 近 7 天趋势

### 🆕 stats 端点
- `GET /api/dsh-mneme/stats?days=N`（SQL 聚合，days 夹紧 1..30，排除归档/遗忘/会话销毁）

### 🔧 复验（kimi-k2.7-code）
- days 参数整数化（`?days=7.5` 不再产生 8 个趋势点）、store 单次 `Date.now()`、趋势 0 值柱 0 高度

## 测试
- 新增 8 个测试，全套 **790 通过**

> 版本号保持 v0.7.5（不影响 v0.8.0 路线图）；所有 README（README.md / docs/MIGRATION.md）已同步