### PR TITLE
docs: 统一安全联系邮箱至 work@modusensus.space，明确受理边界与升级路径

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,13 @@ Versioning follows semantic versioning (`MAJOR.MINOR.PATCH`). Full flow:
 
 ---
 
+## Contact
+
+- **General questions & contributions**: [GitHub Discussions](https://github.com/modusensus/dsh-mneme/discussions) or `work@modusensus.space`
+- **Security vulnerabilities**: report privately via [SECURITY.md](SECURITY.md) — never open a public issue for vulnerabilities
+
+---
+
 ## Miscellaneous
 
 - Security issues go through [SECURITY.md](SECURITY.md) or a GitHub Security Advisory — never paste sensitive info into a public Issue.
@@ -268,6 +275,13 @@ DSH 上游仍处于 developer preview 阶段，API 与服务接口变动频繁�
 4. **提交并推送**：commit → `git push origin main` → `git tag vX.Y.Z` → `git push origin vX.Y.Z`。
 5. **创建 GitHub Release**：标题为 `vX.Y.Z`，正文引用 CHANGELOG 对应条目（发布前需人工过目）。
 6. **发布 npm**：在**仓库根目录**执行 `npm publish`（`prepublishOnly` 会自动把 `dsh-mneme/package.json` 的版本号写入根 `package.json`，`prepack` 自动 sync `lib/`）。
+
+---
+
+## 联系方式
+
+- **一般问题与贡献咨询**：[GitHub Discussions](https://github.com/modusensus/dsh-mneme/discussions) 或 `work@modusensus.space`
+- **安全漏洞**：请通过 [SECURITY.md](SECURITY.md) 私有提交，不要在公开 Issue 中提交漏洞
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,6 +65,22 @@ The following security features are implemented and maintained in the project:
    - Your proposed fix (if any)
    - Whether you are requesting credit / disclosure preferences
 
+### Scope and Out of Scope
+
+**In scope** — issues this policy covers:
+- Remote API authentication or authorization bypass (`apiToken`-protected surfaces)
+- Memory integrity violations (CAS/fence bypass, unauthorized overwrite, replay paths)
+- Mirror consistency and recovery logic that can cause silent data corruption
+- Exploitable vulnerabilities in shipped runtime dependencies (supported versions only)
+
+**Out of scope** — we will not act on:
+- Social engineering or phishing against maintainers or users
+- DoS claims that require unrealistic local resource exhaustion with no product defect
+- Vulnerabilities present only in unsupported versions (`< 0.6.0`)
+- Best-practice hardening suggestions with no demonstrable security impact
+
+Not sure whether your finding is in scope? Report it anyway via the private channel — we will triage and respond.
+
 ### Response Timeline
 
 | Phase | Time | Action |
@@ -76,6 +92,12 @@ The following security features are implemented and maintained in the project:
 | Coordinated Disclosure | At fix release | We publish a security advisory and release patch simultaneously |
 
 **Note**: For Critical vulnerabilities, if a full fix cannot be developed within 14 days, we will provide a temporary mitigation or workaround within that timeframe.
+
+### Escalation (If You Do Not Hear Back)
+
+- If you do not receive an acknowledgment within **48 hours**, re-send to `work@modusensus.space` with subject prefix: `[SECURITY][FOLLOW-UP]`.
+- If there is still no response after another **48 hours**, open a **private security advisory** via [GitHub Security Advisories](https://github.com/modusensus/dsh-mneme/security/advisories) and reference your original report timestamp.
+- Do not disclose details publicly while escalation is in progress.
 
 ### Severity Classification
 
@@ -322,7 +344,7 @@ All contributors must comply with the following security requirements:
 
 ## Contact
 
-- **Security Team**: `guanqishi26@gmail.com`
+- **Security Team**: `work@modusensus.space`
 - **Private Advisory**: [GitHub Security Advisories](https://github.com/modusensus/dsh-mneme/security/advisories)
 - **GPG Key**: Available upon request for encrypted communication
 
@@ -401,6 +423,22 @@ This project is licensed under the **MIT License**. See [LICENSE](https://github
    - 你建议的修复方案（如有）
    - 是否要求在公告中署名 / 披露偏好
 
+### 受理范围与不受理范围
+
+**受理范围**——本政策覆盖以下问题：
+- 远程 API 鉴权 / 授权绕过（`apiToken` 保护面）
+- 记忆完整性破坏（CAS/fence 绕过、未授权覆盖、重放路径）
+- 可导致静默数据损坏的镜像一致性与恢复逻辑缺陷
+- 在受支持版本中可利用的已发布运行时依赖漏洞
+
+**不受理范围**——以下问题我们不予处理：
+- 针对维护者或用户的社工 / 钓鱼类问题
+- 仅通过不现实的本地资源耗尽触发、且无产品缺陷支撑的 DoS 声明
+- 仅存在于不支持版本（`< 0.6.0`）的问题
+- 无可证明安全影响的"最佳实践建议"类问题
+
+不确定你的发现是否在受理范围内？仍请通过私有渠道提交——我们会评估并回复。
+
 ### 响应时间线
 
 | 阶段 | 时间 | 行动 |
@@ -412,6 +450,12 @@ This project is licensed under the **MIT License**. See [LICENSE](https://github
 | 协调披露 | 修复发布时 | 同时发布安全公告和补丁版本 |
 
 **备注**：对于严重漏洞，如果 14 天内无法提供完整修复，我们将在该时间内提供临时缓解措施或替代方案。
+
+### 无响应升级路径
+
+- 若 **48 小时内**未收到确认，请重新发送到 `work@modusensus.space`，邮件标题加前缀：`[SECURITY][FOLLOW-UP]`。
+- 若再次等待 **48 小时**仍无回复，请通过 [GitHub 私有安全公告](https://github.com/modusensus/dsh-mneme/security/advisories) 提交，并注明首次报告时间。
+- 升级处理中请勿公开披露漏洞细节。
 
 ### 严重程度分级
 
@@ -658,7 +702,7 @@ dsh-mneme:
 
 ## 联系方式
 
-- **安全团队**：`guanqishi26@gmail.com`
+- **安全团队**：`work@modusensus.space`
 - **私有公告**：[GitHub Security Advisories](https://github.com/modusensus/dsh-mneme/security/advisories)
 - **GPG 密钥**：如需加密通信，可应请求提供
 
@@ -670,5 +714,5 @@ dsh-mneme:
 
 ---
 
-*Last updated: 2026-08-28*  
-*Policy version: 2.2*
+*Last updated: 2026-09-06*  
+*Policy version: 2.3*


### PR DESCRIPTION
## 变更内容

统一安全与贡献文档的联系方式，并完善安全政策边界。

### SECURITY.md
- **统一邮箱**：全部联系方式改为 `work@modusensus.space`（英文 Contact + 中文联系方式两处原为旧邮箱，现已统一）
- **新增受理边界** Scope / Out of Scope（中英双语）：明确受理范围（apiToken 鉴权绕过、记忆完整性、镜像一致性、受支持版本依赖漏洞）与不受理范围（社工/钓鱼、不现实 DoS、不支持版本、无实际影响的加固建议）
- **新增无响应升级路径**（中英双语）：48h 无确认 → 邮件加 `[SECURITY][FOLLOW-UP]` 前缀重发 → 再 48h 无回复 → GitHub 私有安全公告
- 策略版本 2.2 → 2.3

### CONTRIBUTING.md
- **新增 Contact / 联系方式** 章节（中英双语）：一般问题与贡献咨询走 Discussions 或 `work@modusensus.space`，安全漏洞私有提交

> 说明：此前 PR #62（Copilot 提交）因包含类似内容但已按桉桉要求撤回，本次为自行起草的规范化版本。