### PR TITLE
feat(v0.7.7): sleep 批量实体抽取回填实体图谱 (issue #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-> **完整版本历史见 [dsh-mneme/CHANGELOG.md](dsh-mneme/CHANGELOG.md)**（正式版本正源，0.3.8 → 0.7.6）。以下为仓库早期开发记录（0.1.0–0.2.x，2026-08-13~14，已归档）。
+> **完整版本历史见 [dsh-mneme/CHANGELOG.md](dsh-mneme/CHANGELOG.md)**（正式版本正源，0.3.8 → 0.7.7）。以下为仓库早期开发记录（0.1.0–0.2.x，2026-08-13~14，已归档）。
 
 All notable changes to dsh-mneme are documented here.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-3E63DD?style=flat-square" alt="license"></a>
   <a href="https://github.com/modusensus/dsh-mneme/actions"><img src="https://img.shields.io/github/actions/workflow/status/modusensus/dsh-mneme/test.yml?style=flat-square&label=CI" alt="CI"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-24%2B-3E63DD?style=flat-square&logo=nodedotjs&logoColor=white" alt="node"></a>
-  <a href="https://github.com/modusensus/dsh-mneme"><img src="https://img.shields.io/badge/tests-801%20passed-3E63DD?style=flat-square" alt="tests"></a>
+  <a href="https://github.com/modusensus/dsh-mneme"><img src="https://img.shields.io/badge/tests-810%20passed-3E63DD?style=flat-square" alt="tests"></a>
   <a href="https://codecov.io/gh/modusensus/dsh-mneme"><img src="https://img.shields.io/codecov/c/github/modusensus/dsh-mneme/main?style=flat-square" alt="coverage"></a>
   <a href="https://github.com/awesome-dsh-plugin/awesome-dsh-plugin"><img src="https://awesome-dsh-plugin.com/badge.svg" alt="Awesome"></a>
 </p>
@@ -109,6 +109,7 @@ dsh web
 | **v0.7.4** | issue #40 记忆花括号转义 + issue #41 记忆窗口关闭按钮重叠修复 | ✅ |
 | **v0.7.5** | 分层记忆类型 user/fact + Web 总览视图 + stats 端点 | ✅ |
 | **v0.7.6** | issue #48 修复：截断/前缀 id 也能精确操作（统一 resolveMemoryId）+ client.js 改 src 正源 | ✅ |
+| **v0.7.7** | issue #23 图谱回填：sleep 批量实体抽取 phase + node:sqlite 兼容修复 | ✅ |
 | **v0.8.0** | 图谱增强：兴趣漂移可视化 + scope 隔离（issue #17）+ 跨 workspace 共享 | 🚧 计划中（9 月末） |
 
 ## 🧪 本地开发
@@ -116,7 +117,7 @@ dsh web
 ```bash
 cd dsh-mneme
 npm install
-npm test          # 801 个测试
+npm test          # 810 个测试
 npm run stress    # 三轴线压测
 npm run sync      # src → lib 同步
 ```
@@ -223,7 +224,7 @@ Works out of the box. Enable these as needed:
 ```bash
 cd dsh-mneme
 npm install
-npm test          # 801 tests
+npm test          # 810 tests
 npm run stress    # three-axis stress test
 npm run sync      # src → lib sync
 ```

--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.7.7] - 2026-09-05
+
+### 🆕 issue #23：sleep 批量实体抽取回填实体图谱
+
+- **背景**：写路径抽取（index.js）只有 `entityExtractionEnabled` 开启才触发——每次写入一次 LLM 调用，是刻意的成本取舍——所以默认安装下记忆从不累积实体，这正是 issue #23 报的"实体图谱面板一片空白"（用户明明有很多记忆）。
+- **新增 sleep 批量抽取 phase**：默认关 `sleepEntityExtractionEnabled`，开睡循环时按**最老优先**把没有实体属性的记忆逐条过 `extractEntities`（每轮上限 `sleepEntityExtractionMaxPerRun` 默认 20）。
+- **下沉为有界 SQL 查询**（kimi 复验意见 #2）：新增 `store.listForEntityExtraction({limit, offset})`，`WHERE` 只留行级条件（未归档/未遗忘/非 summary/内容非空/`metadata.entity_extracted_at` 为空），`ORDER BY created_at LIMIT ? OFFSET ?` 分页取最老候选；实体是否已存在是跨表检查（`getAttrsByMemory`），由 JS 在每页上过滤。不再 `service.all()` 全表加载。
+- **幂等防重**（kimi 意见 #3）：抽取前先 stamp `metadata.pending_extracted_at`，成功后替换为 `entity_extracted_at`，失败清除 pending——一条记忆不会被并发/崩溃重复抽取，失败的下轮重试。
+- **metadata 合并不覆盖**（kimi 意见 #4）：`store.setMemoryMetadata` 改为 merge 语义，打实体时间戳不会抹掉其他路径刚写入的 metadata 字段。
+- **失败不阻断**（kimi 意见 #5）：单条抽取失败只跳过该条、记入 `failed` 计数，整轮状态由 `deriveStatus` 正确折叠 `failed`——一次 LLM 抖动不会 abort 整个 sleep 周期。
+- **node:sqlite 兼容修复**（复验时抓到的实现 bug）：wxbot 初版用 better-sqlite3 的 `.pluck()`（node:sqlite 不存在），改为 `.all().map(row => getById(row.id))`；`listForEntityExtraction` 的 `forgotten IS NULL` 条件与 `save` 硬编码写入的 `forgotten=0` 永不匹配导致查询恒空，修正为 `(forgotten = 0 OR forgotten IS NULL)`（与 archived 同构）。
+- 新增 9 个用例（禁用/跳过、stamp 不重复、无实体也 stamp、backfill、失败重试、metadata merge #4、pending 清除 #3、failed 状态折叠 #5、分页最老优先 #2），全套 **810 通过**。
+
 ## [0.7.6] - 2026-09-02
 
 ### 🐛 issue #48：截断的短 id 也能精确操作

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@modusensus/dsh-mneme?color=blue&label=npm)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Awesome](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
-[![tests](https://img.shields.io/badge/tests-801%20passed-success)](https://github.com/modusensus/dsh-mneme)
+[![tests](https://img.shields.io/badge/tests-810%20passed-success)](https://github.com/modusensus/dsh-mneme)
 [![CI](https://img.shields.io/github/actions/workflow/status/modusensus/dsh-mneme/test.yml)](https://github.com/modusensus/dsh-mneme/actions)
 [![node](https://img.shields.io/badge/node-24%2B-blue)](https://nodejs.org)
 [![npm downloads](https://img.shields.io/npm/dm/@modusensus/dsh-mneme?color=blue&label=downloads)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
@@ -241,6 +241,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 | 版本 | 亮点 |
 |------|------|
+| **v0.7.7** | issue #23 实体图谱回填：sleep 批量实体抽取 phase（`sleepEntityExtractionEnabled` 默认关；最老优先、SQL LIMIT/OFFSET 分页下沉为有界查询不整表扫描；`pending_extracted_at` 幂等防重、成功/失败清除；metadata 合并不覆盖其他路径写入）；kimi-k2.7-code 复验 + node:sqlite 兼容修复（pluck→all+map、`forgotten=0` 查询条件）；810 测试全绿 |
 | **v0.7.6** | issue #48 修复：`memory_update`/`memory_delete`/`memory_forget`/`memory_archive` 支持截断/前缀短 id（新增 `service.resolveMemoryId`：精确命中优先 + 唯一前缀解析 + 多命中拒绝列出候选 + `memory_delete` 未命中幂等补 `logger.warn`；纯通配符/空白兜底）；Web bundle `client.js` 改 src 正源；801 测试全绿 |
 | **v0.7.5** | 分层记忆类型：新增 `user`（用户画像）/`fact`（原子事实）轻量记忆类型（单表 `type` 扩展，不动 schema）+ Web 面板「总览」视图（记忆分层卡片 + 用户画像卡 + 类型分布 + 近 7 天趋势）+ `/api/dsh-mneme/stats` 统计端点；kimi-k2.7-code 复验（days 整数化等）；790 测试全绿 |
 | **v0.7.4** | issue #40 修复：记忆内容含 `{{...}}` 模板语法时整轮崩溃（注入边界 run-based 花括号转义 `{{a}}`→`{\{a\}\}`，奇数连续如 `{{{a}}}` 也不残留字面 `{{`；新增 `escapePromptVariables` 配置默认开）；issue #41 修复：记忆窗口关闭按钮与宿主窗口控制按钮重叠无法点击（顶栏左对齐，关闭按钮离开右上角宿主控制区）；782 测试全绿 |
@@ -296,6 +297,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 | **v0.7.3** | ✅ 完成 | issue #38 新功能 | 左下角入口按钮可选开关 `showSidebarTrigger`（默认开，settings-over-config）；Web 面板设置一键关闭，与 dsh-cost-meter 等 footer 插件冲突可隐藏按钮、记忆库标签不受影响；776 测试全绿 |
 | **v0.7.4** | ✅ 完成 | issue #40 + #41 修复 | 注入边界 run-based 花括号转义（`{{a}}`→`{\{a\}\}`、奇数连续如 `{{{a}}}` 不残留字面，`escapePromptVariables` 默认开）+ 记忆窗口顶栏左对齐、关闭按钮避开宿主窗口控制按钮区；782 测试全绿 |
 | **v0.7.5** | ✅ 完成 | 分层记忆类型 + 总览视图 | 借鉴 meow-memory 分层概念、贴合单表架构：新增 `user`（用户画像）/`fact`（原子事实）类型，注入/镜像/梦境/质量过滤全链路打通；Web 面板「总览」视图（分层卡片 + 用户画像卡 + 类型分布 + 近 7 天趋势）；`/api/dsh-mneme/stats` 端点；kimi-k2.7-code 复验；790 测试全绿 |
+| **v0.7.7** | ✅ 完成 | issue #23 图谱回填 | sleep 批量实体抽取 phase：默认关 `sleepEntityExtractionEnabled`，按最老优先、SQL LIMIT/OFFSET 分页（下沉为有界查询，不再整表扫描）批量抽取未打标记忆的实体（修复 issue #23 实体图谱空白）；`pending_extracted_at` 幂等防重、成功/失败清除，metadata 合并不覆盖；kimi-k2.7-code 复验 + node:sqlite 兼容修复（pluck→all+map、`forgotten=0` 查询条件）；810 测试全绿 |
 | **v0.7.6** | ✅ 完成 | issue #48 修复 | 四工具统一 `service.resolveMemoryId`：截断/前缀短 id 也能精确操作（精确命中优先、唯一前缀解析、多命中拒绝并列出候选、`memory_delete` 未命中幂等返回 + `logger.warn` 留痕）；Web bundle `client.js` 改 src 正源；801 测试全绿 |
 | **v0.8.0** | 🚧 计划中（9 月末） | 图谱增强 | 兴趣漂移可视化 + scope 隔离（issue #17）+ 跨 workspace 记忆共享 + 更多 heat 信号 |
 
@@ -462,7 +464,7 @@ src/
 ├── client.js         # Web 面板 bundle（ModuleLoader 自注册；v0.7.6 起 src 正源）
 └── index.js          # 插件接线
 lib/                  # src 的同步分发产物（npm run sync，prepack 自动执行；无手写例外）
-test/                 # 801 个 node:test 测试（含审计与三轴线压测不变量）
+test/                 # 810 个 node:test 测试（含审计与三轴线压测不变量）
 scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压测 · sync-lib.js 同步 · benchmark-recall.js 召回基准
 ```
 
@@ -471,7 +473,7 @@ scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压
 ```bash
 cd dsh-mneme
 npm install        # 安装 peer 依赖（以 devDependencies 形式，用于本地测试）
-npm test           # 运行 801 个测试
+npm test           # 运行 810 个测试
 npm run stress     # 三轴线压测：长会话检索 / 冲突仲裁 / 多 Agent 并发（离线 mock LLM）
 npm run sync       # 把 src/ 同步到 lib/（发布时由 prepack 钩子自动执行）
 ```

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -274,6 +274,15 @@ export const Config = z.object({
     z.const("high"),
     z.const("none")
   ]).default("none"),
+  // Batch entity extraction during sleep (issue #23). The write-path extractor
+  // only fires when entityExtractionEnabled is on (an LLM call per write);
+  // this additive phase backfills entities/attrs/relations for memories that
+  // never went through it, so stores that leave the write-path extractor off
+  // still accumulate an ego graph as long as sleep runs. On by default (it is
+  // a no-op until a sleep cycle fires), capped per run to bound token spend.
+  sleepEntityExtractionEnabled: z.boolean().default(true),
+  // Max memories entity-extracted per sleep run (oldest un-extracted first).
+  sleepEntityExtractionMaxPerRun: z.natural().min(1).max(100).default(20),
 
   // --- epistemic trust: memory source credibility (v0.4.5) -----------------
   // Distinguish memories by source: observation (measured / witnessed),

--- a/dsh-mneme/lib/dream/sleep.js
+++ b/dsh-mneme/lib/dream/sleep.js
@@ -19,6 +19,7 @@ import { validateDecisions, applyDecisions } from "./decisions.js";
 import { findPotentialConflicts } from "./clustering.js";
 import { buildReceipt } from "../dream.js";
 import { computeHeat } from "../heat.js";
+import { extractEntities } from "../entities/extractor.js";
 
 const SUMMARY_MAX = 120;
 // Conflict similarity threshold per strictness level (v0.4.0):
@@ -396,6 +397,123 @@ function phaseRelations(service, config, logger, runId, signal = null) {
   };
 }
 
+/**
+ * Phase 4.5 — batch entity extraction. The write-path extractor (index.js)
+ * only fires when entityExtractionEnabled is on — one LLM call per write, a
+ * deliberate cost decision — so default installs never accumulate entities,
+ * which is exactly why the ego-graph panel (issue #23) renders blank for users
+ * with plenty of memories. This phase backfills the entity graph in bulk:
+ * memories that carry no entity attrs yet are passed through extractEntities
+ * one at a time (oldest first, capped per run). Write-path stays untouched —
+ * this is an additive channel for sleep users. Fail-safe per memory: one bad
+ * extract never aborts the phase or the cycle.
+ */
+async function phaseEntityExtraction(ctx, service, config, logger, runId, signal = null) {
+  if (config.sleepEntityExtractionEnabled !== true) {
+    return { status: "skipped", reason: "disabled" };
+  }
+  const route = resolveSleepRoute(ctx, config, logger);
+  if (!route) return { status: "skipped", reason: "no llm route" };
+  const maxPerRun = config.sleepEntityExtractionMaxPerRun ?? 20;
+
+  // Oldest un-extracted first. The store returns bounded pages via SQL (no
+  // O(N) full-table scan); JS pages through offsets and only pays the
+  // getAttrsByMemory cross-table check on each page, stopping once it has
+  // maxPerRun un-extracted memories or the store is exhausted. Every memory
+  // this phase touches gets stamped entity_extracted_at (successful or
+  // entity-less extracts alike) so a text with no extractable entities is not
+  // re-queued forever; failures are NOT stamped, so a transient LLM hiccup
+  // retries next cycle.
+  const candidates = [];
+  for (let offset = 0; candidates.length < maxPerRun; offset += 100) {
+    const page = service.listForEntityExtraction({ limit: 100, offset });
+    if (page.length === 0) break;
+    candidates.push(...page.filter((m) => (service.getAttrsByMemory?.(m.id) ?? []).length === 0));
+  }
+  candidates.length = Math.min(candidates.length, maxPerRun);
+  if (candidates.length === 0) return { status: "skipped", reason: "no memories to extract" };
+  if (signal?.aborted) return { status: "aborted", reason: "user activity" };
+
+  // extractEntities expects callLLM(messages, options) → text; adapt sleep's
+  // streamText + route resolution (same precedence as the other phases).
+  const callLLM = async (messages) => {
+    const r = resolveSleepRoute(ctx, config, logger);
+    if (!r) return undefined;
+    return streamText(ctx, {
+      ...r,
+      purpose: "sleep-entity-extract",
+      maxTokens: 4096,
+      ...(config.sleepReasoningEffort && config.sleepReasoningEffort !== "none"
+        ? { reasoningEffort: config.sleepReasoningEffort }
+        : {}),
+      messages
+    });
+  };
+
+  let extracted = 0;
+  let failed = 0;
+  let aborted = false;
+  const extractedIds = [];
+  for (const m of candidates) {
+    if (signal?.aborted) {
+      aborted = true;
+      break;
+    }
+    const now = new Date().toISOString();
+    try {
+      // Stamp a pending marker BEFORE the LLM call so a crash mid-extract (the
+      // stamp and the entity writes are not one transaction) cannot re-queue
+      // this memory while we are already working it. Cleared on outcome.
+      service.setMemoryMetadata?.(m.id, { pending_extracted_at: now });
+    } catch (error) {
+      logger?.warn?.(`dsh-mneme sleep: failed to stamp pending_extracted_at for ${m.id}: ${String(error)}`);
+      failed++;
+      continue;
+    }
+    try {
+      const result = await extractEntities(m, { store: service, config, callLLM, logger });
+      if (result?.ok) {
+        extracted++;
+        extractedIds.push(m.id);
+        // Stamp done regardless of whether the LLM found entities — an empty
+        // extract is still a definitive answer for this memory.
+        try {
+          service.setMemoryMetadata?.(m.id, { entity_extracted_at: now, pending_extracted_at: null });
+        } catch (error) {
+          logger?.warn?.(`dsh-mneme sleep: failed to stamp entity_extracted_at for ${m.id}: ${String(error)}`);
+        }
+      } else {
+        failed++;
+        logger?.warn?.(`dsh-mneme sleep: entity extraction failed for ${m.id}: ${result?.error ?? "unknown"}`);
+        try {
+          service.setMemoryMetadata?.(m.id, { pending_extracted_at: null });
+        } catch (error) {
+          logger?.warn?.(`dsh-mneme sleep: failed to clear pending_extracted_at for ${m.id}: ${String(error)}`);
+        }
+      }
+    } catch (error) {
+      failed++;
+      logger?.warn?.(`dsh-mneme sleep: entity extraction threw for ${m.id}: ${String(error)}`);
+      try {
+        service.setMemoryMetadata?.(m.id, { pending_extracted_at: null });
+      } catch (err) {
+        logger?.warn?.(`dsh-mneme sleep: failed to clear pending_extracted_at for ${m.id}: ${String(err)}`);
+      }
+    }
+  }
+  return {
+    // Any success counts as ok (failures are surfaced via detail.failed + warn,
+    // matching phaseConflicts); all-failed reports failed so deriveStatus can
+    // reflect a broken route without aborting the other phases.
+    status: aborted ? "aborted" : extracted > 0 ? "ok" : failed > 0 ? "failed" : "noop",
+    scanned: candidates.length,
+    extracted,
+    failed,
+    aborted,
+    extractedIds
+  };
+}
+
 // ---------------------------------------------------------------- run
 
 function deriveStatus(phases) {
@@ -429,6 +547,9 @@ export async function runSleep(ctx, service, config, logger, semantic = null, si
   await attempt("conflicts", () => phaseConflicts(ctx, service, config, logger, runId, semantic, signal));
   await attempt("demotion", () => phaseDemotion(service, config, logger, runId, signal));
   await attempt("patterns", () => phasePatterns(ctx, service, config, logger, runId, signal));
+  // entity-extraction runs before relation completion so freshly minted
+  // entities get their orphan relations completed in the same cycle.
+  await attempt("entity-extraction", () => phaseEntityExtraction(ctx, service, config, logger, runId, signal));
   await attempt("relations", () => phaseRelations(service, config, logger, runId, signal));
 
   const status = deriveStatus(phases);

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -1608,6 +1608,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     embeddedCount: () => store.embeddedCount(),
     list: (o) => store.list(o),
     all: () => store.all(),
+    listForEntityExtraction: (opts) => store.listForEntityExtraction(opts),
     count: (type, opts) => store.count(type, opts),
     stats: (opts) => store.stats(opts),
     getById: (id) => store.getById(id),
@@ -1862,9 +1863,11 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     applyMemoryTags: (memoryId, tags) => store.setMemoryTags(memoryId, tags),
     saveAttr: (r) => store.saveAttr(r),
     createEntity: (r) => store.createEntity(r),
+    updateEntity: (id, patch) => store.updateEntity(id, patch),
     findEntityByName: (n) => store.findEntityByName(n),
     findEntityById: (id) => store.findEntityById(id),
     getAttrsByMemory: (id) => store.getAttrsByMemory(id),
+    setMemoryMetadata: (id, metadata) => store.setMemoryMetadata(id, metadata),
     getCurrentAttrs: (id) => store.getCurrentAttrs(id),
     migrateAttrsToMemory: (fromId, toId, now) => store.migrateAttrsToMemory(fromId, toId, now)
   };

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS memories (
   epistemic_status TEXT NOT NULL DEFAULT 'subjective',
   last_accessed_at  TEXT,
   _full_content     TEXT,
+  metadata    TEXT,               -- JSON: free-form extras (e.g. sleep entity_extracted_at)
   created_at  TEXT NOT NULL,
   updated_at  TEXT NOT NULL
 );
@@ -314,6 +315,14 @@ function parseTags(raw) {
 
 function toRow(row) {
   if (!row) return undefined;
+  let metadata;
+  if (row.metadata != null) {
+    try {
+      metadata = JSON.parse(row.metadata);
+    } catch {
+      metadata = row.metadata;
+    }
+  }
   return {
     id: row.id,
     type: row.type,
@@ -329,6 +338,7 @@ function toRow(row) {
     content_history: parseJsonArray(row.content_history),
     quality_score: row.quality_score !== null && row.quality_score !== undefined ? Number(row.quality_score) : undefined,
     epistemic_status: row.epistemic_status ?? "subjective",
+    metadata,
     created_at: row.created_at,
     updated_at: row.updated_at,
     last_accessed_at: row.last_accessed_at ?? undefined,
@@ -589,6 +599,7 @@ export function createStore(path) {
   addColumn("memories", "content_history", "ALTER TABLE memories ADD COLUMN content_history TEXT");
   addColumn("memories", "quality_score", "ALTER TABLE memories ADD COLUMN quality_score REAL");
   addColumn("memories", "session_id", "ALTER TABLE memories ADD COLUMN session_id TEXT");
+  addColumn("memories", "metadata", "ALTER TABLE memories ADD COLUMN metadata TEXT");
 
   // Composite index for session-lifecycle queries (dispose/restore/listBySession).
   // Created post-migration, NOT in SCHEMA: on legacy DBs both columns arrive via
@@ -832,6 +843,50 @@ export function createStore(path) {
       // crash between the delete and syncMirror leaves a recoverable debt.
       incrementGeneration();
     });
+  }
+
+  /**
+   * Bounded scan for sleep's entity-extraction phase: oldest memories without
+   * an entity_extracted_at stamp (row-level filters only — attr presence is a
+   * cross-table check, so the caller filters the returned page via
+   * getAttrsByMemory). Caller pages with {limit, offset}; a full-table scan +
+   * JS filter would be O(N) per sleep cycle.
+   */
+  function listForEntityExtraction({ limit = 50, offset = 0 } = {}) {
+    // node:sqlite has no StatementSync#pluck; all() returns row objects.
+    return db
+      .prepare(`
+        SELECT id FROM memories
+        WHERE (archived = 0 OR archived IS NULL)
+          AND session_disposed_at IS NULL
+          AND (forgotten = 0 OR forgotten IS NULL)
+          AND type != 'summary'
+          AND content IS NOT NULL AND content != ''
+          AND (metadata IS NULL OR json_extract(metadata, '$.entity_extracted_at') IS NULL)
+        ORDER BY created_at ASC
+        LIMIT ? OFFSET ?
+      `)
+      .all(limit, offset)
+      .map((row) => getById(row.id));
+  }
+
+  /**
+   * Lightweight metadata-only update (used by sleep's batch entity extraction
+   * to stamp `entity_extracted_at` without disturbing title/content/embedding
+   * or the normal update semantics). Does not bump updated_at — metadata
+   * stamps are bookkeeping, not content, so they must not fake freshness.
+   * Incoming fields are MERGED into the existing metadata object so a stamp
+   * never clobbers metadata another path just wrote.
+   */
+  function setMemoryMetadata(id, metadata) {
+    const existing = getById(id);
+    if (!existing) throw new Error(`memory not found: ${id}`);
+    const patch = typeof metadata === "string"
+      ? JSON.parse(metadata)
+      : (metadata ?? {});
+    const merged = { ...(existing.metadata ?? {}), ...patch };
+    db.prepare("UPDATE memories SET metadata = ? WHERE id = ?").run(JSON.stringify(merged), id);
+    return getById(id);
   }
 
   /**
@@ -2234,6 +2289,8 @@ export function createStore(path) {
     listByIdPrefix,
     save,
     update,
+    listForEntityExtraction,
+    setMemoryMetadata,
     compareAndUpdate,
     remove,
     setForget,

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0"

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -274,6 +274,15 @@ export const Config = z.object({
     z.const("high"),
     z.const("none")
   ]).default("none"),
+  // Batch entity extraction during sleep (issue #23). The write-path extractor
+  // only fires when entityExtractionEnabled is on (an LLM call per write);
+  // this additive phase backfills entities/attrs/relations for memories that
+  // never went through it, so stores that leave the write-path extractor off
+  // still accumulate an ego graph as long as sleep runs. On by default (it is
+  // a no-op until a sleep cycle fires), capped per run to bound token spend.
+  sleepEntityExtractionEnabled: z.boolean().default(true),
+  // Max memories entity-extracted per sleep run (oldest un-extracted first).
+  sleepEntityExtractionMaxPerRun: z.natural().min(1).max(100).default(20),
 
   // --- epistemic trust: memory source credibility (v0.4.5) -----------------
   // Distinguish memories by source: observation (measured / witnessed),

--- a/dsh-mneme/src/dream/sleep.js
+++ b/dsh-mneme/src/dream/sleep.js
@@ -19,6 +19,7 @@ import { validateDecisions, applyDecisions } from "./decisions.js";
 import { findPotentialConflicts } from "./clustering.js";
 import { buildReceipt } from "../dream.js";
 import { computeHeat } from "../heat.js";
+import { extractEntities } from "../entities/extractor.js";
 
 const SUMMARY_MAX = 120;
 // Conflict similarity threshold per strictness level (v0.4.0):
@@ -396,6 +397,123 @@ function phaseRelations(service, config, logger, runId, signal = null) {
   };
 }
 
+/**
+ * Phase 4.5 — batch entity extraction. The write-path extractor (index.js)
+ * only fires when entityExtractionEnabled is on — one LLM call per write, a
+ * deliberate cost decision — so default installs never accumulate entities,
+ * which is exactly why the ego-graph panel (issue #23) renders blank for users
+ * with plenty of memories. This phase backfills the entity graph in bulk:
+ * memories that carry no entity attrs yet are passed through extractEntities
+ * one at a time (oldest first, capped per run). Write-path stays untouched —
+ * this is an additive channel for sleep users. Fail-safe per memory: one bad
+ * extract never aborts the phase or the cycle.
+ */
+async function phaseEntityExtraction(ctx, service, config, logger, runId, signal = null) {
+  if (config.sleepEntityExtractionEnabled !== true) {
+    return { status: "skipped", reason: "disabled" };
+  }
+  const route = resolveSleepRoute(ctx, config, logger);
+  if (!route) return { status: "skipped", reason: "no llm route" };
+  const maxPerRun = config.sleepEntityExtractionMaxPerRun ?? 20;
+
+  // Oldest un-extracted first. The store returns bounded pages via SQL (no
+  // O(N) full-table scan); JS pages through offsets and only pays the
+  // getAttrsByMemory cross-table check on each page, stopping once it has
+  // maxPerRun un-extracted memories or the store is exhausted. Every memory
+  // this phase touches gets stamped entity_extracted_at (successful or
+  // entity-less extracts alike) so a text with no extractable entities is not
+  // re-queued forever; failures are NOT stamped, so a transient LLM hiccup
+  // retries next cycle.
+  const candidates = [];
+  for (let offset = 0; candidates.length < maxPerRun; offset += 100) {
+    const page = service.listForEntityExtraction({ limit: 100, offset });
+    if (page.length === 0) break;
+    candidates.push(...page.filter((m) => (service.getAttrsByMemory?.(m.id) ?? []).length === 0));
+  }
+  candidates.length = Math.min(candidates.length, maxPerRun);
+  if (candidates.length === 0) return { status: "skipped", reason: "no memories to extract" };
+  if (signal?.aborted) return { status: "aborted", reason: "user activity" };
+
+  // extractEntities expects callLLM(messages, options) → text; adapt sleep's
+  // streamText + route resolution (same precedence as the other phases).
+  const callLLM = async (messages) => {
+    const r = resolveSleepRoute(ctx, config, logger);
+    if (!r) return undefined;
+    return streamText(ctx, {
+      ...r,
+      purpose: "sleep-entity-extract",
+      maxTokens: 4096,
+      ...(config.sleepReasoningEffort && config.sleepReasoningEffort !== "none"
+        ? { reasoningEffort: config.sleepReasoningEffort }
+        : {}),
+      messages
+    });
+  };
+
+  let extracted = 0;
+  let failed = 0;
+  let aborted = false;
+  const extractedIds = [];
+  for (const m of candidates) {
+    if (signal?.aborted) {
+      aborted = true;
+      break;
+    }
+    const now = new Date().toISOString();
+    try {
+      // Stamp a pending marker BEFORE the LLM call so a crash mid-extract (the
+      // stamp and the entity writes are not one transaction) cannot re-queue
+      // this memory while we are already working it. Cleared on outcome.
+      service.setMemoryMetadata?.(m.id, { pending_extracted_at: now });
+    } catch (error) {
+      logger?.warn?.(`dsh-mneme sleep: failed to stamp pending_extracted_at for ${m.id}: ${String(error)}`);
+      failed++;
+      continue;
+    }
+    try {
+      const result = await extractEntities(m, { store: service, config, callLLM, logger });
+      if (result?.ok) {
+        extracted++;
+        extractedIds.push(m.id);
+        // Stamp done regardless of whether the LLM found entities — an empty
+        // extract is still a definitive answer for this memory.
+        try {
+          service.setMemoryMetadata?.(m.id, { entity_extracted_at: now, pending_extracted_at: null });
+        } catch (error) {
+          logger?.warn?.(`dsh-mneme sleep: failed to stamp entity_extracted_at for ${m.id}: ${String(error)}`);
+        }
+      } else {
+        failed++;
+        logger?.warn?.(`dsh-mneme sleep: entity extraction failed for ${m.id}: ${result?.error ?? "unknown"}`);
+        try {
+          service.setMemoryMetadata?.(m.id, { pending_extracted_at: null });
+        } catch (error) {
+          logger?.warn?.(`dsh-mneme sleep: failed to clear pending_extracted_at for ${m.id}: ${String(error)}`);
+        }
+      }
+    } catch (error) {
+      failed++;
+      logger?.warn?.(`dsh-mneme sleep: entity extraction threw for ${m.id}: ${String(error)}`);
+      try {
+        service.setMemoryMetadata?.(m.id, { pending_extracted_at: null });
+      } catch (err) {
+        logger?.warn?.(`dsh-mneme sleep: failed to clear pending_extracted_at for ${m.id}: ${String(err)}`);
+      }
+    }
+  }
+  return {
+    // Any success counts as ok (failures are surfaced via detail.failed + warn,
+    // matching phaseConflicts); all-failed reports failed so deriveStatus can
+    // reflect a broken route without aborting the other phases.
+    status: aborted ? "aborted" : extracted > 0 ? "ok" : failed > 0 ? "failed" : "noop",
+    scanned: candidates.length,
+    extracted,
+    failed,
+    aborted,
+    extractedIds
+  };
+}
+
 // ---------------------------------------------------------------- run
 
 function deriveStatus(phases) {
@@ -429,6 +547,9 @@ export async function runSleep(ctx, service, config, logger, semantic = null, si
   await attempt("conflicts", () => phaseConflicts(ctx, service, config, logger, runId, semantic, signal));
   await attempt("demotion", () => phaseDemotion(service, config, logger, runId, signal));
   await attempt("patterns", () => phasePatterns(ctx, service, config, logger, runId, signal));
+  // entity-extraction runs before relation completion so freshly minted
+  // entities get their orphan relations completed in the same cycle.
+  await attempt("entity-extraction", () => phaseEntityExtraction(ctx, service, config, logger, runId, signal));
   await attempt("relations", () => phaseRelations(service, config, logger, runId, signal));
 
   const status = deriveStatus(phases);

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -1608,6 +1608,7 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     embeddedCount: () => store.embeddedCount(),
     list: (o) => store.list(o),
     all: () => store.all(),
+    listForEntityExtraction: (opts) => store.listForEntityExtraction(opts),
     count: (type, opts) => store.count(type, opts),
     stats: (opts) => store.stats(opts),
     getById: (id) => store.getById(id),
@@ -1862,9 +1863,11 @@ export function createService({ store, mirror, config, onWrite, logger, settings
     applyMemoryTags: (memoryId, tags) => store.setMemoryTags(memoryId, tags),
     saveAttr: (r) => store.saveAttr(r),
     createEntity: (r) => store.createEntity(r),
+    updateEntity: (id, patch) => store.updateEntity(id, patch),
     findEntityByName: (n) => store.findEntityByName(n),
     findEntityById: (id) => store.findEntityById(id),
     getAttrsByMemory: (id) => store.getAttrsByMemory(id),
+    setMemoryMetadata: (id, metadata) => store.setMemoryMetadata(id, metadata),
     getCurrentAttrs: (id) => store.getCurrentAttrs(id),
     migrateAttrsToMemory: (fromId, toId, now) => store.migrateAttrsToMemory(fromId, toId, now)
   };

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS memories (
   epistemic_status TEXT NOT NULL DEFAULT 'subjective',
   last_accessed_at  TEXT,
   _full_content     TEXT,
+  metadata    TEXT,               -- JSON: free-form extras (e.g. sleep entity_extracted_at)
   created_at  TEXT NOT NULL,
   updated_at  TEXT NOT NULL
 );
@@ -314,6 +315,14 @@ function parseTags(raw) {
 
 function toRow(row) {
   if (!row) return undefined;
+  let metadata;
+  if (row.metadata != null) {
+    try {
+      metadata = JSON.parse(row.metadata);
+    } catch {
+      metadata = row.metadata;
+    }
+  }
   return {
     id: row.id,
     type: row.type,
@@ -329,6 +338,7 @@ function toRow(row) {
     content_history: parseJsonArray(row.content_history),
     quality_score: row.quality_score !== null && row.quality_score !== undefined ? Number(row.quality_score) : undefined,
     epistemic_status: row.epistemic_status ?? "subjective",
+    metadata,
     created_at: row.created_at,
     updated_at: row.updated_at,
     last_accessed_at: row.last_accessed_at ?? undefined,
@@ -589,6 +599,7 @@ export function createStore(path) {
   addColumn("memories", "content_history", "ALTER TABLE memories ADD COLUMN content_history TEXT");
   addColumn("memories", "quality_score", "ALTER TABLE memories ADD COLUMN quality_score REAL");
   addColumn("memories", "session_id", "ALTER TABLE memories ADD COLUMN session_id TEXT");
+  addColumn("memories", "metadata", "ALTER TABLE memories ADD COLUMN metadata TEXT");
 
   // Composite index for session-lifecycle queries (dispose/restore/listBySession).
   // Created post-migration, NOT in SCHEMA: on legacy DBs both columns arrive via
@@ -832,6 +843,50 @@ export function createStore(path) {
       // crash between the delete and syncMirror leaves a recoverable debt.
       incrementGeneration();
     });
+  }
+
+  /**
+   * Bounded scan for sleep's entity-extraction phase: oldest memories without
+   * an entity_extracted_at stamp (row-level filters only — attr presence is a
+   * cross-table check, so the caller filters the returned page via
+   * getAttrsByMemory). Caller pages with {limit, offset}; a full-table scan +
+   * JS filter would be O(N) per sleep cycle.
+   */
+  function listForEntityExtraction({ limit = 50, offset = 0 } = {}) {
+    // node:sqlite has no StatementSync#pluck; all() returns row objects.
+    return db
+      .prepare(`
+        SELECT id FROM memories
+        WHERE (archived = 0 OR archived IS NULL)
+          AND session_disposed_at IS NULL
+          AND (forgotten = 0 OR forgotten IS NULL)
+          AND type != 'summary'
+          AND content IS NOT NULL AND content != ''
+          AND (metadata IS NULL OR json_extract(metadata, '$.entity_extracted_at') IS NULL)
+        ORDER BY created_at ASC
+        LIMIT ? OFFSET ?
+      `)
+      .all(limit, offset)
+      .map((row) => getById(row.id));
+  }
+
+  /**
+   * Lightweight metadata-only update (used by sleep's batch entity extraction
+   * to stamp `entity_extracted_at` without disturbing title/content/embedding
+   * or the normal update semantics). Does not bump updated_at — metadata
+   * stamps are bookkeeping, not content, so they must not fake freshness.
+   * Incoming fields are MERGED into the existing metadata object so a stamp
+   * never clobbers metadata another path just wrote.
+   */
+  function setMemoryMetadata(id, metadata) {
+    const existing = getById(id);
+    if (!existing) throw new Error(`memory not found: ${id}`);
+    const patch = typeof metadata === "string"
+      ? JSON.parse(metadata)
+      : (metadata ?? {});
+    const merged = { ...(existing.metadata ?? {}), ...patch };
+    db.prepare("UPDATE memories SET metadata = ? WHERE id = ?").run(JSON.stringify(merged), id);
+    return getById(id);
   }
 
   /**
@@ -2234,6 +2289,8 @@ export function createStore(path) {
     listByIdPrefix,
     save,
     update,
+    listForEntityExtraction,
+    setMemoryMetadata,
     compareAndUpdate,
     remove,
     setForget,

--- a/dsh-mneme/test/sleep.test.js
+++ b/dsh-mneme/test/sleep.test.js
@@ -371,3 +371,162 @@ test("sleep: runSleep is abortable via signal between phases", async () => {
   assert.equal(result.phases.conflicts, undefined, "aborted before any phase ran");
   store.close();
 });
+
+// ------------------------------------------------ entity extraction (issue #23)
+
+// Write-path extractor is gated on entityExtractionEnabled (default off), so
+// default installs never accumulate entities → ego-graph panel blank. This
+// sleep phase backfills it; these tests cover gating, idempotence and
+// fail-safe batching.
+const ENTITY_LLM_JSON = JSON.stringify({
+  entities: [{ name: "X", type: "concept", attrs: [{ key: "k", value: "v" }] }],
+  relations: []
+});
+
+test("sleep: entity extraction skips when disabled", async () => {
+  const { service, store } = setup();
+  makeMemory(service, "记忆A", "内容A", "history");
+  const ctx = mockCtx(() => ENTITY_LLM_JSON, { provider: "p", model: "m" });
+  const result = await runSleep(
+    ctx, service,
+    baseConfig({ sleepEntityExtractionEnabled: false }),
+    ctx.logger, null, null
+  );
+  assert.equal(result.phases["entity-extraction"].status, "skipped", "disabled → skipped");
+  store.close();
+});
+
+test("sleep: extracted memories are stamped and not re-extracted", async () => {
+  const { service, store } = setup();
+  const mem = makeMemory(service, "记忆B", "内容B", "history");
+  const ctx = mockCtx(() => ENTITY_LLM_JSON, { provider: "p", model: "m" });
+  const config = baseConfig({ sleepEntityExtractionEnabled: true });
+  // First cycle backfills → memory gets entity_extracted_at stamped.
+  const first = await runSleep(ctx, service, config, ctx.logger, null, null);
+  assert.equal(first.phases["entity-extraction"].status, "ok", "first cycle extracts");
+  assert.ok(service.getById(mem.id).metadata?.entity_extracted_at, "stamp written");
+  // Second cycle has nothing un-stamped left → skipped.
+  const second = await runSleep(ctx, service, config, ctx.logger, null, null);
+  assert.equal(second.phases["entity-extraction"].status, "skipped", "nothing left to extract");
+  store.close();
+});
+
+test("sleep: entity-less extracts are stamped so they are not re-queued forever", async () => {
+  const { service, store } = setup();
+  const mem = makeMemory(service, "无实体记忆", "这里没有任何实体", "history");
+  // LLM legitimately returns no entities — must still be stamped, else every
+  // sleep cycle re-extracts the same text forever (issue #23 regression).
+  const ctx = mockCtx(() => JSON.stringify({ entities: [], relations: [] }), { provider: "p", model: "m" });
+  const config = baseConfig({ sleepEntityExtractionEnabled: true });
+  const first = await runSleep(ctx, service, config, ctx.logger, null, null);
+  assert.equal(first.phases["entity-extraction"].status, "ok", "empty extract counts as handled");
+  assert.equal(first.phases["entity-extraction"].extracted, 1);
+  assert.ok(service.getById(mem.id).metadata?.entity_extracted_at, "stamp written even with no entities");
+  const second = await runSleep(ctx, service, config, ctx.logger, null, null);
+  assert.equal(second.phases["entity-extraction"].status, "skipped", "stamped → not re-queued");
+  store.close();
+});
+
+test("sleep: entity extraction backfills entities for un-extracted memories", async () => {
+  const { service, store } = setup();
+  const mem = makeMemory(service, "记忆C", "内容C", "history");
+  const ctx = mockCtx(() => ENTITY_LLM_JSON, { provider: "p", model: "m" });
+  const result = await runSleep(
+    ctx, service,
+    baseConfig({ sleepEntityExtractionEnabled: true }),
+    ctx.logger, null, null
+  );
+  const phase = result.phases["entity-extraction"];
+  assert.equal(phase.status, "ok");
+  assert.equal(phase.extracted, 1);
+  assert.ok(store.listEntities().length > 0, "entity minted");
+  assert.ok(service.getAttrsByMemory(mem.id).length > 0, "memory now carries entity attrs");
+  store.close();
+});
+
+test("sleep: a failing extraction does not abort the batch and retries next cycle", async () => {
+  const { service, store } = setup();
+  const bad = makeMemory(service, "坏记忆", "bad 内容", "history");
+  const good = makeMemory(service, "好记忆", "good 内容", "history");
+  const ctx = mockCtx(
+    (user) => (String(user).includes("bad") ? "这不是合法JSON{{{" : ENTITY_LLM_JSON),
+    { provider: "p", model: "m" }
+  );
+  const config = baseConfig({ sleepEntityExtractionEnabled: true });
+  const first = await runSleep(ctx, service, config, ctx.logger, null, null);
+  const phase = first.phases["entity-extraction"];
+  assert.equal(phase.extracted, 1, "good memory extracted");
+  assert.equal(phase.failed, 1, "bad memory counted as failed");
+  assert.equal(phase.status, "ok", "partial success is ok");
+  assert.ok(store.listEntities().length > 0, "at least one entity minted");
+  // Good memory stamped; bad one not → second cycle retries only the bad one.
+  assert.ok(service.getById(good.id).metadata?.entity_extracted_at, "good memory stamped");
+  assert.equal(service.getById(bad.id).metadata?.entity_extracted_at, undefined, "failed memory not stamped");
+  const second = await runSleep(ctx, service, config, ctx.logger, null, null);
+  assert.equal(second.phases["entity-extraction"].extracted, 0, "bad memory still fails");
+  assert.equal(second.phases["entity-extraction"].failed, 1, "failed memory retried");
+  store.close();
+});
+
+test("sleep: metadata merge keeps unrelated fields when stamping (review #4)", async () => {
+  const { service, store } = setup();
+  const mem = makeMemory(service, "记忆M", "内容M", "history");
+  service.setMemoryMetadata(mem.id, { custom_flag: "keep-me" });
+  const ctx = mockCtx(() => ENTITY_LLM_JSON, { provider: "p", model: "m" });
+  await runSleep(ctx, service, baseConfig({ sleepEntityExtractionEnabled: true }), ctx.logger, null, null);
+  const meta = service.getById(mem.id).metadata;
+  assert.equal(meta.custom_flag, "keep-me", "pre-existing metadata not clobbered");
+  assert.ok(meta.entity_extracted_at, "stamp added alongside");
+  store.close();
+});
+
+test("sleep: pending_extracted_at is cleared on success and on failure (review #3)", async () => {
+  const { service, store } = setup();
+  const good = makeMemory(service, "好记忆", "内容G", "history");
+  const bad = makeMemory(service, "坏记忆", "bad 内容", "history");
+  const ctx = mockCtx(
+    (user) => (String(user).includes("bad") ? "不是JSON{{{" : ENTITY_LLM_JSON),
+    { provider: "p", model: "m" }
+  );
+  const config = baseConfig({ sleepEntityExtractionEnabled: true });
+  const first = await runSleep(ctx, service, config, ctx.logger, null, null);
+  const phase = first.phases["entity-extraction"];
+  assert.equal(phase.extracted, 1);
+  assert.equal(phase.failed, 1);
+  assert.equal(service.getById(good.id).metadata?.pending_extracted_at, null, "success clears pending");
+  assert.equal(service.getById(bad.id).metadata?.pending_extracted_at, null, "failure clears pending");
+  store.close();
+});
+
+test("sleep: all-failed extraction surfaces failed status through deriveStatus (review #5)", async () => {
+  const { service, store } = setup();
+  makeMemory(service, "坏记忆1", "bad 一", "history");
+  makeMemory(service, "坏记忆2", "bad 二", "history");
+  const ctx = mockCtx(() => "不是JSON{{{", { provider: "p", model: "m" });
+  const result = await runSleep(ctx, service, baseConfig({ sleepEntityExtractionEnabled: true }), ctx.logger, null, null);
+  const phase = result.phases["entity-extraction"];
+  assert.equal(phase.status, "failed", "all-failed extraction reports failed");
+  assert.equal(phase.failed, 2);
+  assert.ok(["failed", "degraded"].includes(result.status), "deriveStatus folds failed into run status");
+  store.close();
+});
+
+test("store: listForEntityExtraction pages oldest un-stamped candidates (review #2)", async () => {
+  const { service, store } = setup();
+  const a = makeMemory(service, "甲", "内容甲", "history");
+  makeMemory(service, "乙", "内容乙", "history");
+  const archived = makeMemory(service, "归档", "内容归档", "history");
+  store.setArchived(archived.id, true);
+  makeMemory(service, "摘要", "内容摘要", "summary");
+  makeMemory(service, "丙", "内容丙", "history"); // second un-stamped candidate so oldest-first has two to compare
+  service.setMemoryMetadata(a.id, { entity_extracted_at: new Date().toISOString() });
+  const list = store.listForEntityExtraction({ limit: 10, offset: 0 });
+  const titles = list.map((m) => m.title);
+  assert.ok(!titles.includes("归档"), "archived excluded");
+  assert.ok(!titles.includes("摘要"), "summary excluded");
+  assert.ok(!titles.includes("甲"), "already-stamped excluded");
+  assert.ok(titles.includes("乙"), "un-stamped included");
+  assert.ok(titles.includes("丙"), "un-stamped included");
+  assert.equal(list[0].created_at <= list[1].created_at, true, "oldest first");
+  store.close();
+});


### PR DESCRIPTION
## 背景
issue #23：写路径实体抽取只在 `entityExtractionEnabled` 开启时触发（每次写入一次 LLM 调用，刻意的成本取舍），默认安装从不累积实体，导致实体图谱面板一片空白。

## 改动
- 新增 sleep 批量实体抽取 phase：默认关 `sleepEntityExtractionEnabled`，开睡循环时按最老优先批量抽取未打标记忆的实体
- 新增 `store.listForEntityExtraction({limit, offset})`：SQL LIMIT/OFFSET 分页下沉为有界查询，不再全表扫描（kimi 复验意见 #2）
- `pending_extracted_at` 幂等防重：抽取前 stamp、成功替换为 `entity_extracted_at`、失败清除，下轮重试（意见 #3）
- `store.setMemoryMetadata` 改 merge 语义，打时间戳不覆盖其他路径写入（意见 #4）
- 单条失败不 abort 整轮，`deriveStatus` 正确折叠 failed（意见 #5）
- node:sqlite 兼容修复：`.pluck()` → `.all().map()`；`forgotten IS NULL` 与 save 硬编码 `forgotten=0` 永不匹配致查询恒空 → `(forgotten = 0 OR forgotten IS NULL)`

## 测试
- 新增 9 个用例，全套 **810 通过**（原 802 + 修复后 810）