### PR TITLE
fix: v0.7.8 的 snapshotEvents 适配未同步 lib/，加发布前 src/lib 一致性校验 (issue #65)

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.7.9] - 2026-09-06
+
+### 🐛 修复：v0.7.8 的 rc.1 snapshotEvents 适配未同步到 lib/（issue #65）
+
+- **现象**：v0.7.8 为兼容 DSH 0.1.2-rc.1（`Session.events` → `snapshotEvents()`）只改了 `src/inject.js` 与 `src/summarize.js`，发布产物 `lib/` 从未同步——npm 包实际加载的是 `lib/`（`main` 指向 `lib/index.js`），用户在 rc.1 下安装 0.7.8 运行的仍是未适配代码。因代码带 `?.` / `?? []` 容错，**不报错但热记忆注入与会话摘要静默失效**。
+- **修复**：将 src 的兼容垫片同步到 `lib/`（两文件 3 处），`src/` 与 `lib/` 逐文件一致。
+- **防再犯（双保险）**：
+  - 新增 `scripts/check-sync.js`：断言 `src/` 与 `lib/` 一致性，root `prepack` 钩子调用——发布前不一致直接 fail；
+  - 新增 `test/lib-smoke.test.js`：从 `lib/` 直接导入复跑 snapshotEvents 关键用例 + 静态断言 src→lib 逐文件一致，CI 每次全量测试拦截。
+- 新增 3 个用例（lib 版 snapshotEvents 注入/摘要 + 一致性断言），全套 **815 通过**。
+
 ## [0.7.8] - 2026-09-06
 
 ### 🐛 修复：DSH 0.1.2-rc.1 兼容（issues #58 #59）

--- a/dsh-mneme/lib/inject.js
+++ b/dsh-mneme/lib/inject.js
@@ -8,7 +8,7 @@ import { createHotMemory } from "./hot-memory.js";
 // falls back to the legacy rule-based pick, never breaking the render.
 function lastUserQuery(ctx) {
   try {
-    const events = ctx?.agent?.session?.events;
+    const events = ctx?.agent?.session?.snapshotEvents?.() ?? ctx?.agent?.session?.events;
     if (!Array.isArray(events) || events.length === 0) return "";
     for (let i = events.length - 1; i >= 0; i--) {
       const event = events[i];
@@ -34,7 +34,7 @@ function lastUserQuery(ctx) {
 // returns [] on any failure, and the hot block simply does not render.
 function extractRounds(ctx, maxRounds) {
   try {
-    const events = ctx?.agent?.session?.events;
+    const events = ctx?.agent?.session?.snapshotEvents?.() ?? ctx?.agent?.session?.events;
     if (!Array.isArray(events) || events.length === 0) return [];
     const rounds = [];
     let pendingQuery = null;

--- a/dsh-mneme/lib/summarize.js
+++ b/dsh-mneme/lib/summarize.js
@@ -78,7 +78,9 @@ function toProtocolChunk(chunk) {
 // check below.
 function collectMessages(session) {
   const messages = [];
-  for (const event of session.events ?? []) {
+  // DSH 0.1.2-rc.1 起 Session 改用 snapshotEvents()，兼容旧版 .events
+  const events = session.snapshotEvents?.() ?? session.events ?? [];
+  for (const event of events) {
     const kind = event.data?.source?.kind;
     if (event.type !== "user/message") continue;
     if (kind !== undefined && kind !== "user") continue;

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/dsh-mneme/scripts/check-sync.js
+++ b/dsh-mneme/scripts/check-sync.js
@@ -1,0 +1,42 @@
+// 发布前校验 src/ 与 lib/ 一致性。
+//
+// npm 包实际加载 lib/（package main → lib/index.js），而 root 层 `npm publish`
+// 不触发 dsh-mneme/ 的 prepack → sync 同步。历史教训：PR #60 只改了 src 忘了同步
+// lib，v0.7.8 发出去的 npm 包跑的还是旧代码（issue #65）。此脚本让这类漂移在发布时
+// 直接 fail，而不是带着旧产物上线。
+//
+// 用法：node scripts/check-sync.js （root package.json 的 prepack 钩子自动调用）
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL("..", import.meta.url))); // dsh-mneme/
+const srcDir = join(root, "src");
+const libDir = join(root, "lib");
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (entry.isFile()) out.push(full);
+  }
+  return out;
+}
+
+const bad = [];
+for (const file of walk(srcDir)) {
+  const rel = relative(srcDir, file);
+  const dest = join(libDir, rel);
+  if (!existsSync(dest)) {
+    bad.push(`missing  lib/${rel}`);
+  } else if (!readFileSync(file).equals(readFileSync(dest))) {
+    bad.push(`differ   lib/${rel}`);
+  }
+}
+if (bad.length) {
+  console.error(`✗ src/ 与 lib/ 不一致（${bad.length} 处）——npm 包实际加载 lib/，请先 npm run sync 并提交：`);
+  for (const line of bad) console.error(`  ${line}`);
+  process.exit(1);
+}
+console.log(`✓ src/ 与 lib/ 一致（${walk(srcDir).length} 个文件）`);

--- a/dsh-mneme/test/lib-smoke.test.js
+++ b/dsh-mneme/test/lib-smoke.test.js
@@ -1,0 +1,109 @@
+// lib/ 是 npm 实际加载的产物（package main 指向 lib/index.js），而现有测试只引 src/，
+// 覆盖不到发布产物——issue #65 就是 src 适配了、lib 没同步，npm 包静默跑旧代码。
+// 本文件直接从 lib/ 导入，复跑 DSH 0.1.2-rc.1 snapshotEvents 关键用例，
+// 并静态断言 src → lib 逐文件一致，防止同类回归再次发生。
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, relative } from "node:path";
+import { createStore } from "../lib/store.js";
+import { createService } from "../lib/service.js";
+import { createInjector } from "../lib/inject.js";
+import { createSettings } from "../lib/settings.js";
+import { createSummarizer, parseSummaryJson } from "../lib/summarize.js";
+
+function setup(over = {}) {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const settings = createSettings(store.db);
+  const contexts = [];
+  const ctx = {
+    systemPrompt: {
+      context(def) {
+        contexts.push(def);
+        return () => {};
+      }
+    }
+  };
+  const config = { maxInjectedItems: 3, importanceThreshold: 3, ...over };
+  const injector = createInjector(ctx, service, settings, config);
+  return { contexts, injector };
+}
+
+test("lib: session with only snapshotEvents() (DSH 0.1.2-rc.1) still renders hot context", () => {
+  const { contexts } = setup();
+  const text = contexts[0].text({
+    agent: {
+      session: {
+        id: "s1",
+        snapshotEvents: () => [
+          { type: "user/message", data: { source: { kind: "user" }, content: ["用快照接口提问"] } },
+          { type: "assistant/message", data: { source: { kind: "assistant" }, content: ["快照返回的答复"] } }
+        ]
+      }
+    }
+  });
+  assert.ok(text.includes("[短期上下文]"), "hot context rendered");
+  assert.ok(text.includes("用快照接口提问"), "user query picked up from snapshotEvents");
+  assert.ok(text.includes("快照返回的答复"), "assistant reply picked up from snapshotEvents");
+});
+
+test("lib: session with only snapshotEvents() (DSH 0.1.2-rc.1) still summarizes", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const events = [];
+  const ctx = {
+    on(name, fn) {
+      events.push({ name, fn });
+      return () => {};
+    },
+    llm: {
+      stream() {
+        const json = JSON.stringify([
+          { type: "decision", title: "选型", content: "确定用 node:sqlite", importance: 4 },
+          { type: "preference", title: "语言", content: "用户喜欢中文交流", importance: 5 }
+        ]);
+        return (async function* () {
+          yield { type: "finish", kind: "ok" };
+          yield { type: "block-start", block: { type: "text" } };
+          yield { type: "text-delta", delta: json };
+          yield { type: "block-end", block: { type: "text" } };
+        })();
+      }
+    }
+  };
+  const summarizer = createSummarizer(ctx, service, { autoSummarize: true });
+  const handler = events.find((e) => e.name === "session/event").fn;
+  const session = {
+    id: "s6",
+    requestHeader: () => ({ config: { provider: "deepseek", model: "deepseek-chat" } }),
+    snapshotEvents: () => [{ type: "user/message", data: { content: ["用快照接口提问"] } }, { seq: 2, type: "turn/end" }]
+  };
+  await handler(session, { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 2);
+  assert.ok(store.all().some((m) => m.type === "decision"));
+  assert.ok(store.all().some((m) => m.type === "preference"));
+  summarizer.dispose();
+});
+
+test("lib/ mirrors src/ — every src file identical in lib (npm loads lib!)", () => {
+  const srcRoot = fileURLToPath(new URL("../src/", import.meta.url));
+  const libRoot = fileURLToPath(new URL("../lib/", import.meta.url));
+  const mismatches = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        const rel = relative(srcRoot, full);
+        const counterpart = join(libRoot, rel);
+        if (!existsSync(counterpart) || !readFileSync(full).equals(readFileSync(counterpart))) {
+          mismatches.push(rel);
+        }
+      }
+    }
+  };
+  walk(srcRoot);
+  assert.deepEqual(mismatches, [], "src 文件在 lib 缺失或内容不一致——请先 npm run sync 并提交");
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     }
   },
   "scripts": {
+    "prepack": "node dsh-mneme/scripts/check-sync.js",
     "prepublishOnly": "node -e \"const fs=require('fs');const v=JSON.parse(fs.readFileSync('./dsh-mneme/package.json','utf8')).version;const p=JSON.parse(fs.readFileSync('./package.json','utf8'));p.version=v;fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\\n')\""
   },
   "peerDependencies": {


### PR DESCRIPTION
## 修复 issue #65

v0.7.8 为兼容 DSH 0.1.2-rc.1（`Session.events` → `snapshotEvents()`）只改了 `src/`，但 npm 实际加载的 `lib/`（package main 指向 `lib/index.js`）从未同步，用户在 rc.1 下安装 0.7.8 运行的是旧代码——因带 `?.`/`?? []` 容错，**不报错但热记忆注入与会话摘要静默失效**。

## 改动

1. **同步 lib**：`lib/inject.js`（2 处）、`lib/summarize.js`（1 处）补齐 snapshotEvents 兼容垫片，与 src 逐文件一致。
2. **发布闸门**：新增 `scripts/check-sync.js`，root `prepack` 钩子调用——发布前断言 src/lib 逐文件一致，漂移直接 fail（根因：root 层 npm publish 不触发 dsh-mneme/ 的 prepack→sync，本次修复后漂移不可能再发出去）。
3. **lib 冒烟测试**：新增 `test/lib-smoke.test.js`，从 lib 直接导入复跑 snapshotEvents 注入/摘要用例 + 静态一致性断言（CI 层双保险）。

## 验证

- 全套 **815 通过**（含 3 个新用例）
- check-sync 实测：lib 注入漂移 → prepack exit 1 阻断；还原 → pass
- kimi-k2.7-code 复验 + 主 agent 复验均通过