### PR TITLE
release: v0.7.13 编码记忆蒸馏(codingRetrospect)/智能调速器/语义保留 + CI 修复

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.7.13] - 2026-09-08
+
+### 新增
+
+- **编码记忆蒸馏（`codingRetrospect`，默认关）**：turn/end 蒸馏改用**完整转录**（用户输入 + 助手思考/回复 + 工具调用/结果 + 代码执行）提炼原子记忆，蒸馏模型能看到工具报错与调试全过程，不再只盯着用户打了什么字。新增三种编码专属记忆类型，专治重复踩坑 / 遗忘被否决方案 / 丢失工程约束：
+  - `rejected_solution`（被否决/废弃的实现方案：方案简述 + 被否决原因 + 最终采用方案）
+  - `pitfall`（调试踩坑记录：现象/报错 + 根因 + 解决/规避方法）
+  - `constraint`（项目工程约束：约束描述 + 来源）
+  - 读取侧按需加权：`isCodingTask` 判定编码任务（`codingKeywords` 关键词命中），命中时编码类记忆注入排序权重 ×`codingBoostFactor`（默认 2，封顶 5）；普通闲聊检索不到编码记忆，不污染通用召回。`tools.js` 的 `memory_save/search/list/update` 类型枚举同步扩到 7 种。
+- **智能调速器（429 保护）**：对话一多时 turn/end 会批量触发蒸馏，多个 LLM 请求「一拥而上」正是 429 的来源。所有蒸馏调用进**全局串行队列**（`distillRateLimitIntervalMs` 默认 1000ms 分批放行，单次蒸馏零延迟），命中 429 按 `distillRateLimitBaseDelayMs`（默认 1000ms）**指数退避**（1s→2s→4s…）自动重试 `distillRateLimitRetries`（默认 3）次，全程对用户透明，不把 429 错误码抛出去。
+- **语义保留（原子记忆）**：蒸馏 prompt 改为「每条记忆只装一个独立事实/偏好/决策，短小、自带完整上下文（数字/名字/路径/结论保留原文），宁可拆成多条也绝不合并丢细节」；完整转录上限由 `distillMaxChars`（默认 24000，可调大）控制。
+
+### 工程
+
+- **修复 v0.7.12 CI 回归**：v0.7.11（ce4658e）移除 c8 与 `test:coverage` 脚本但 `test.yml` 仍调用 → 两版测试工作流 `Missing script: "test:coverage"` 直接红；恢复 `c8@^12.0.0` devDependency + `test:coverage` 脚本，覆盖率流水线复原。
+
+### 测试
+
+- 616 全绿（+4）：蒸馏全局串行队列、429 指数退避重试（`distillRateLimitRetries:3` 实测 3 次退避）、完整转录原子记忆 prompt、`codingRetrospect` 落库 `rejected_solution`（tags 空数组，读取侧靠 `m.type` 门控）。
+
 ## [0.7.12] - 2026-09-08
 
 ### 新增

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -241,6 +241,9 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 | 版本 | 亮点 |
 |------|------|
+| **v0.7.13** | 编码记忆蒸馏（`codingRetrospect` 默认关）：完整转录（用户+助手思考/回复+工具调用/结果+代码执行）提炼原子记忆，新增 `rejected_solution`/`pitfall`/`constraint` 三类型，编码任务 `codingBoostFactor` 加权（cap 5）+ 智能调速器（蒸馏全局串行队列 + 429 指数退避自动重试）+ 原子记忆语义保留（宁可拆多条不合并丢细节，`distillMaxChars` 默认 24000）+ 修复 v0.7.12 CI 回归（恢复 c8 覆盖率）；616 测试全绿 |
+| **v0.7.12** | 独立外部 API（插件自带 HTTP 服务 `127.0.0.1:8790` Bearer 鉴权，生态集成）+ 零依赖 CLI `dsh-mneme`（status/list/search/get/add/delete/config）+ 轻量模式 lightMode（简化预设、面板一键切换）+ 设置面板新卡片（运行模式/外部访问 API）；612 测试全绿 |
+| **v0.7.11** | 记忆库面板改版：按月分页+无限滚动（`limit=500` 静默丢失→100 条/页分页，total 常显）、搜索全局化（关键词/语义走服务端命中全库）、30s 静默刷新 + 状态子页（记忆/实体/向量索引/LLM 消耗四卡）+ 删除两步确认 + 重要性过滤芯片 + 内联 Lucide 图标；bundle 默认开启实体抽取；Issue #72 最大化窗口图谱节点裁剪修复（力导向全程 viewBox 用户单位）+ Issue #59 autoSummarize 从不执行修复（snapshotEvents 垫片）；双语 README；595 测试全绿 |
 | **v0.7.10** | Web 面板体验升级：记忆类型色点体系（筛选/时间树/详情三处贯穿）+ 图谱画布平移/滚轮缩放/重置视图（补齐 `cursor: grab` 暗示却缺失的交互）+ 设置页 Claude 风格分区重排（编号规则行、悬停删除、口语化文案）+ 侧边栏入口同标签冲突修复（可见性过滤 + 渲染验证 + 多候选重试）+ 详情 meta 精排（来源截断、相对时间）+ 新增只读 `GET /api/dsh-mneme/entities` 实体清单端点（19→20 条路由）；815 测试全绿 |
 | **v0.7.9** | issue #65 修复：v0.7.8 的 snapshotEvents 适配只改了 `src/`，npm 实际加载的 `lib/` 从未同步——静默失效；补齐 lib 三处垫片 + 新增 `scripts/check-sync.js` 发布前 src↔lib 一致性闸门（root prepack 调用，漂移直接 fail）+ `test/lib-smoke.test.js` 从 lib 导入复跑 + 一致性断言（CI 双保险）；815 测试全绿 |
 | **v0.7.8** | DSH 0.1.2-rc.1 兼容（issues #58 #59）：官方移除 `Session.events` 属性改为 `snapshotEvents()` 方法，autoSummarize 与 hot-context（短期上下文）注入取不到事件而失效；改用兼容垫片 `session.snapshotEvents?.() ?? session.events`，新旧 DSH 通吃，老版本行为不受影响；新增 2 个回归用例；812 测试全绿 |

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## release: v0.7.13

编码记忆蒸馏 + 智能调速器 + 语义保留（承接 #73 合并进 main 的三功能，本次发布让 npm 跟上）+ 修复 v0.7.12 CI 回归。

### 新功能
- **编码记忆蒸馏（`codingRetrospect`，默认关）**：turn/end 蒸馏改用完整转录（用户输入 + 助手思考/回复 + 工具调用/结果 + 代码执行）提炼原子记忆。新增三种编码专属类型：
  - `rejected_solution`（被否决方案：方案 + 否决原因 + 最终采用）
  - `pitfall`（调试踩坑：现象/报错 + 根因 + 解决/规避）
  - `constraint`（工程约束：描述 + 来源）
  - `isCodingTask` 关键词判定，编码任务下编码记忆注入权重 ×`codingBoostFactor`（默认 2，cap 5）；`tools.js` 类型枚举扩到 7 种。
- **智能调速器（429 保护）**：蒸馏调用全局串行队列（`distillRateLimitIntervalMs` 默认 1000ms）+ 429 指数退避自动重试（`distillRateLimitRetries` 默认 3 / `BaseDelayMs` 默认 1000），对话一多批量蒸馏不再一拥而上。
- **语义保留（原子记忆）**：完整转录上限 `distillMaxChars`（默认 24000）+ 「每条记忆只装一个独立事实…宁可拆多条也绝不合并丢细节」原子 prompt。

### 修复
- **v0.7.12 CI 回归**：v0.7.11 移除 c8 + `test:coverage` 脚本但 `test.yml` 仍调用 → CI `Missing script` 红；恢复 `c8@^12` + 脚本，覆盖率流水线复原。

### 工程
- 616 测试全绿（+4：串行队列 / 429 退避 / 完整转录原子 prompt / codingRetrospect 落库）。

### 升级提示
- `codingRetrospect` 默认**关**，不影响现有行为；开启后新增配置：`codingRetrospect` / `codingKeywords` / `codingBoostFactor` / `distillMaxChars` / `distillRateLimitIntervalMs` / `distillRateLimitRetries` / `distillRateLimitBaseDelayMs`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coding-memory distillation from complete transcripts, including new memory types and improved retrieval for coding tasks.
  - Added serialized processing with automatic retries for temporary rate-limit responses.
  - Clarified atomic-memory prompt behavior.
  - Restored coverage tooling following a CI regression.

- **Documentation**
  - Updated the changelog and README with v0.7.13 highlights and recent release information.
  - Documented the external API, CLI, light mode, and memory-panel improvements.

- **Release**
  - Updated the application version to 0.7.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->