### PR TITLE
ci: c8 覆盖率统计排除 lib/ 构建产物——v0.7.9 引入的 lib-smoke 将整个 lib/ 拉进分母致覆盖率 93.5…

### DIFF
--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -78,6 +78,11 @@
     "reporter": [
       "text",
       "lcov"
+    ],
+    "exclude": [
+      "lib/**",
+      "test/**",
+      "**/*.test.js"
     ]
   }
 }


### PR DESCRIPTION
…%→77.4% (#69 后续)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated code coverage configuration to exclude library internals, test files, and test-specific scripts from coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->