### PR TITLE
ci: GitHub Actions 自动发 npm（摆脱隧道依赖）

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      # npm publish 必须从仓库根跑（根 package.json main → ./dsh-mneme/lib/index.js）。
+      # prepublishOnly 会把 dsh-mneme/package.json 的版本写回根 package.json，
+      # 所以发出的版本永远跟随 dsh-mneme/ 子目录版本号。
+      - name: Publish @modusensus/dsh-mneme
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # 发布后自检：查 registry 上刚发的版本是否可读
+      - name: Verify published version
+        run: |
+          V="$(node -p "require('./dsh-mneme/package.json').version")"
+          echo "Published: $(npm view "@modusensus/dsh-mneme@${V}" version)"


### PR DESCRIPTION
## 背景

registry.npmjs.org 在这台云服务器上 TLS/SNI 被出口过滤（TCP 通、ClientHello 后无响应），本地 publish 必须走 Windows 反向隧道（17897），隧道一断就发不了版。GitHub runner 出口网络不受此限制。

## 改动

新增 `.github/workflows/publish.yml`：
- 打 `v*" tag 自动 `npm publish`（发布从仓库根跑，prepublishOnly 取 dsh-mneme/package.json 版本 → 发出版本永远跟随子目录版本号）
- 支持 `workflow_dispatch` 手动触发
- 发布后自检 `npm view` 刚发的版本

## 依赖

- 已配 `NPM_TOKEN` secret（复用本地发布 token，未外显）

## 验证路径

v0.7.6（issue #48 修复）已 git 侧发版完毕，只差 npm。合入后 dispatch 一次即发。