### PR TITLE
chore: bump version to 0.7.8

### DIFF
--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 说明

- 将 `dsh-mneme/package.json` 版本号 0.7.7 → 0.7.8（tag `v0.7.8` 已发布，本 PR 同步 main 上的版本号保持一致）
- 纯版本号改动，无逻辑变更