### PR TITLE
ci: codecov patch 检查降级为 informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+# Codecov 状态检查配置。
+#
+# 背景：Web 面板（dsh-mneme/src/client.js）以 React 渲染代码为主，而 client
+# 测试是源码静态断言、不执行渲染路径——UI 改动为主的 PR 的 patch 覆盖率
+# 天然偏低（如 #68 为 55%），patch 红叉并不反映测试质量。
+# 因此 patch 检查降级为 informational（只展示、不标失败）；project 检查
+# 保持 auto target，整体覆盖率回退仍会被标红。
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        target: auto


### PR DESCRIPTION
## 🔧 背景

PR #68 合并时 `codecov/patch` 标红（55%，auto target 77.35%）。原因：Web 面板 `dsh-mneme/src/client.js` 以 React 渲染代码为主，而 client 测试是**源码静态断言**、不执行渲染路径——UI 改动为主的 PR 的 patch 覆盖率天然偏低，红叉并不反映测试质量（当次 Test job 是绿的，815 用例全过）。

## 修复
在仓库根新增 `.codecov.yml`：
- `patch.default.informational: true`——patch 检查降级为**只展示、不标失败**；
- `project.default.target: auto` 保持不变——整体覆盖率回退仍会被标红，闸门不放松。

## 说明
- codecov/patch 本就不在分支保护 required checks 里（只有 `Test`），本 PR 只消除视觉噪音，不影响任何合并门槛。
- 对已合并的 #68 不追溯生效，自下一个上传覆盖率的 PR 起按新配置计算。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated code coverage reporting so patch coverage results are informational and do not block status checks.
  - Project-wide coverage continues to use its existing automatic target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->