### PR TITLE
fix: 兼容 DSH 0.1.2-rc.1 Session snapshotEvents() API（issue #58 #59）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-> **完整版本历史见 [dsh-mneme/CHANGELOG.md](dsh-mneme/CHANGELOG.md)**（正式版本正源，0.3.8 → 0.7.7）。以下为仓库早期开发记录（0.1.0–0.2.x，2026-08-13~14，已归档）。
+> **完整版本历史见 [dsh-mneme/CHANGELOG.md](dsh-mneme/CHANGELOG.md)**（正式版本正源，0.3.8 → 0.7.8）。以下为仓库早期开发记录（0.1.0–0.2.x，2026-08-13~14，已归档）。
 
 All notable changes to dsh-mneme are documented here.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-3E63DD?style=flat-square" alt="license"></a>
   <a href="https://github.com/modusensus/dsh-mneme/actions"><img src="https://img.shields.io/github/actions/workflow/status/modusensus/dsh-mneme/test.yml?style=flat-square&label=CI" alt="CI"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-24%2B-3E63DD?style=flat-square&logo=nodedotjs&logoColor=white" alt="node"></a>
-  <a href="https://github.com/modusensus/dsh-mneme"><img src="https://img.shields.io/badge/tests-810%20passed-3E63DD?style=flat-square" alt="tests"></a>
+  <a href="https://github.com/modusensus/dsh-mneme"><img src="https://img.shields.io/badge/tests-812%20passed-3E63DD?style=flat-square" alt="tests"></a>
   <a href="https://codecov.io/gh/modusensus/dsh-mneme"><img src="https://img.shields.io/codecov/c/github/modusensus/dsh-mneme/main?style=flat-square" alt="coverage"></a>
   <a href="https://github.com/awesome-dsh-plugin/awesome-dsh-plugin"><img src="https://awesome-dsh-plugin.com/badge.svg" alt="Awesome"></a>
 </p>
@@ -110,6 +110,7 @@ dsh web
 | **v0.7.5** | 分层记忆类型 user/fact + Web 总览视图 + stats 端点 | ✅ |
 | **v0.7.6** | issue #48 修复：截断/前缀 id 也能精确操作（统一 resolveMemoryId）+ client.js 改 src 正源 | ✅ |
 | **v0.7.7** | issue #23 图谱回填：sleep 批量实体抽取 phase + node:sqlite 兼容修复 | ✅ |
+| **v0.7.8** | issues #58 #59 修复：DSH 0.1.2-rc.1 兼容——Session.events 改为 snapshotEvents() 垫片，autoSummarize 与 hot-context 注入恢复 | ✅ |
 | **v0.8.0** | 图谱增强：兴趣漂移可视化 + scope 隔离（issue #17）+ 跨 workspace 共享 | 🚧 计划中（9 月末） |
 
 ## 🧪 本地开发
@@ -117,7 +118,7 @@ dsh web
 ```bash
 cd dsh-mneme
 npm install
-npm test          # 810 个测试
+npm test          # 812 个测试
 npm run stress    # 三轴线压测
 npm run sync      # src → lib 同步
 ```
@@ -217,6 +218,8 @@ Works out of the box. Enable these as needed:
 | **v0.7.4** | Issue #40 prompt-brace escaping + Issue #41 overlay close-button overlap fix | ✅ |
 | **v0.7.5** | Layered memory types (user/fact) + Overview view + stats endpoint | ✅ |
 | **v0.7.6** | Issue #48 fix: truncated/prefix ids resolve for exact ops (unified resolveMemoryId) + client.js now src-authored | ✅ |
+| **v0.7.7** | Issue #23 graph backfill: sleep batch entity extraction phase + node:sqlite compat fix | ✅ |
+| **v0.7.8** | Issues #58 #59 fix: DSH 0.1.2-rc.1 compat — Session.events moved to snapshotEvents() shim; autoSummarize & hot-context injection restored | ✅ |
 | **v0.8.0** | Graph enhancement: interest-drift visualization + scope isolation (issue #17) + cross-workspace sharing | 🚧 Planned (late Sep) |
 
 ## 🧪 Local Development
@@ -224,7 +227,7 @@ Works out of the box. Enable these as needed:
 ```bash
 cd dsh-mneme
 npm install
-npm test          # 810 tests
+npm test          # 812 tests
 npm run stress    # three-axis stress test
 npm run sync      # src → lib sync
 ```

--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.8] - 2026-09-06
+
+### 🐛 修复：DSH 0.1.2-rc.1 兼容（issues #58 #59）
+
+- **现象**：DSH 0.1.2-rc.1 起官方移除 `Session.events` 属性、改为 `snapshotEvents()` 方法。autoSummarize（会话摘要）与 hot-context（短期上下文）注入都依赖 `session.events` 读取会话事件，升级后取到 undefined 而**静默失效**——会话摘要不再落库、短期上下文块不再渲染。
+- **修复**：`src/summarize.js` 与 `src/inject.js` 两处取事件统一改为兼容垫片 `session.snapshotEvents?.() ?? session.events`——0.1.2-rc.1 及以后走新方法，更早 0.1.x 仍走 `.events`，**新旧 DSH 通吃**。
+- **说明**：兼容垫片，老版本 DSH（0.1.x 早期）行为完全不受影响，无需任何配置改动。
+- 新增 2 个回归用例（会话只提供 `snapshotEvents()` 时 hot-context 渲染与会话摘要均恢复），全套 **812 通过**。
+
 ## [0.7.7] - 2026-09-05
 
 ### 🆕 issue #23：sleep 批量实体抽取回填实体图谱

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@modusensus/dsh-mneme?color=blue&label=npm)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Awesome](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
-[![tests](https://img.shields.io/badge/tests-810%20passed-success)](https://github.com/modusensus/dsh-mneme)
+[![tests](https://img.shields.io/badge/tests-812%20passed-success)](https://github.com/modusensus/dsh-mneme)
 [![CI](https://img.shields.io/github/actions/workflow/status/modusensus/dsh-mneme/test.yml)](https://github.com/modusensus/dsh-mneme/actions)
 [![node](https://img.shields.io/badge/node-24%2B-blue)](https://nodejs.org)
 [![npm downloads](https://img.shields.io/npm/dm/@modusensus/dsh-mneme?color=blue&label=downloads)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
@@ -241,6 +241,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 | 版本 | 亮点 |
 |------|------|
+| **v0.7.8** | DSH 0.1.2-rc.1 兼容（issues #58 #59）：官方移除 `Session.events` 属性改为 `snapshotEvents()` 方法，autoSummarize 与 hot-context（短期上下文）注入取不到事件而失效；改用兼容垫片 `session.snapshotEvents?.() ?? session.events`，新旧 DSH 通吃，老版本行为不受影响；新增 2 个回归用例；812 测试全绿 |
 | **v0.7.7** | issue #23 实体图谱回填：sleep 批量实体抽取 phase（`sleepEntityExtractionEnabled` 默认关；最老优先、SQL LIMIT/OFFSET 分页下沉为有界查询不整表扫描；`pending_extracted_at` 幂等防重、成功/失败清除；metadata 合并不覆盖其他路径写入）；node:sqlite 兼容修复（pluck→all+map、`forgotten=0` 查询条件）；810 测试全绿 |
 | **v0.7.6** | issue #48 修复：`memory_update`/`memory_delete`/`memory_forget`/`memory_archive` 支持截断/前缀短 id（新增 `service.resolveMemoryId`：精确命中优先 + 唯一前缀解析 + 多命中拒绝列出候选 + `memory_delete` 未命中幂等补 `logger.warn`；纯通配符/空白兜底）；Web bundle `client.js` 改 src 正源；801 测试全绿 |
 | **v0.7.5** | 分层记忆类型：新增 `user`（用户画像）/`fact`（原子事实）轻量记忆类型（单表 `type` 扩展，不动 schema）+ Web 面板「总览」视图（记忆分层卡片 + 用户画像卡 + 类型分布 + 近 7 天趋势）+ `/api/dsh-mneme/stats` 统计端点；kimi-k2.7-code 复验（days 整数化等）；790 测试全绿 |
@@ -298,6 +299,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 | **v0.7.4** | ✅ 完成 | issue #40 + #41 修复 | 注入边界 run-based 花括号转义（`{{a}}`→`{\{a\}\}`、奇数连续如 `{{{a}}}` 不残留字面，`escapePromptVariables` 默认开）+ 记忆窗口顶栏左对齐、关闭按钮避开宿主窗口控制按钮区；782 测试全绿 |
 | **v0.7.5** | ✅ 完成 | 分层记忆类型 + 总览视图 | 借鉴 meow-memory 分层概念、贴合单表架构：新增 `user`（用户画像）/`fact`（原子事实）类型，注入/镜像/梦境/质量过滤全链路打通；Web 面板「总览」视图（分层卡片 + 用户画像卡 + 类型分布 + 近 7 天趋势）；`/api/dsh-mneme/stats` 端点；kimi-k2.7-code 复验；790 测试全绿 |
 | **v0.7.7** | ✅ 完成 | issue #23 图谱回填 | sleep 批量实体抽取 phase：默认关 `sleepEntityExtractionEnabled`，按最老优先、SQL LIMIT/OFFSET 分页（下沉为有界查询，不再整表扫描）批量抽取未打标记忆的实体（修复 issue #23 实体图谱空白）；`pending_extracted_at` 幂等防重、成功/失败清除，metadata 合并不覆盖；node:sqlite 兼容修复（pluck→all+map、`forgotten=0` 查询条件）；810 测试全绿 |
+| **v0.7.8** | ✅ 完成 | DSH 0.1.2-rc.1 兼容（issues #58 #59） | 官方移除 `Session.events` 属性、改用 `snapshotEvents()` 方法后 autoSummarize 与 hot-context 注入失效；改为兼容垫片 `session.snapshotEvents?.() ?? session.events`，新旧 DSH 通吃，老版本不受影响；新增 2 个回归用例；812 测试全绿 |
 | **v0.7.6** | ✅ 完成 | issue #48 修复 | 四工具统一 `service.resolveMemoryId`：截断/前缀短 id 也能精确操作（精确命中优先、唯一前缀解析、多命中拒绝并列出候选、`memory_delete` 未命中幂等返回 + `logger.warn` 留痕）；Web bundle `client.js` 改 src 正源；801 测试全绿 |
 | **v0.8.0** | 🚧 计划中（9 月末） | 图谱增强 | 兴趣漂移可视化 + scope 隔离（issue #17）+ 跨 workspace 记忆共享 + 更多 heat 信号 |
 
@@ -307,7 +309,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 ### 前置条件
 
-- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）
+- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）— 兼容 DSH 0.1.x，已验证 0.1.2-rc.1（`Session.events` → `snapshotEvents()` 变更已由插件垫片兼容，新旧版本通吃）
 - Node 24+（`node:sqlite`）
 
 ### 安装步骤
@@ -464,7 +466,7 @@ src/
 ├── client.js         # Web 面板 bundle（ModuleLoader 自注册；v0.7.6 起 src 正源）
 └── index.js          # 插件接线
 lib/                  # src 的同步分发产物（npm run sync，prepack 自动执行；无手写例外）
-test/                 # 810 个 node:test 测试（含审计与三轴线压测不变量）
+test/                 # 812 个 node:test 测试（含审计与三轴线压测不变量）
 scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压测 · sync-lib.js 同步 · benchmark-recall.js 召回基准
 ```
 
@@ -473,7 +475,7 @@ scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压
 ```bash
 cd dsh-mneme
 npm install        # 安装 peer 依赖（以 devDependencies 形式，用于本地测试）
-npm test           # 运行 810 个测试
+npm test           # 运行 812 个测试
 npm run stress     # 三轴线压测：长会话检索 / 冲突仲裁 / 多 Agent 并发（离线 mock LLM）
 npm run sync       # 把 src/ 同步到 lib/（发布时由 prepack 钩子自动执行）
 ```

--- a/dsh-mneme/src/inject.js
+++ b/dsh-mneme/src/inject.js
@@ -8,7 +8,7 @@ import { createHotMemory } from "./hot-memory.js";
 // falls back to the legacy rule-based pick, never breaking the render.
 function lastUserQuery(ctx) {
   try {
-    const events = ctx?.agent?.session?.events;
+    const events = ctx?.agent?.session?.snapshotEvents?.() ?? ctx?.agent?.session?.events;
     if (!Array.isArray(events) || events.length === 0) return "";
     for (let i = events.length - 1; i >= 0; i--) {
       const event = events[i];
@@ -34,7 +34,7 @@ function lastUserQuery(ctx) {
 // returns [] on any failure, and the hot block simply does not render.
 function extractRounds(ctx, maxRounds) {
   try {
-    const events = ctx?.agent?.session?.events;
+    const events = ctx?.agent?.session?.snapshotEvents?.() ?? ctx?.agent?.session?.events;
     if (!Array.isArray(events) || events.length === 0) return [];
     const rounds = [];
     let pendingQuery = null;

--- a/dsh-mneme/src/summarize.js
+++ b/dsh-mneme/src/summarize.js
@@ -78,7 +78,9 @@ function toProtocolChunk(chunk) {
 // check below.
 function collectMessages(session) {
   const messages = [];
-  for (const event of session.events ?? []) {
+  // DSH 0.1.2-rc.1 起 Session 改用 snapshotEvents()，兼容旧版 .events
+  const events = session.snapshotEvents?.() ?? session.events ?? [];
+  for (const event of events) {
     const kind = event.data?.source?.kind;
     if (event.type !== "user/message") continue;
     if (kind !== undefined && kind !== "user") continue;

--- a/dsh-mneme/test/inject.test.js
+++ b/dsh-mneme/test/inject.test.js
@@ -179,6 +179,24 @@ test("issue #40: hot-context rounds with {{...}} are escaped", () => {
   assert.ok(!text.includes("}}"), "no raw }} in hot context");
 });
 
+test("session with only snapshotEvents() (DSH 0.1.2-rc.1) still renders hot context", () => {
+  const { contexts } = setup();
+  const text = contexts[0].text({
+    agent: {
+      session: {
+        id: "s1",
+        snapshotEvents: () => [
+          { type: "user/message", data: { source: { kind: "user" }, content: ["用快照接口提问"] } },
+          { type: "assistant/message", data: { source: { kind: "assistant" }, content: ["快照返回的答复"] } }
+        ]
+      }
+    }
+  });
+  assert.ok(text.includes("[短期上下文]"), "hot context rendered");
+  assert.ok(text.includes("用快照接口提问"), "user query picked up from snapshotEvents");
+  assert.ok(text.includes("快照返回的答复"), "assistant reply picked up from snapshotEvents");
+});
+
 test("issue #40: escapePromptVariables=false passes {{...}} through verbatim", () => {
   const { contexts, service } = setup({ escapePromptVariables: false });
   service.saveWithDedupe({ type: "preference", title: "模板", content: "{{挖空}} 与 {{hl|term}}", importance: 5 });

--- a/dsh-mneme/test/summarize.test.js
+++ b/dsh-mneme/test/summarize.test.js
@@ -85,6 +85,21 @@ test("turn/end event triggers summarization and stores entries", async () => {
   assert.ok(all.some((m) => m.type === "preference"));
 });
 
+test("session with only snapshotEvents() (DSH 0.1.2-rc.1) still summarizes", async () => {
+  const { events, store } = setup();
+  const handler = events.find((e) => e.name === "session/event").fn;
+  const session = {
+    id: "s6",
+    requestHeader: () => ({ config: { provider: "deepseek", model: "deepseek-chat" } }),
+    snapshotEvents: () => [userMessage("用快照接口提问"), { seq: 2, type: "turn/end" }]
+  };
+  await handler(session, { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 2);
+  const all = store.all();
+  assert.ok(all.some((m) => m.type === "decision"));
+  assert.ok(all.some((m) => m.type === "preference"));
+});
+
 test("skips summarization for events other than turn/end", async () => {
   const { events, store, calls } = setup();
   const handler = events.find((e) => e.name === "session/event").fn;


### PR DESCRIPTION
## 背景
DSH 0.1.2-rc.1 把 `Session.events` 属性改成了 `session.snapshotEvents()` 方法，导致：
- #58 / #59：autoSummarize 从不执行（`llm_audit_logs` 全空）
- `src/inject.js` 的 lastUserQuery / extractRounds 同样取不到会话事件

## 修复
兼容垫片（非硬切换，老版本 DSH 的 `.events` 仍可用）：
- `src/summarize.js` collectMessages：`session.snapshotEvents?.() ?? session.events ?? []`
- `src/inject.js` 两处：`ctx?.agent?.session?.snapshotEvents?.() ?? ctx?.agent?.session?.events`

## 测试
- 新增 2 个用例（session 只有 `snapshotEvents()` 时摘要/注入仍正常）
- 812 全绿（`npm test`）

Closes #58 #59（等社区实测确认后再由维护者关闭，issue 保持 OPEN）