### PR TITLE
release/0.7.12-integration: 0.7.11 + 0.7.12 全量集成到 0.7.10 主线

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.7.12] - 2026-09-08
+
+### 🌐 独立外部 API + CLI 工具 + 轻量模式
+
+- **独立外部 API（生态集成）**：插件可启动自己的 HTTP 服务（默认 `127.0.0.1:8790`，仅回环绑定，Bearer token 首次启用自动生成并持久化），其他插件/CLI/桌面工具直接读写记忆，不再依赖 DSH 内部端口。路由：`GET /health`（免鉴权）、`GET /status`、`GET/POST/DELETE /memories`、`GET /memories/:id`、`GET /search`；非法 type/缺字段 400、未知资源 404。配置 `externalApiEnabled/externalApiPort/externalApiHost` + 面板设置持久化（重启生效）；非回环绑定的安全责任由操作者承担。exact 路由 22 → 25。
+- **CLI 工具 `dsh-mneme`**：零依赖命令行（`bin/cli.mjs`，包新增 bin 字段）——`status` / `list` / `search` / `get` / `add` / `delete` / `config set|show|path`；配置优先级 参数 > 环境变量（`DSH_MNEME_URL`/`DSH_MNEME_TOKEN`）> `~/.dsh-mneme/cli.json`；`--json` 机器输出；token 打码显示。
+- **轻量模式（lightMode）**：面向非技术用户的简化预设——只保留核心记忆读写与自动注入（autoInject/autoSummarize/hot memory/质量过滤），关闭 autoDream、睡眠、实体抽取、rerank、bm25、选择性注入、语义去重、自动重建索引、hybrid 注入共 9 项重资源字段（`applyLightModePreset` 纯函数，light 模式下连 ONNX 嵌入模型都不加载）；`panel_mode` 持久化优先于 bundle 配置；设置面板一键切换（重启生效）。
+- **设置面板新卡片**：「运行模式」（轻量/标准）与「外部访问 API」（启停/地址端口校验/Token 只读复制），中英文案齐备。
+
+### 测试
+
+- 全套 **838 测试通过**（+12：standalone-api 10 例——401/health/CRUD 闭环/搜索/400 校验；external_api 合并与 panel_mode 往返 2 例）。`store.count` 支持 minImportance/source 后分页 total 与行一致。
+
+## [0.7.11] - 2026-09-08
+
+### 🐛 两个 issue 修复 + 面板可扩展性改版 + 实体抽取默认开
+
+- **issue #72：窗口最大化后图谱节点不可见**：力导向模拟此前以 SVG 元素的 CSS 宽度（`clientWidth`）为布局边界——最大化下元素上千 CSS px，重心与钳制区间落到 380×300 viewBox 之外，节点整体被裁出画布。现在模拟全程在 viewBox 用户单位（`VIEW_W`/`VIEW_H`）中运行，浏览器把 viewBox 等比缩放到任意元素尺寸，布局不再依赖挂载时的容器测量。
+- **issue #59：autoSummarize 在 DSH ≥0.1.2-rc 上从不执行**：`Session.events` 属性被移除，事件只能经 `snapshotEvents()` 获取。`summarize.js` 与 `inject.js` 三处统一为 `session.snapshotEvents?.() ?? session.events ?? []` 兼容垫片（远程 0.7.8/0.7.9 已修，本版本线合入同一语义）。
+- **记忆库面板改版（可扩展性 + 实时性）**：记忆浏览从一次性 `limit=500`（超限静默丢失）改为 100 条/页时间序分页（`list?order=chrono`，`store.list` 新增 `order` 参数）+ 滚动到底自动加载；月份默认折叠仅展开最新月（吸顶表头 + 月计数）；关键词/语义搜索全部走服务端命中全库；记忆子视图激活即刷新 + 30s 静默轮询；新增「状态」子页（记忆/实体/向量/LLM 消耗四张卡，分区独立加载）；记忆删除（两步确认，`POST /api/dsh-mneme/delete`）；重要性 全部/★3+/★4+/★5 服务端过滤芯片；内联 Lucide stroke 图标体系（零运行时依赖）。
+- **bundle 默认开启实体抽取**：`cordis.patch.yml` 增加 `entityExtractionEnabled: true`（此前默认 false）。
+- **双语 README**：新增 `README.en.md`，两版互挂语言切换链接。
+
+### 测试
+
+- 移植批次全套 **838 测试通过**（snapshotEvents 回归 2 例 + 面板改版新增断言并入）。
+
 ## [0.7.10] - 2026-09-07
 
 ### 🆕 Web 面板体验升级：类型色点 / 图谱平移缩放 / 设置页重排 / 侧边栏冲突修复

--- a/dsh-mneme/bin/cli.mjs
+++ b/dsh-mneme/bin/cli.mjs
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+/**
+ * dsh-mneme CLI —— @modusensus/dsh-mneme 外部 API 命令行客户端
+ *
+ * 零依赖 ESM（Node >= 20，使用全局 fetch）。
+ * 配置优先级：命令行 --url/--token > 环境变量 DSH_MNEME_URL / DSH_MNEME_TOKEN
+ *            > 配置文件 ~/.dsh-mneme/cli.json（{"url","token"}）
+ * 默认服务地址：http://127.0.0.1:8790
+ */
+
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const CLI_NAME = 'dsh-mneme';
+const DEFAULT_URL = 'http://127.0.0.1:8790';
+const CONFIG_DIR = path.join(os.homedir(), '.dsh-mneme');
+const CONFIG_PATH = path.join(CONFIG_DIR, 'cli.json');
+const MEMORY_TYPES = ['preference', 'project', 'decision', 'summary', 'history'];
+const SEARCH_MODES = ['keyword', 'vector', 'auto'];
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function readPkgVersion() {
+  try {
+    const pkgPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'package.json'
+    );
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version ?? '?';
+  } catch {
+    return '?';
+  }
+}
+
+const PKG_VERSION = readPkgVersion();
+
+const USAGE = `${CLI_NAME} —— DSH 记忆插件（@modusensus/dsh-mneme）外部 API 命令行客户端
+
+用法：
+  ${CLI_NAME} <命令> [参数] [选项]
+
+配置（优先级从高到低）：
+  1. 命令行参数 --url <url> / --token <token>
+  2. 环境变量 DSH_MNEME_URL / DSH_MNEME_TOKEN
+  3. 配置文件 ~/.dsh-mneme/cli.json（由 \`config set\` 写入）
+  未配置时使用默认地址：${DEFAULT_URL}
+
+命令：
+  config set <url> <token>     写入配置文件（token 省略时保留原值）
+  config show                  查看当前配置（token 打码显示）
+  config path                  打印配置文件路径
+  status                       服务状态（版本 / 记忆统计 / 实体 / 运行时长）
+  list [--type t] [--min-importance n] [--source s]
+       [--limit n] [--offset n] [--json]
+                               列出记忆（type: preference | project | decision | summary | history）
+  search <query> [--mode m] [--topk n] [--json]
+                               搜索记忆（mode: keyword | vector | auto）
+  get <id> [--json]            查看单条记忆
+  add --type <t> --title <t> --content <c>
+      [--importance n] [--tags a,b] [--source s] [--json]
+                               新增记忆（type: preference | project | decision | summary | history）
+  delete <id>                  删除记忆
+
+选项：
+  --url <url>                  覆盖服务地址
+  --token <token>              覆盖访问 token
+  --json                       输出原始 JSON
+  -h, --help                   显示本帮助
+  -V, --version                显示版本号
+
+说明：
+  token 在 DSH 面板「设置 → 外部访问」或插件设置中查看；
+  除 GET /health 外，所有外部 API 路由均需 Bearer token。
+
+示例：
+  ${CLI_NAME} config set ${DEFAULT_URL} my-token
+  ${CLI_NAME} status
+  ${CLI_NAME} list --type project --limit 10
+  ${CLI_NAME} search "部署流程" --mode vector --topk 5
+  ${CLI_NAME} add --type decision --title "采用 SQLite" --content "存储层使用 node:sqlite" --importance 4 --tags 存储,决策
+  ${CLI_NAME} get 42
+  ${CLI_NAME} delete 42`;
+
+/* ---------------------------------- 参数解析 ---------------------------------- */
+
+function parseArgv(argv) {
+  const positionals = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--') {
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+    if (arg.startsWith('--')) {
+      let key = arg.slice(2);
+      let value;
+      const eq = key.indexOf('=');
+      if (eq >= 0) {
+        value = key.slice(eq + 1);
+        key = key.slice(0, eq);
+      } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--') && argv[i + 1] !== '--') {
+        value = argv[++i];
+      } else {
+        value = true;
+      }
+      flags[key.toLowerCase()] = value;
+    } else {
+      positionals.push(arg);
+    }
+  }
+  return { positionals, flags };
+}
+
+function flagValue(flags, ...names) {
+  for (const name of names) {
+    const value = flags[name.toLowerCase()];
+    if (value !== undefined && value !== true && value !== '') return value;
+  }
+  return undefined;
+}
+
+function flagBool(flags, ...names) {
+  for (const name of names) {
+    const value = flags[name.toLowerCase()];
+    if (value !== undefined) return value === true || value === 'true' || value === '';
+  }
+  return false;
+}
+
+/* ---------------------------------- 配置解析 ---------------------------------- */
+
+function readConfigFile() {
+  try {
+    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    return data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+  } catch {
+    return {};
+  }
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return undefined;
+}
+
+function resolveConfig(flags) {
+  const file = readConfigFile();
+  const url =
+    firstNonEmpty(flagValue(flags, 'url'), process.env.DSH_MNEME_URL, file.url) ?? DEFAULT_URL;
+  const token =
+    firstNonEmpty(flagValue(flags, 'token'), process.env.DSH_MNEME_TOKEN, file.token) ?? '';
+  return { url: url.replace(/\/+$/, ''), token, jsonMode: false };
+}
+
+function maskToken(token) {
+  if (!token) return '(未设置)';
+  if (token.length <= 8) return '****';
+  return `${token.slice(0, 4)}****${token.slice(-4)}`;
+}
+
+/* ---------------------------------- 输出与错误 ---------------------------------- */
+
+function stringify(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function fail(cfg, message, { rawJson } = {}) {
+  if (cfg.jsonMode) {
+    console.error(rawJson !== undefined ? rawJson : stringify({ error: message }));
+  } else {
+    console.error(message);
+  }
+  process.exit(1);
+}
+
+function failHttp(cfg, status, pathname, data, text) {
+  const serverError =
+    data && typeof data === 'object' && data.error
+      ? String(data.error)
+      : (text || '').slice(0, 200);
+  let hint = '';
+  if (status === 401) {
+    hint =
+      `\n访问 token 缺失或无效。token 可在 DSH 面板「设置 → 外部访问」或插件设置中查看，\n` +
+      `然后用 \`${CLI_NAME} config set <url> <token>\`、环境变量 DSH_MNEME_TOKEN 或 --token 配置。`;
+  } else if (status === 404) {
+    hint = `\n资源不存在：${pathname}`;
+  }
+  fail(cfg, `请求失败（HTTP ${status}）${serverError ? `：${serverError}` : ''} [${pathname}]${hint}`, {
+    rawJson: cfg.jsonMode && text ? text : undefined,
+  });
+}
+
+function failNetwork(cfg, url, err) {
+  const timedOut = err && (err.name === 'TimeoutError' || err.name === 'AbortError');
+  const reason = timedOut
+    ? `请求超时（${REQUEST_TIMEOUT_MS / 1000} 秒）`
+    : `无法连接到服务（${err?.code ?? err?.cause?.code ?? err?.message ?? '未知错误'}）`;
+  fail(
+    cfg,
+    `${reason}：${url}\n` +
+      `请确认 DSH 已启动、插件外部 API 已开启，且地址正确（默认 ${DEFAULT_URL}）。`
+  );
+}
+
+function requireToken(cfg) {
+  if (cfg.token) return;
+  fail(
+    cfg,
+    [
+      '未配置访问 token，无法调用该命令（外部 API 需要 Bearer 鉴权）。',
+      '',
+      'token 可在 DSH 面板「设置 → 外部访问」或插件设置中查看，然后任选其一配置：',
+      `  1. ${CLI_NAME} config set <url> <token>`,
+      '  2. 环境变量 DSH_MNEME_TOKEN=<token>',
+      '  3. 命令行参数 --token <token>',
+    ].join('\n')
+  );
+}
+
+function parseIntArg(cfg, value, label) {
+  if (value === undefined || value === true || value === '') return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    fail(cfg, `无效的 ${label}: ${value}（应为非负整数）`);
+  }
+  return n;
+}
+
+/* ---------------------------------- HTTP 请求 ---------------------------------- */
+
+async function apiRequest(cfg, method, pathname, { query, body } = {}) {
+  let url = cfg.url + pathname;
+  if (query) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== null && value !== '') {
+        params.set(key, String(value));
+      }
+    }
+    const qs = params.toString();
+    if (qs) url += `?${qs}`;
+  }
+
+  const headers = { Accept: 'application/json' };
+  if (cfg.token) headers.Authorization = `Bearer ${cfg.token}`;
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+
+  let res;
+  try {
+    res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    failNetwork(cfg, url, err);
+  }
+
+  const text = await res.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    // 非 JSON 响应体，保留原始文本用于报错展示
+  }
+
+  if (!res.ok) {
+    failHttp(cfg, res.status, pathname, data, text);
+  }
+  return data;
+}
+
+/* ---------------------------------- 结果格式化 ---------------------------------- */
+
+function formatTimestamp(value) {
+  if (!value) return '';
+  const s = String(value);
+  return s.length >= 10 ? s.slice(0, 10) : s;
+}
+
+function formatMemoryLine(item) {
+  const id = item?.id ?? '?';
+  const type = item?.type ?? '?';
+  const importance = item?.importance != null ? ` ★${item.importance}` : '';
+  const title = item?.title ? ` ${item.title}` : '';
+  const tags =
+    Array.isArray(item?.tags) && item.tags.length ? ` [${item.tags.join(',')}]` : '';
+  const date = formatTimestamp(item?.created_at ?? item?.createdAt);
+  return `  #${id}  [${type}]${importance}${title}${tags}${date ? ` (${date})` : ''}`;
+}
+
+function printMemoryItems(payload, { withMode = false } = {}) {
+  const items = Array.isArray(payload?.items) ? payload.items : [];
+  const total = payload?.total ?? items.length;
+  if (withMode && payload?.mode) console.log(`搜索模式: ${payload.mode}`);
+  console.log(`共 ${total} 条，本次显示 ${items.length} 条`);
+  if (!items.length) return;
+  console.log('');
+  for (const item of items) {
+    const score = item?.score ?? item?.similarity;
+    const scoreText =
+      typeof score === 'number' && Number.isFinite(score) ? ` (score ${score.toFixed(3)})` : '';
+    console.log(formatMemoryLine(item) + scoreText);
+    const content =
+      typeof item?.content === 'string' ? item.content.replace(/\s+/g, ' ').trim() : '';
+    if (content) {
+      console.log(`      ${content.length > 80 ? `${content.slice(0, 80)}…` : content}`);
+    }
+  }
+}
+
+function printMemoryDetail(item) {
+  if (!item || typeof item !== 'object') {
+    console.log(stringify(item ?? null));
+    return;
+  }
+  const fields = [];
+  if (item.id !== undefined) fields.push(`id: ${item.id}`);
+  if (item.type !== undefined) fields.push(`类型: ${item.type}`);
+  if (item.importance !== undefined) fields.push(`重要性: ${item.importance}`);
+  if (item.title !== undefined) fields.push(`标题: ${item.title}`);
+  if (item.tags !== undefined) {
+    fields.push(`标签: ${Array.isArray(item.tags) ? item.tags.join(', ') : item.tags}`);
+  }
+  if (item.source !== undefined) fields.push(`来源: ${item.source}`);
+  const created = item.created_at ?? item.createdAt;
+  if (created) fields.push(`创建时间: ${created}`);
+  for (const line of fields) console.log(line);
+  if (item.content !== undefined) console.log(`\n${item.content}`);
+}
+
+function printStatus(data) {
+  console.log(`服务版本: ${data?.version ?? '?'}`);
+  console.log(`运行时长: ${data?.uptime_s ?? data?.uptimeS ?? '?'} 秒`);
+  const memories = data?.memories ?? {};
+  console.log(`记忆总数: ${memories.total ?? '?'}`);
+  const byType = memories.byType;
+  if (Array.isArray(byType)) {
+    for (const row of byType) {
+      console.log(`  - ${row?.type ?? row?.name ?? '?'}: ${row?.count ?? row?.total ?? '?'}`);
+    }
+  } else if (byType && typeof byType === 'object') {
+    for (const [type, count] of Object.entries(byType)) {
+      console.log(`  - ${type}: ${count}`);
+    }
+  }
+  const entities = data?.entities;
+  if (entities != null) {
+    const total =
+      typeof entities === 'object' && !Array.isArray(entities)
+        ? entities.total
+        : entities;
+    console.log(`实体数量: ${total ?? '?'}`);
+  }
+}
+
+/* ---------------------------------- 子命令 ---------------------------------- */
+
+async function cmdConfig(cfg, sub, rest) {
+  const subCmd = sub || 'show';
+
+  if (subCmd === 'set') {
+    const [url, tokenArg] = rest;
+    if (!url) {
+      fail(
+        cfg,
+        `用法: ${CLI_NAME} config set <url> <token>\n示例: ${CLI_NAME} config set ${DEFAULT_URL} my-token`
+      );
+    }
+    if (!/^https?:\/\//i.test(url)) {
+      fail(cfg, `无效的服务地址: ${url}（应以 http:// 或 https:// 开头）`);
+    }
+    const existing = readConfigFile();
+    const token = tokenArg ?? existing.token ?? '';
+    await fsp.mkdir(CONFIG_DIR, { recursive: true });
+    await fsp.writeFile(CONFIG_PATH, `${JSON.stringify({ url, token }, null, 2)}\n`, 'utf8');
+    if (cfg.jsonMode) {
+      console.log(stringify({ configPath: CONFIG_PATH, url, tokenConfigured: Boolean(token) }));
+    } else {
+      console.log(`已写入配置文件: ${CONFIG_PATH}`);
+      console.log(`  url: ${url}`);
+      console.log(`  token: ${maskToken(token)}`);
+    }
+    return;
+  }
+
+  if (subCmd === 'show') {
+    const hasFile = fs.existsSync(CONFIG_PATH);
+    const file = readConfigFile();
+    if (cfg.jsonMode) {
+      console.log(
+        stringify({
+          configPath: CONFIG_PATH,
+          configExists: hasFile,
+          url: file.url ?? DEFAULT_URL,
+          token: maskToken(file.token),
+        })
+      );
+      return;
+    }
+    if (!hasFile) {
+      console.log(`尚未创建配置文件（未配置）: ${CONFIG_PATH}`);
+      console.log('');
+      console.log(`可运行 \`${CLI_NAME} config set <url> <token>\` 创建配置；`);
+      console.log('token 可在 DSH 面板「设置 → 外部访问」或插件设置中查看。');
+      console.log(
+        `未配置时使用默认地址 ${DEFAULT_URL}，也可用环境变量 DSH_MNEME_URL / DSH_MNEME_TOKEN。`
+      );
+      return;
+    }
+    console.log(`配置文件: ${CONFIG_PATH}`);
+    console.log(`  url: ${file.url ?? `(未设置，默认 ${DEFAULT_URL})`}`);
+    console.log(`  token: ${maskToken(file.token)}`);
+    console.log('');
+    console.log('配置优先级: --url/--token > 环境变量 DSH_MNEME_URL / DSH_MNEME_TOKEN > 配置文件');
+    return;
+  }
+
+  if (subCmd === 'path') {
+    console.log(CONFIG_PATH);
+    return;
+  }
+
+  fail(cfg, `未知的 config 子命令: ${subCmd}\n可用子命令: set / show / path`);
+}
+
+async function cmdStatus(cfg) {
+  requireToken(cfg);
+  const data = await apiRequest(cfg, 'GET', '/status');
+  if (cfg.jsonMode) {
+    console.log(stringify(data));
+  } else {
+    printStatus(data);
+  }
+}
+
+async function cmdList(cfg, flags) {
+  requireToken(cfg);
+  const query = {
+    type: flagValue(flags, 'type'),
+    minImportance: parseIntArg(cfg, flagValue(flags, 'min-importance', 'minImportance'), '--min-importance'),
+    source: flagValue(flags, 'source'),
+    limit: parseIntArg(cfg, flagValue(flags, 'limit'), '--limit'),
+    offset: parseIntArg(cfg, flagValue(flags, 'offset'), '--offset'),
+  };
+  const data = await apiRequest(cfg, 'GET', '/memories', { query });
+  if (cfg.jsonMode) {
+    console.log(stringify(data));
+  } else {
+    printMemoryItems(data);
+  }
+}
+
+async function cmdSearch(cfg, rest, flags) {
+  requireToken(cfg);
+  const q = rest[0];
+  if (!q) {
+    fail(
+      cfg,
+      `用法: ${CLI_NAME} search <query> [--mode m] [--topk n]\n` +
+        `示例: ${CLI_NAME} search "部署流程" --mode vector --topk 5`
+    );
+  }
+  const mode = flagValue(flags, 'mode');
+  if (mode !== undefined && !SEARCH_MODES.includes(mode)) {
+    fail(cfg, `无效的 --mode: ${mode}（可选: ${SEARCH_MODES.join(' | ')}）`);
+  }
+  const topK = parseIntArg(cfg, flagValue(flags, 'topk', 'top-k', 'topK'), '--topk');
+  const data = await apiRequest(cfg, 'GET', '/search', { query: { q, mode, topK } });
+  if (cfg.jsonMode) {
+    console.log(stringify(data));
+  } else {
+    printMemoryItems(data, { withMode: true });
+  }
+}
+
+async function cmdGet(cfg, rest) {
+  requireToken(cfg);
+  const id = rest[0];
+  if (!id) {
+    fail(cfg, `用法: ${CLI_NAME} get <id> [--json]`);
+  }
+  const data = await apiRequest(cfg, 'GET', `/memories/${encodeURIComponent(id)}`);
+  if (cfg.jsonMode) {
+    console.log(stringify(data));
+  } else {
+    printMemoryDetail(data);
+  }
+}
+
+async function cmdAdd(cfg, flags) {
+  requireToken(cfg);
+  const type = flagValue(flags, 'type');
+  const title = flagValue(flags, 'title');
+  const content = flagValue(flags, 'content');
+  if (!type || !title || !content) {
+    fail(
+      cfg,
+      `用法: ${CLI_NAME} add --type <${MEMORY_TYPES.join('|')}> --title <标题> --content <内容>\n` +
+        `      [--importance n] [--tags a,b] [--source s]\n\n` +
+        `示例: ${CLI_NAME} add --type decision --title "采用 SQLite" --content "存储层使用 node:sqlite"`
+    );
+  }
+  if (!MEMORY_TYPES.includes(type)) {
+    fail(cfg, `无效的 --type: ${type}（可选: ${MEMORY_TYPES.join(' | ')}）`);
+  }
+  const importanceRaw = flagValue(flags, 'importance');
+  let importance;
+  if (importanceRaw !== undefined) {
+    importance = Number(importanceRaw);
+    if (!Number.isInteger(importance) || importance < 1 || importance > 5) {
+      fail(cfg, `无效的 --importance: ${importanceRaw}（应为 1-5 的整数）`);
+    }
+  }
+  const tagsRaw = flagValue(flags, 'tags');
+  const tags =
+    tagsRaw !== undefined
+      ? tagsRaw.split(',').map((t) => t.trim()).filter(Boolean)
+      : undefined;
+  const source = flagValue(flags, 'source');
+
+  const body = { type, title, content };
+  if (importance !== undefined) body.importance = importance;
+  if (tags) body.tags = tags;
+  if (source) body.source = source;
+
+  const data = await apiRequest(cfg, 'POST', '/memories', { body });
+  if (cfg.jsonMode) {
+    console.log(stringify(data));
+  } else {
+    console.log('已添加记忆:');
+    printMemoryDetail(data);
+  }
+}
+
+async function cmdDelete(cfg, rest) {
+  requireToken(cfg);
+  const id = rest[0];
+  if (!id) {
+    fail(cfg, `用法: ${CLI_NAME} delete <id>`);
+  }
+  const data = await apiRequest(cfg, 'DELETE', `/memories/${encodeURIComponent(id)}`);
+  if (cfg.jsonMode) {
+    console.log(stringify(data));
+  } else {
+    console.log(`已删除记忆 ${id}`);
+  }
+}
+
+/* ---------------------------------- 入口 ---------------------------------- */
+
+async function main(argv) {
+  const { positionals, flags } = parseArgv(argv);
+  const cmd = positionals[0];
+  const rest = positionals.slice(1);
+
+  if (!cmd || cmd === '-h' || cmd === '--help' || cmd === 'help') {
+    console.log(USAGE);
+    return;
+  }
+  if (cmd === '-V' || cmd === '--version' || cmd === 'version') {
+    console.log(PKG_VERSION);
+    return;
+  }
+
+  const cfg = resolveConfig(flags);
+  cfg.jsonMode = flagBool(flags, 'json');
+
+  switch (cmd) {
+    case 'config':
+      return cmdConfig(cfg, rest[0], rest.slice(1));
+    case 'status':
+      return cmdStatus(cfg);
+    case 'list':
+    case 'ls':
+      return cmdList(cfg, flags);
+    case 'search':
+      return cmdSearch(cfg, rest, flags);
+    case 'get':
+      return cmdGet(cfg, rest);
+    case 'add':
+      return cmdAdd(cfg, flags);
+    case 'delete':
+    case 'rm':
+      return cmdDelete(cfg, rest);
+    default:
+      fail(cfg, `未知命令: ${cmd}\n运行 \`${CLI_NAME} --help\` 查看帮助。`);
+  }
+}
+
+main(process.argv.slice(2)).catch((err) => {
+  console.error(err?.stack ?? String(err));
+  process.exit(1);
+});

--- a/dsh-mneme/cordis.patch.yml
+++ b/dsh-mneme/cordis.patch.yml
@@ -13,3 +13,4 @@
         dreamThresholdCount: 10
         dreamThresholdChars: 5000
         dreamDelayMs: 2000
+        entityExtractionEnabled: true

--- a/dsh-mneme/lib/api-standalone.js
+++ b/dsh-mneme/lib/api-standalone.js
@@ -1,0 +1,264 @@
+// Standalone HTTP API (v0.7.12): a plain node:http server for ecosystem
+// integrations that live outside the DSH host and cannot reach the plugin's
+// internal webServer routes (/api/dsh-mneme/*). Mirrors the JSON semantics of
+// those routes but with mandatory Bearer-token auth on everything except
+// GET /health, so the store can be exposed safely on loopback.
+//
+// Security: the default bind host is 127.0.0.1. Pointing externalApiHost at a
+// non-loopback address exposes the whole memory store to the network — that is
+// the operator's explicit responsibility (documented in README).
+import { createServer } from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { TYPES } from "./store.js";
+
+const DEFAULT_PORT = 8790;
+const DEFAULT_HOST = "127.0.0.1";
+// Hardcoded release version (package.json is bumped at publish time and may
+// lag the code that ships in between).
+const VERSION = "0.7.12";
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(payload));
+}
+
+/** True when the request carries the configured token. */
+function isAuthorized(req, apiToken) {
+  const raw = req.headers?.authorization ?? req.headers?.["x-dsh-mneme-token"] ?? "";
+  const token = raw.startsWith("Bearer ") ? raw.slice(7).trim() : raw.trim();
+  if (token === "" || token.length !== apiToken.length) return false;
+  // Constant-time comparison: no timing oracle on the token.
+  return timingSafeEqual(Buffer.from(token), Buffer.from(apiToken));
+}
+
+/** Collect the request body as text (tolerant of transport errors). */
+function readBody(req) {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => resolve(body));
+    req.on("error", () => resolve(""));
+  });
+}
+
+/**
+ * Create (and start) the standalone API server.
+ * Accepts { service, store, config, logger, settings, port, host }:
+ *   - token: persisted settings kv "external_api" wins; auto-generated
+ *     (crypto.randomBytes(24).toString("base64url")) and persisted when empty.
+ *   - port:  explicit arg > persisted settings > config.externalApiPort > 8790.
+ *   - host:  explicit arg > config.externalApiHost > "127.0.0.1".
+ * Returns { server, port, host, token, ready }: `port` is the effective bound
+ * port (updated to the OS-assigned one after `ready` resolves when asked to
+ * bind port 0), `ready` resolves once listening and rejects if the bind fails.
+ */
+export function createStandaloneApi({ service, store, config = {}, logger, settings, port, host }) {
+  const persisted = settings?.getExternalApi?.() ?? {};
+
+  let token = typeof persisted.token === "string" ? persisted.token : "";
+  if (!token) {
+    token = randomBytes(24).toString("base64url");
+    // Persist only the token; enabled/port keys stay as they are (merge).
+    try {
+      settings?.setExternalApi?.({ token });
+    } catch (error) {
+      logger?.warn?.(`[dsh-mneme] standalone API token persistence failed: ${String(error)}`);
+    }
+  }
+
+  // Persisted host (set from the panel) wins over the bundle config, same
+  // precedence as port; the explicit argument still wins over both.
+  const boundHost = host
+    ?? (typeof persisted.host === "string" && persisted.host ? persisted.host : undefined)
+    ?? config.externalApiHost
+    ?? DEFAULT_HOST;
+  const persistedPort = Number(persisted.port);
+  const boundPort = port
+    ?? (Number.isInteger(persistedPort) && persistedPort > 0 ? persistedPort : undefined)
+    ?? config.externalApiPort
+    ?? DEFAULT_PORT;
+
+  const server = createServer((req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const pathname = url.pathname;
+
+      // Health is the single unauthenticated probe (monitor checks).
+      if (req.method === "GET" && pathname === "/health") {
+        sendJson(res, 200, { ok: true });
+        return;
+      }
+
+      // Everything else requires the Bearer token.
+      if (!isAuthorized(req, token)) {
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      // --- GET /status: version + store shape + uptime -----------------------
+      if (req.method === "GET" && pathname === "/status") {
+        const byType = {};
+        for (const type of TYPES) byType[type] = service.count(type);
+        let entities = 0;
+        try {
+          entities = store.db.prepare("SELECT count(*) AS c FROM entities").get().c;
+        } catch { /* entities storage unavailable → 0 */ }
+        sendJson(res, 200, {
+          version: VERSION,
+          memories: { total: service.count(), byType },
+          entities,
+          uptime_s: Math.floor(process.uptime())
+        });
+        return;
+      }
+
+      // --- GET /memories: paged + filtered list (same semantics as the
+      //     internal /api/dsh-mneme/list) ------------------------------------
+      if (req.method === "GET" && pathname === "/memories") {
+        const type = url.searchParams.get("type") ?? undefined;
+        const limit = Number(url.searchParams.get("limit") ?? 50);
+        const offset = Number(url.searchParams.get("offset") ?? 0);
+        const order = url.searchParams.get("order") ?? undefined;
+        const minRaw = url.searchParams.get("minImportance");
+        const minImportance = minRaw !== null && minRaw !== "" && !Number.isNaN(Number(minRaw))
+          ? Number(minRaw)
+          : undefined;
+        const source = url.searchParams.get("source") || undefined;
+        const items = service.toApiList(service.list({ type, limit, offset, order, minImportance, source }));
+        // Total honors the same filters so pager math stays correct.
+        sendJson(res, 200, { items, total: service.count(type, { minImportance, source }) });
+        return;
+      }
+
+      // --- GET/DELETE /memories/:id ------------------------------------------
+      const idMatch = pathname.match(/^\/memories\/([^/]+)$/);
+      if (idMatch) {
+        let id = idMatch[1];
+        try { id = decodeURIComponent(id); } catch { /* keep raw */ }
+        if (req.method === "GET") {
+          const row = service.getById(id);
+          if (!row) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          sendJson(res, 200, service.toApiList([row])[0]);
+          return;
+        }
+        if (req.method === "DELETE") {
+          // store.remove deletes silently — precheck for a distinguishable 404.
+          if (!service.getById(id)) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          service.remove(id);
+          sendJson(res, 200, { ok: true });
+          return;
+        }
+        sendJson(res, 404, { error: "not-found" });
+        return;
+      }
+
+      // --- POST /memories: save with title-dedupe (safer than raw save) ------
+      if (req.method === "POST" && pathname === "/memories") {
+        void readBody(req).then((text) => {
+          let body;
+          try {
+            body = JSON.parse(text || "{}");
+          } catch {
+            sendJson(res, 400, { error: "invalid-json" });
+            return;
+          }
+          if (body === null || typeof body !== "object" || Array.isArray(body)) {
+            sendJson(res, 400, { error: "invalid-body" });
+            return;
+          }
+          // Pre-validate what store.save would throw on, so clients get a
+          // clean 400 instead of a leaked SQLite error.
+          if (!TYPES.has(body.type)) {
+            sendJson(res, 400, { error: "invalid-type" });
+            return;
+          }
+          if (typeof body.title !== "string" || !body.title.trim()) {
+            sendJson(res, 400, { error: "missing-title" });
+            return;
+          }
+          if (typeof body.content !== "string") {
+            sendJson(res, 400, { error: "missing-content" });
+            return;
+          }
+          if (body.tags !== undefined && !Array.isArray(body.tags)) {
+            sendJson(res, 400, { error: "tags-must-be-an-array" });
+            return;
+          }
+          try {
+            const { action, memory } = service.saveWithDedupe({
+              type: body.type,
+              title: body.title,
+              content: body.content,
+              importance: body.importance,
+              tags: body.tags,
+              source: body.source
+            });
+            sendJson(res, action === "created" ? 201 : 200, service.toApiList([memory])[0]);
+          } catch (error) {
+            logger?.warn?.(`[dsh-mneme] standalone API save failed: ${String(error)}`);
+            sendJson(res, 500, { error: "internal" });
+          }
+        });
+        return;
+      }
+
+      // --- GET /search: unified recall pipeline (keyword + vector + BM25) ----
+      if (req.method === "GET" && pathname === "/search") {
+        const q = url.searchParams.get("q") ?? "";
+        const limit = Number(url.searchParams.get("topK") ?? url.searchParams.get("limit") ?? 20);
+        const mode = url.searchParams.get("mode") ?? "auto";
+        const rerank = url.searchParams.get("rerank") !== "false";
+        const query = q.trim();
+        if (!query) {
+          sendJson(res, 200, { items: [], mode: "keyword" });
+          return;
+        }
+        // Any vector/rerank failure degrades to keyword inside searchMemories.
+        void Promise.resolve(
+          service.searchMemories(query, { mode, topK: limit, useRerank: rerank })
+        ).then((rows) => {
+          const used = rows.some((m) => m.vector === true) ? "vector" : "keyword";
+          sendJson(res, 200, { items: service.toApiList(rows), mode: used });
+        }).catch(() => {
+          sendJson(res, 200, { items: service.toApiList(service.search(query, { limit })), mode: "keyword" });
+        });
+        return;
+      }
+
+      sendJson(res, 404, { error: "not-found" });
+    } catch {
+      sendJson(res, 500, { error: "internal" });
+    }
+  });
+
+  // A permanent error listener keeps an EADDRINUSE / runtime socket error from
+  // crashing the host process; `ready` still surfaces the first bind failure.
+  server.on("error", (error) => {
+    logger?.warn?.(`[dsh-mneme] standalone API error: ${String(error)}`);
+  });
+  const ready = new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  server.listen(boundPort, boundHost);
+  ready.then(() => {
+    const address = server.address();
+    if (address && typeof address === "object") {
+      logger?.info?.(`[dsh-mneme] standalone API listening on http://${address.address}:${address.port}`);
+    }
+  }).catch(() => { /* already logged by the error handler above */ });
+
+  const api = { server, port: boundPort, host: boundHost, token, ready };
+  // After the OS assigns the real port (bind port 0), reflect it for callers.
+  ready.then(() => {
+    const address = server.address();
+    if (address && typeof address === "object") api.port = address.port;
+  }).catch(() => { /* bind failed: port stays as configured */ });
+  return api;
+}

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -1,9 +1,23 @@
 import { URL } from "node:url";
-import { timingSafeEqual } from "node:crypto";
+import { timingSafeEqual, randomBytes } from "node:crypto";
 
 function sendJson(res, status, payload) {
   res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(payload));
+}
+
+// Defaults for the standalone external API — keep in step with the schema
+// defaults in config.js (externalApiPort / externalApiHost).
+const EXTERNAL_API_DEFAULTS = { enabled: false, port: 8790, host: "127.0.0.1" };
+
+/** Merge persisted external-api kv over the defaults for client display. */
+function fullExternalConfig(kv = {}) {
+  return {
+    enabled: kv.enabled === true,
+    port: Number.isInteger(kv.port) && kv.port > 0 ? kv.port : EXTERNAL_API_DEFAULTS.port,
+    host: kv.host || EXTERNAL_API_DEFAULTS.host,
+    token: kv.token || ""
+  };
 }
 
 /**
@@ -88,8 +102,20 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
         const type = url.searchParams.get("type") ?? undefined;
         const limit = Number(url.searchParams.get("limit") ?? 50);
         const offset = Number(url.searchParams.get("offset") ?? 0);
-        const items = service.toApiList(service.list({ type, limit, offset }));
-        sendJson(res, 200, { items, total: service.count(type) });
+        // order=chrono: pure newest-first for paged browsing; default keeps
+        // the importance-ranked order other callers rely on.
+        const order = url.searchParams.get("order") ?? undefined;
+        // minImportance: numeric lower bound on importance (absent/NaN → no
+        // floor); source: exact match on the source column (empty → no filter).
+        const minRaw = url.searchParams.get("minImportance");
+        const minImportance = minRaw !== null && minRaw !== "" && !Number.isNaN(Number(minRaw))
+          ? Number(minRaw)
+          : undefined;
+        const source = url.searchParams.get("source") || undefined;
+        const items = service.toApiList(service.list({ type, limit, offset, order, minImportance, source }));
+        // Total honors the same filters as the rows, or the pager's
+        // has-more math breaks whenever minImportance/source is active.
+        sendJson(res, 200, { items, total: service.count(type, { minImportance, source }) });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }
@@ -169,6 +195,40 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           });
         }
         sendJson(res, 200, { profile: settings.getProfile() });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- delete one memory by id ---
+  // Mutation route: apiToken-gated like the profile/rules writes above. POST
+  // body is JSON { id }. store.remove deletes silently, so existence is checked
+  // up front to give clients a distinguishable 404 instead of a fake success.
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/delete",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") {
+          sendJson(res, 404, { error: "not-found" });
+          return;
+        }
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then((text) => {
+          const body = parseBody(text);
+          const id = typeof body.id === "string" ? body.id.trim() : "";
+          if (!id) {
+            sendJson(res, 400, { error: "missing-id" });
+            return;
+          }
+          if (!service.getById(id)) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          service.remove(id);
+          sendJson(res, 200, { ok: true });
+        });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }
@@ -704,6 +764,81 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // --- panel mode (v0.7.12): light / standard -------------------------------
+  // Persists the Web panel's feature preset into the settings kv
+  // ("panel_mode"). PUT requires auth like every other settings write; the
+  // value is validated against the enum. index.js applies the light preset on
+  // the next boot (persisted mode wins over the bundle config).
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/mode",
+    handler(req, res) {
+      try {
+        if (req.method === "PUT" || req.method === "POST") {
+          if (!requireAuth(req, res, apiToken)) return;
+          return readBody(req).then((text) => {
+            const body = parseBody(text);
+            if (body.mode !== "light" && body.mode !== "standard") {
+              sendJson(res, 400, { error: "invalid-mode" });
+              return;
+            }
+            settings.setPanelMode(body.mode);
+            sendJson(res, 200, { mode: settings.getPanelMode() });
+          });
+        }
+        sendJson(res, 200, { mode: settings.getPanelMode() });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- external API settings (the standalone server's panel-facing config) ---
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/external-api",
+    handler(req, res) {
+      try {
+        if (req.method === "PUT" || req.method === "POST") {
+          if (!requireAuth(req, res, apiToken)) return;
+          return readBody(req).then((text) => {
+            const body = parseBody(text);
+            const patch = {};
+            if (body.enabled !== undefined) patch.enabled = body.enabled === true;
+            if (body.port !== undefined) {
+              const port = Number(body.port);
+              if (!Number.isInteger(port) || port < 1 || port > 65535) {
+                sendJson(res, 400, { error: "invalid-port" });
+                return;
+              }
+              patch.port = port;
+            }
+            if (body.host !== undefined) {
+              const host = String(body.host).trim();
+              if (!host || host.includes("://")) {
+                sendJson(res, 400, { error: "invalid-host" });
+                return;
+              }
+              patch.host = host;
+            }
+            sendJson(res, 200, { config: fullExternalConfig(settings.setExternalApi(patch)) });
+          });
+        }
+        // GET: always hand back a token — the standalone server generates its
+        // own on first enabled boot, but the panel displays it before that,
+        // so materialize and persist one here.
+        const kv = settings.getExternalApi() ?? {};
+        if (!kv.token) {
+          kv.token = randomBytes(24).toString("base64url");
+          settings.setExternalApi({ token: kv.token });
+        }
+        sendJson(res, 200, { config: fullExternalConfig(kv) });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
   // --- custom commands ---
   register({
     kind: "exact",
@@ -818,7 +953,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   });
 
   return {
-    routes: 20,
+    routes: 25,
     dispose: () => {
       for (const dispose of disposers) dispose();
     }

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -39,6 +39,41 @@ window.__ModuleLoader__.load({
       h("circle", { cx: 12.4, cy: 12, r: 1.8, fill: "currentColor" })
     );
 
+    // Stroke icons, Lucide path data (ISC license) inlined as [tag, attrs]
+    // tuples — the plugin runtime cannot require third-party libraries, so
+    // the data ships with the bundle (the morphicons/lucide pairing the
+    // data package documents, minus the runtime dependency). Stroke picks
+    // up currentColor, so icons follow the host theme tokens.
+    const ICON_PATHS = {
+      database: [["ellipse", { cx: "12", cy: "5", rx: "9", ry: "3" }], ["path", { d: "M3 5V19A9 3 0 0 0 21 19V5" }], ["path", { d: "M3 12A9 3 0 0 0 21 12" }]],
+      waypoints: [["path", { d: "m10.586 5.414-5.172 5.172" }], ["path", { d: "m18.586 13.414-5.172 5.172" }], ["path", { d: "M6 12h12" }], ["circle", { cx: "12", cy: "20", r: "2" }], ["circle", { cx: "12", cy: "4", r: "2" }], ["circle", { cx: "20", cy: "12", r: "2" }], ["circle", { cx: "4", cy: "12", r: "2" }]],
+      settings: [["path", { d: "M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" }], ["circle", { cx: "12", cy: "12", r: "3" }]],
+      search: [["path", { d: "m21 21-4.34-4.34" }], ["circle", { cx: "11", cy: "11", r: "8" }]],
+      refresh: [["path", { d: "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" }], ["path", { d: "M21 3v5h-5" }], ["path", { d: "M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" }], ["path", { d: "M8 16H3v5" }]],
+      chevronDown: [["path", { d: "m6 9 6 6 6-6" }]],
+      chevronRight: [["path", { d: "m9 18 6-6-6-6" }]],
+      copy: [["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2" }], ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" }]],
+      check: [["path", { d: "M20 6 9 17l-5-5" }]],
+      inbox: [["polyline", { points: "22 12 16 12 14 15 10 15 8 12 2 12" }], ["path", { d: "M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" }]],
+      activity: [["path", { d: "M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" }]]
+    };
+    const Icon = ({ name, size = 16, className }) => {
+      const parts = ICON_PATHS[name];
+      if (!parts) return null;
+      return h("svg", {
+        width: size,
+        height: size,
+        viewBox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        strokeWidth: 2,
+        strokeLinecap: "round",
+        strokeLinejoin: "round",
+        className,
+        "aria-hidden": "true"
+      }, parts.map(([tag, attrs], i) => h(tag, { key: i, ...attrs })));
+    };
+
     // Unified API fetcher: attaches the optional apiToken (set in the settings
     // view, persisted in localStorage) as a Bearer header. When no token has
     // been configured the header is omitted and the API stays open (default).
@@ -181,7 +216,45 @@ window.__ModuleLoader__.load({
         "memory.wikilink.forward": "此记忆链接到",
         "memory.wikilink.empty": "暂无关联记忆",
         "memory.wikilink.loading": "加载中…",
-        "memory.wikilink.unresolved": "目标记忆不存在"
+        "memory.wikilink.unresolved": "目标记忆不存在",
+        "memory.entity.person": "人物",
+        "memory.entity.project": "项目",
+        "memory.entity.concept": "概念",
+        "memory.entity.technology": "技术",
+        "memory.entity.organization": "组织",
+        "memory.entity.other": "其他",
+        "memory.explorer.tabStatus": "状态",
+        "memory.explorer.loadMore": "加载更多",
+        "memory.explorer.delete": "删除",
+        "memory.explorer.confirmDelete": "确认删除?",
+        "memory.explorer.cancel": "取消",
+        "memory.explorer.deleted": "已删除",
+        "memory.explorer.deleteFailed": "删除失败",
+        "memory.status.memories": "记忆总数",
+        "memory.status.entities": "实体",
+        "memory.status.vector": "向量索引",
+        "memory.status.vectorOn": "已启用",
+        "memory.status.vectorOff": "未启用",
+        "memory.status.llm": "LLM 消耗",
+        "memory.status.llmCalls": "近 7 天 · {n} 次调用",
+        "memory.status.error": "加载失败",
+        "memory.settings.mode.title": "运行模式",
+        "memory.settings.mode.desc": "轻量模式只保留核心的记忆读写与自动注入（关闭 autoDream 巩固、实体抽取、语义搜索等高级功能），适合只想「记住偏好」的轻量使用；标准模式开启全部功能。",
+        "memory.settings.mode.light": "轻量",
+        "memory.settings.mode.standard": "标准",
+        "memory.settings.mode.savedHint": "已保存，重启 DSH 后生效",
+        "memory.settings.mode.offList": "已关闭：巩固（autoDream）· 实体抽取 · 语义搜索",
+        "memory.settings.extapi.title": "外部访问 API",
+        "memory.settings.extapi.desc": "独立 HTTP 服务，供其他插件 / CLI / 桌面工具读写记忆，默认绑定 127.0.0.1。重启 DSH 后生效。",
+        "memory.settings.extapi.enabled": "启用",
+        "memory.settings.extapi.disabled": "停用",
+        "memory.settings.extapi.address": "地址",
+        "memory.settings.extapi.port": "端口",
+        "memory.settings.extapi.token": "Token",
+        "memory.settings.extapi.copy": "复制",
+        "memory.settings.extapi.copied": "已复制",
+        "memory.settings.extapi.savedHint": "已保存，重启 DSH 后生效",
+        "memory.settings.extapi.invalidPort": "端口需为 1-65535 的数字"
       },
       en: {
         "memory.panel.empty": "No memories yet",
@@ -307,7 +380,45 @@ window.__ModuleLoader__.load({
         "memory.wikilink.forward": "This memory links to",
         "memory.wikilink.empty": "No linked memories",
         "memory.wikilink.loading": "Loading…",
-        "memory.wikilink.unresolved": "Target memory not found"
+        "memory.wikilink.unresolved": "Target memory not found",
+        "memory.entity.person": "People",
+        "memory.entity.project": "Projects",
+        "memory.entity.concept": "Concepts",
+        "memory.entity.technology": "Technologies",
+        "memory.entity.organization": "Organizations",
+        "memory.entity.other": "Others",
+        "memory.explorer.tabStatus": "Status",
+        "memory.explorer.loadMore": "Load more",
+        "memory.explorer.delete": "Delete",
+        "memory.explorer.confirmDelete": "Confirm delete?",
+        "memory.explorer.cancel": "Cancel",
+        "memory.explorer.deleted": "Deleted",
+        "memory.explorer.deleteFailed": "Delete failed",
+        "memory.status.memories": "Total memories",
+        "memory.status.entities": "Entities",
+        "memory.status.vector": "Vector index",
+        "memory.status.vectorOn": "Enabled",
+        "memory.status.vectorOff": "Disabled",
+        "memory.status.llm": "LLM Usage",
+        "memory.status.llmCalls": "Last 7 days · {n} calls",
+        "memory.status.error": "Failed to load",
+        "memory.settings.mode.title": "Runtime mode",
+        "memory.settings.mode.desc": "Light mode keeps only the core memory read/write and auto-injection (autoDream consolidation, entity extraction and semantic search are off) — for light use where you just want preferences remembered. Standard mode enables everything.",
+        "memory.settings.mode.light": "Light",
+        "memory.settings.mode.standard": "Standard",
+        "memory.settings.mode.savedHint": "Saved. Takes effect after restarting DSH",
+        "memory.settings.mode.offList": "Off: consolidation (autoDream) · entity extraction · semantic search",
+        "memory.settings.extapi.title": "External API",
+        "memory.settings.extapi.desc": "A standalone HTTP service for other plugins / CLIs / desktop tools to read and write memories, bound to 127.0.0.1 by default. Takes effect after restarting DSH.",
+        "memory.settings.extapi.enabled": "Enable",
+        "memory.settings.extapi.disabled": "Disable",
+        "memory.settings.extapi.address": "Address",
+        "memory.settings.extapi.port": "Port",
+        "memory.settings.extapi.token": "Token",
+        "memory.settings.extapi.copy": "Copy",
+        "memory.settings.extapi.copied": "Copied",
+        "memory.settings.extapi.savedHint": "Saved. Takes effect after restarting DSH",
+        "memory.settings.extapi.invalidPort": "Port must be a number between 1 and 65535"
       }
     };
 
@@ -563,7 +674,35 @@ window.__ModuleLoader__.load({
       ".mneme-overlaybar{flex:none;display:flex;align-items:center;justify-content:flex-start;gap:12px;height:44px;padding:0 12px 0 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
       ".mneme-overlaytitle{font-size:14px;font-weight:600;color:var(--dsw-alias-label-primary)}",
       ".mneme-overlaybody{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}",
-      "@keyframes mneme-fadein{from{opacity:0}to{opacity:1}}"
+      "@keyframes mneme-fadein{from{opacity:0}to{opacity:1}}",
+      // --- explorer refresh: paged month tree, sticky headers, inline icons ---
+      ".mneme-vtabico{flex:none;opacity:.85}",
+      ".mneme-xsearchwrap{position:relative;flex:none}",
+      ".mneme-xsearchico{position:absolute;left:9px;top:50%;transform:translateY(-50%);color:var(--dsw-alias-label-tertiary);pointer-events:none}",
+      ".mneme-xsearchwrap .mneme-xsearch{padding-left:27px}",
+      ".mneme-footbtn{display:inline-flex;align-items:center;gap:4px}",
+      ".mneme-xmonth{position:sticky;top:0;z-index:2;background:var(--dsw-alias-bg-layer-1);display:flex;align-items:center;gap:6px}",
+      ".mneme-xmonthcount{margin-left:auto;color:var(--dsw-alias-label-tertiary);font-weight:400;font-variant-numeric:tabular-nums}",
+      ".mneme-xcaret{display:inline-flex;align-items:center;justify-content:center;color:var(--dsw-alias-label-tertiary)}",
+      ".mneme-xmore{display:flex;justify-content:center;align-items:center;padding:10px 0 24px;min-height:20px}",
+      ".mneme-xemptyico{display:block;margin:0 auto 6px;opacity:.7}",
+      // --- status sub-view: responsive stat-card grid (auto-fill, ~220px min) ---
+      ".mneme-status{flex:1;min-height:0;overflow-y:auto;padding:16px 20px 32px;box-sizing:border-box}",
+      ".mneme-statusgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;max-width:960px}",
+      ".mneme-statuscard{min-width:0;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:14px}",
+      ".mneme-statusnum{font-size:24px;font-weight:600;line-height:32px;color:var(--dsw-alias-label-primary);font-variant-numeric:tabular-nums}",
+      ".mneme-statuscap{margin-top:4px;font-size:13px;line-height:19px;color:var(--dsw-alias-label-tertiary);word-break:break-word}",
+      // --- destructive actions: red outline = delete, solid red = confirm ---
+      ".mneme-btndanger{color:var(--dsw-alias-state-error,#c33);border-color:var(--dsw-alias-state-error,#c33)}",
+      ".mneme-btndanger:hover{background:color-mix(in srgb,var(--dsw-alias-state-error,#c33) 12%,transparent)}",
+      ".mneme-btndangerconfirm{background:var(--dsw-alias-state-error,#c33);border-color:var(--dsw-alias-state-error,#c33);color:#fff}",
+      ".mneme-btndangerconfirm:hover{filter:brightness(.9)}",
+      // --- settings cards: boxed cards for the runtime-mode and external-API
+      // sections — each card owns its fetch/PUT state, so it renders as a
+      // self-contained unit inside the stacked settings view ---
+      ".mneme-set-card{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:14px;margin-bottom:12px}",
+      ".mneme-set-token{font-family:monospace;font-size:12px;padding:7px 10px;border:1px solid var(--dsw-alias-border-l2);border-radius:8px;background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);word-break:break-all;user-select:all}",
+      ".mneme-set-hint{font-size:12px;color:var(--dsw-alias-label-tertiary)}"
     ].join("\n");
     if (typeof document !== "undefined" && document.querySelector(`style[data-plugin-css="${CSS_TAG}"]`) === null) {
       const tag = document.createElement("style");
@@ -1076,6 +1215,21 @@ window.__ModuleLoader__.load({
       const [autoTagSaved, setAutoTagSaved] = react.useState(false);
       const [showSidebarTrigger, setShowSidebarTrigger] = react.useState(true);
       const [sidebarTriggerSaved, setSidebarTriggerSaved] = react.useState(false);
+      // 运行模式 — light vs standard; null = still loading. The card keeps
+      // its own busy/saved/error state so it never blocks the others.
+      const [mode, setMode] = react.useState(null);
+      const [modeBusy, setModeBusy] = react.useState(false);
+      const [modeSaved, setModeSaved] = react.useState(false);
+      const [modeError, setModeError] = react.useState("");
+      // 外部访问 API — config fetched from the backend (the token is generated
+      // and kept server-side); host/port inputs are drafts, PUT only on save.
+      const [extapi, setExtapi] = react.useState(null);
+      const [extapiHost, setExtapiHost] = react.useState("127.0.0.1");
+      const [extapiPort, setExtapiPort] = react.useState("");
+      const [extapiBusy, setExtapiBusy] = react.useState(false);
+      const [extapiSaved, setExtapiSaved] = react.useState(false);
+      const [extapiCopied, setExtapiCopied] = react.useState(false);
+      const [extapiError, setExtapiError] = react.useState("");
 
       const load = react.useCallback(async () => {
         try {
@@ -1100,6 +1254,34 @@ window.__ModuleLoader__.load({
       }, []);
 
       react.useEffect(() => { load(); }, [load]);
+
+      // Runtime mode + external API — two independent fetches: one failing
+      // endpoint only errors its own card, never the other one.
+      react.useEffect(() => {
+        let cancelled = false;
+        const toErr = (err) => (err && err.message) || "failed";
+        apiFetch("/api/dsh-mneme/mode")
+          .then((res) => { if (!res.ok) throw new Error("HTTP " + res.status); return res.json(); })
+          .then((j) => { if (!cancelled) setMode(j.mode === "light" ? "light" : "standard"); })
+          .catch((err) => { if (!cancelled) setModeError(toErr(err)); });
+        apiFetch("/api/dsh-mneme/external-api")
+          .then((res) => { if (!res.ok) throw new Error("HTTP " + res.status); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            const cfg = (j && j.config) || {};
+            const next = {
+              enabled: !!cfg.enabled,
+              host: cfg.host || "127.0.0.1",
+              port: Number(cfg.port) || 0,
+              token: cfg.token || ""
+            };
+            setExtapi(next);
+            setExtapiHost(next.host);
+            setExtapiPort(next.port ? String(next.port) : "");
+          })
+          .catch((err) => { if (!cancelled) setExtapiError(toErr(err)); });
+        return () => { cancelled = true; };
+      }, []);
 
       async function saveProfile() {
         try {
@@ -1216,6 +1398,85 @@ window.__ModuleLoader__.load({
         } catch { /* ignore */ }
       }
 
+      // Runtime mode: optimistic chip flip, rolled back on failure. Both
+      // changes only take effect after a DSH restart — the saved hint says so.
+      async function saveMode(next) {
+        if (modeBusy) return;
+        const prev = mode;
+        setModeBusy(true);
+        setModeError("");
+        setMode(next);
+        try {
+          const res = await apiFetch("/api/dsh-mneme/mode", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: next })
+          });
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          setModeSaved(true);
+          setTimeout(() => setModeSaved(false), 2500);
+        } catch (err) {
+          setMode(prev);
+          setModeError((err && err.message) || "failed");
+        }
+        setModeBusy(false);
+      }
+
+      // External API: the backend owns the token and returns the full config,
+      // so every PUT response refreshes host/port/token from the server.
+      async function putExtapi(body) {
+        setExtapiBusy(true);
+        setExtapiError("");
+        try {
+          const res = await apiFetch("/api/dsh-mneme/external-api", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body)
+          });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || "HTTP " + res.status);
+          const cfg = data.config || {};
+          const next = {
+            enabled: !!cfg.enabled,
+            host: cfg.host || "127.0.0.1",
+            port: Number(cfg.port) || 0,
+            token: cfg.token || ""
+          };
+          setExtapi(next);
+          setExtapiHost(next.host);
+          setExtapiPort(next.port ? String(next.port) : "");
+          setExtapiSaved(true);
+          setTimeout(() => setExtapiSaved(false), 2500);
+        } catch (err) {
+          setExtapiError((err && err.message) || "failed");
+        }
+        setExtapiBusy(false);
+      }
+
+      function saveExtapiEnabled(enabled) {
+        if (extapiBusy) return;
+        putExtapi({ enabled });
+      }
+
+      function saveExtapiAddress() {
+        if (extapiBusy) return;
+        const raw = String(extapiPort).trim();
+        const port = Number(raw);
+        if (!/^\d+$/.test(raw) || port < 1 || port > 65535) {
+          setExtapiError(t("memory.settings.extapi.invalidPort"));
+          return;
+        }
+        putExtapi({ port, host: extapiHost.trim() || "127.0.0.1" });
+      }
+
+      function copyExtapiToken() {
+        const token = extapi ? extapi.token || "" : "";
+        navigator.clipboard?.writeText(token).then(
+          () => { setExtapiCopied(true); setTimeout(() => setExtapiCopied(false), 1500); },
+          () => {}
+        );
+      }
+
       return h("div", null,
         h("section", { className: "mneme-set-sec" },
           h("div", { className: "mneme-set-title" }, t("memory.settings.profile")),
@@ -1288,6 +1549,86 @@ window.__ModuleLoader__.load({
               cmdError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error, #c33)" } }, cmdError)
             )
           )
+        ),
+        // 运行模式 — light vs standard chip radios; each click PUTs and the
+        // change only lands after a DSH restart (green saved hint says so).
+        h("section", { className: "mneme-set-card" },
+          h("div", { className: "mneme-set-title" }, t("memory.settings.mode.title")),
+          h("div", { className: "mneme-set-desc" }, t("memory.settings.mode.desc")),
+          modeError && h("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)", marginBottom: 8 } }, modeError),
+          mode === null && !modeError
+            ? h("div", { className: "mneme-set-hint" }, "…")
+            : h(react.Fragment, null,
+                h("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" } },
+                  h("button", {
+                    className: mode === "light" ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: modeBusy,
+                    onClick: () => saveMode("light")
+                  }, t("memory.settings.mode.light")),
+                  h("button", {
+                    className: mode === "standard" ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: modeBusy,
+                    onClick: () => saveMode("standard")
+                  }, t("memory.settings.mode.standard")),
+                  modeSaved && h("span", { className: "mneme-saved" }, t("memory.settings.mode.savedHint"))
+                ),
+                mode === "light" && h("div", { className: "mneme-set-hint", style: { marginTop: 8 } },
+                  t("memory.settings.mode.offList"))
+              )
+        ),
+        // 外部访问 API — standalone HTTP service for plugins/CLI/desktop tools;
+        // the token is generated and kept by the backend, so it is read-only
+        // here with a copy affordance. Changes need a DSH restart.
+        h("section", { className: "mneme-set-card" },
+          h("div", { className: "mneme-set-title" }, t("memory.settings.extapi.title")),
+          h("div", { className: "mneme-set-desc" }, t("memory.settings.extapi.desc")),
+          extapiError && h("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)", marginBottom: 8 } }, extapiError),
+          extapi === null && !extapiError
+            ? h("div", { className: "mneme-set-hint" }, "…")
+            : h(react.Fragment, null,
+                h("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" } },
+                  h("button", {
+                    className: extapi && extapi.enabled ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: extapiBusy,
+                    onClick: () => saveExtapiEnabled(true)
+                  }, t("memory.settings.extapi.enabled")),
+                  h("button", {
+                    className: extapi && !extapi.enabled ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: extapiBusy,
+                    onClick: () => saveExtapiEnabled(false)
+                  }, t("memory.settings.extapi.disabled")),
+                  extapiSaved && h("span", { className: "mneme-saved" }, t("memory.settings.extapi.savedHint"))
+                ),
+                extapi && extapi.enabled && h(react.Fragment, null,
+                  h("div", { className: "mneme-set-hint", style: { marginTop: 10 } },
+                    `${t("memory.settings.extapi.address")}: http://${extapi.host}:${extapi.port}`),
+                  h("div", { style: { display: "flex", gap: 8, marginTop: 8 } },
+                    h("input", {
+                      className: "mneme-set-input",
+                      style: { marginBottom: 0, flex: 2, minWidth: 0, width: "auto" },
+                      value: extapiHost,
+                      placeholder: "127.0.0.1",
+                      onChange: (e) => setExtapiHost(e.target.value)
+                    }),
+                    h("input", {
+                      className: "mneme-set-input",
+                      style: { marginBottom: 0, flex: 1, minWidth: 0, width: "auto" },
+                      value: extapiPort,
+                      placeholder: t("memory.settings.extapi.port"),
+                      inputMode: "numeric",
+                      onChange: (e) => setExtapiPort(e.target.value)
+                    }),
+                    h("button", { className: "mneme-btn", disabled: extapiBusy, onClick: saveExtapiAddress },
+                      t("memory.settings.vectorSave"))
+                  ),
+                  h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginTop: 10 } },
+                    h("div", { className: "mneme-set-token", style: { flex: 1, minWidth: 0 } }, extapi.token || "—"),
+                    h("button", { className: "mneme-btn", onClick: copyExtapiToken },
+                      t("memory.settings.extapi.copy")),
+                    extapiCopied && h("span", { className: "mneme-saved" }, t("memory.settings.extapi.copied"))
+                  )
+                )
+              )
         ),
         h("section", { className: "mneme-set-sec" },
           h("div", { className: "mneme-set-title" }, t("memory.settings.autoTagTitle")),
@@ -1734,12 +2075,160 @@ window.__ModuleLoader__.load({
     }
 
     const EXPLORER_TYPES = ["preference", "project", "decision", "summary", "history", "user", "fact"];
+    const PAGE_SIZE = 100; // browse page size — the tree grows by 100-row pages
+
+    // --- Status sub-view: a responsive grid of stat cards. Every card owns
+    // its fetch, loading ("…") and error state, so one failing endpoint
+    // never blanks or blocks the others. ---
+    function StatusCard({ t, title, loading, error, num, cap }) {
+      return h("div", { className: "mneme-statuscard" },
+        h("div", { className: "mneme-xcolhead" }, title),
+        loading
+          ? h("div", { className: "mneme-statusnum" }, "…")
+          : error
+            ? h("div", { className: "mneme-statuscap", style: { color: "var(--dsw-alias-state-error,#c33)" } }, t("memory.status.error"))
+            : h(react.Fragment, null,
+                h("div", { className: "mneme-statusnum" }, num),
+                cap ? h("div", { className: "mneme-statuscap" }, cap) : null
+              )
+      );
+    }
+
+    // 记忆总数 — list total plus per-type subtotals; each subtotal request
+    // may fail independently (rendered as "—") without sinking the card.
+    function MemoriesStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, total: 0, byType: [] });
+      useEffect(() => {
+        let cancelled = false;
+        const one = (ty) =>
+          apiFetch(`/api/dsh-mneme/list?limit=1&order=chrono${ty ? `&type=${encodeURIComponent(ty)}` : ""}`)
+            .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); });
+        one()
+          .then((all) => {
+            if (cancelled) return null;
+            const total = all.total || 0;
+            return Promise.all(EXPLORER_TYPES.map((ty) =>
+              one(ty).then((j) => [ty, j.total || 0]).catch(() => [ty, null])
+            )).then((byType) => {
+              if (!cancelled) setState({ loading: false, error: false, total, byType });
+            });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, total: 0, byType: [] }); });
+        return () => { cancelled = true; };
+      }, []);
+      const cap = state.byType
+        .map(([ty, n]) => `${typeLabel(t, ty)} ${n === null ? "—" : n}`)
+        .join(" · ");
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.memories"),
+        loading: state.loading,
+        error: state.error,
+        num: state.total.toLocaleString(),
+        cap
+      });
+    }
+
+    // 实体 — directory snapshot grouped by entity type.
+    function EntitiesStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, total: 0, byType: [] });
+      useEffect(() => {
+        let cancelled = false;
+        const order = ["organization", "person", "project", "technology", "concept"];
+        apiFetch("/api/dsh-mneme/entities?limit=500")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            const list = Array.isArray(j.entities) ? j.entities : [];
+            const counts = new Map();
+            for (const e of list) {
+              const key = order.includes(e.type) ? e.type : "other";
+              counts.set(key, (counts.get(key) || 0) + 1);
+            }
+            const byType = order.concat("other")
+              .filter((k) => counts.has(k))
+              .map((k) => [k, counts.get(k)]);
+            setState({ loading: false, error: false, total: list.length, byType });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, total: 0, byType: [] }); });
+        return () => { cancelled = true; };
+      }, []);
+      const cap = state.byType.map(([ty, n]) => `${entityTypeLabel(t, ty)} ${n}`).join(" · ");
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.entities"),
+        loading: state.loading,
+        error: state.error,
+        num: state.total.toLocaleString(),
+        cap
+      });
+    }
+
+    // 向量索引 — whether semantic recall is switched on.
+    function VectorStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, enabled: false });
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/vector-config")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((j) => { if (!cancelled) setState({ loading: false, error: false, enabled: !!j.config?.enabled }); })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, enabled: false }); });
+        return () => { cancelled = true; };
+      }, []);
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.vector"),
+        loading: state.loading,
+        error: state.error,
+        num: state.enabled ? t("memory.status.vectorOn") : t("memory.status.vectorOff"),
+        cap: ""
+      });
+    }
+
+    // LLM 消耗 — calls + tokens over the trailing 7 days.
+    function LlmStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, calls: 0, tokens: 0 });
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/semantic/llm-audit/stats?days=7")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            const s = j && typeof j === "object" ? (j.stats || j) : {};
+            setState({ loading: false, error: false, calls: Number(s.total_calls ?? 0), tokens: Number(s.total_tokens ?? 0) });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, calls: 0, tokens: 0 }); });
+        return () => { cancelled = true; };
+      }, []);
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.llm"),
+        loading: state.loading,
+        error: state.error,
+        num: state.tokens.toLocaleString(),
+        cap: t("memory.status.llmCalls").replace("{n}", state.calls.toLocaleString())
+      });
+    }
+
+    function StatusPanel({ t }) {
+      return h("div", { className: "mneme-status" },
+        h("div", { className: "mneme-statusgrid" },
+          h(MemoriesStatusCard, { t }),
+          h(EntitiesStatusCard, { t }),
+          h(VectorStatusCard, { t }),
+          h(LlmStatusCard, { t })
+        )
+      );
+    }
 
     function MemoryExplorer({ t }) {
-      const [view, setView] = useState("memory"); // memory | overview | directory | graph | settings
-      const [items, setItems] = useState([]);
+      const [view, setView] = useState("memory"); // memory | overview | directory | status | graph | settings
+      const [items, setItems] = useState([]); // loaded browse pages, chrono desc
+      const [total, setTotal] = useState(0); // server count for the current type filter
       const [loading, setLoading] = useState(true);
+      const [loadingMore, setLoadingMore] = useState(false);
       const [type, setType] = useState("all");
+      const [minImp, setMinImp] = useState(0); // importance floor: 0 = all, else 3/4/5
       const [query, setQuery] = useState("");
       const [semantic, setSemantic] = useState(false);
       const [vecEnabled, setVecEnabled] = useState(false);
@@ -1747,12 +2236,18 @@ window.__ModuleLoader__.load({
       const [remoteItems, setRemoteItems] = useState(null);
       const [selectedId, setSelectedId] = useState(null);
       const [collapsed, setCollapsed] = useState({});
+      // paged month tree: null = 仅最新一个月展开, else a per-month override map
+      const [expandedMonths, setExpandedMonths] = useState(null);
       // v0.6.3 directory sub-view: its own folder-collapse state, kept in
       // MemoryExplorer so switching tabs does not lose it and jumpToMemory's
       // time-tree reset (setCollapsed({})) cannot clobber it.
       const [dirCollapsed, setDirCollapsed] = useState({});
       const [copied, setCopied] = useState(false);
       const [reloadKey, setReloadKey] = useState(0);
+      const [confirmDelete, setConfirmDelete] = useState(false); // two-step delete armed
+      const [deleting, setDeleting] = useState(false);
+      const [deleteError, setDeleteError] = useState(false);
+      const [deleteMsg, setDeleteMsg] = useState(false); // transient "deleted" notice
       const [graphFocus, setGraphFocus] = useState("");
       // v0.6.2 tag editing state for the detail pane. The authoritative tag set
       // lives server-side (entity_attrs), so it is fetched per selected memory
@@ -1762,6 +2257,7 @@ window.__ModuleLoader__.load({
       const [tagInput, setTagInput] = useState("");
       const [tagAdding, setTagAdding] = useState(false);
       const itemRefs = useRef(new Map());
+      const moreRef = useRef(null);
 
       useEffect(() => {
         apiFetch("/api/dsh-mneme/vector-config")
@@ -1770,36 +2266,116 @@ window.__ModuleLoader__.load({
           .catch(() => {});
       }, []);
 
+      // One query string behind every browse-list fetch (initial page,
+      // loadMore, auto-refresh): the type filter and the importance floor
+      // always travel together, so counts and pagination stay consistent.
+      const filterQS = (type === "all" ? "" : `&type=${encodeURIComponent(type)}`)
+        + (minImp ? `&minImportance=${minImp}` : "");
+      const listUrl = (offset) => `/api/dsh-mneme/list?limit=${PAGE_SIZE}&offset=${offset}${filterQS}&order=chrono`;
+
+      // Browse = paged, pure-chronological pages (order=chrono). The default
+      // importance ordering would interleave months across pages and break
+      // the month tree; type/importance filters run server-side so pages
+      // stay consistent however large the store grows.
       useEffect(() => {
         let cancelled = false;
         setLoading(true);
-        apiFetch("/api/dsh-mneme/list?limit=500")
-          .then((res) => (res.ok ? res.json() : { items: [] }))
-          .then((d) => { if (!cancelled) { setItems(d.items || []); setLoading(false); } })
-          .catch(() => { if (!cancelled) { setItems([]); setLoading(false); } });
+        apiFetch(listUrl(0))
+          .then((res) => (res.ok ? res.json() : { items: [], total: 0 }))
+          .then((d) => {
+            if (cancelled) return;
+            setItems(d.items || []);
+            setTotal(d.total || 0);
+            setExpandedMonths(null); // 新数据回到「仅最新月展开」
+            setLoading(false);
+          })
+          .catch(() => { if (!cancelled) { setItems([]); setTotal(0); setLoading(false); } });
         return () => { cancelled = true; };
-      }, [reloadKey]);
+      }, [reloadKey, filterQS]);
 
-      // Semantic search: server-side ranking replaces the client filter
-      // while enabled and a query is present (debounced). tag: queries always
-      // go server-side (searchMemories resolves them without vector support),
-      // so they bypass the semantic toggle and use the same search endpoint.
+      const canLoadMore = !query.trim() && !remoteItems && items.length < total;
+      const loadMore = useCallback(() => {
+        if (loadingMore || query.trim() || remoteItems) return;
+        if (items.length >= total) return;
+        setLoadingMore(true);
+        apiFetch(listUrl(items.length))
+          .then((res) => (res.ok ? res.json() : { items: [] }))
+          .then((d) => setItems((cur) => cur.concat(d.items || [])))
+          .catch(() => {})
+          .finally(() => setLoadingMore(false));
+      }, [items.length, total, loadingMore, query, remoteItems, filterQS]);
+
+      // Infinite scroll: a sentinel just past the loaded rows pulls the next
+      // page while browsing (search results arrive complete already). The
+      // scroll container is the timeline card.
       useEffect(() => {
-        const q = query.trim();
-        if ((!semantic && !q.startsWith("tag:")) || !q || q.startsWith("entity:")) { setRemoteItems(null); return; }
+        const el = moreRef.current;
+        if (!el || !canLoadMore) return undefined;
+        const io = new IntersectionObserver((entries) => {
+          if (entries.some((e) => e.isIntersecting)) loadMore();
+        }, { root: el.closest(".mneme-card--tree"), rootMargin: "240px" });
+        io.observe(el);
+        return () => io.disconnect();
+      }, [canLoadMore, loadMore]);
+
+      // Search hits the server so matches are global — not limited to the
+      // loaded pages: keyword = literal text; vector = semantic ranking
+      // (the pipeline falls back to keyword when no embedder is available).
+      // tag: queries ride the same endpoint (the server resolves them
+      // without vector support); entity: is the graph grammar and just
+      // clears the list.
+      useEffect(() => {
+        const query0 = query.trim();
+        if (!query0 || query0.startsWith("entity:")) { setRemoteItems(null); return; }
         let cancelled = false;
         const timer = setTimeout(() => {
-          apiFetch(`/api/dsh-mneme/search?q=${encodeURIComponent(q)}&mode=vector&topK=${searchTopK}`)
+          const mode = semantic ? "vector" : "keyword";
+          apiFetch(`/api/dsh-mneme/search?q=${encodeURIComponent(query0)}&mode=${mode}&topK=${searchTopK}`)
             .then((res) => (res.ok ? res.json() : { items: [] }))
             .then((d) => { if (!cancelled) setRemoteItems(d.items || []); })
             .catch(() => { if (!cancelled) setRemoteItems([]); });
         }, 250);
         return () => { cancelled = true; clearTimeout(timer); };
-      }, [semantic, query, searchTopK]);
+      }, [query, semantic, searchTopK]);
+
+      // Live view: while the memory tab is open, quietly re-fetch page 1
+      // every 30s (and on every activation) so fresh memories surface
+      // without a manual refresh. Later pages stay as loaded.
+      const refreshFirstPage = useCallback(() => {
+        if (query.trim() || remoteItems) return;
+        apiFetch(listUrl(0))
+          .then((res) => (res.ok ? res.json() : null))
+          .then((d) => {
+            if (!d) return;
+            setTotal(d.total || 0);
+            setItems((cur) => {
+              const fresh = d.items || [];
+              const seen = new Set(fresh.map((m) => m.id));
+              return fresh.concat(cur.filter((m) => !seen.has(m.id)));
+            });
+          })
+          .catch(() => {});
+      }, [query, remoteItems, filterQS]);
+
+      useEffect(() => {
+        if (view !== "memory") return undefined;
+        refreshFirstPage();
+        const iv = setInterval(() => {
+          if (document.visibilityState === "visible") refreshFirstPage();
+        }, 30000);
+        return () => clearInterval(iv);
+      }, [view, refreshFirstPage]);
 
       useEffect(() => {
         if (!selectedId) return;
         itemRefs.current.get(selectedId)?.scrollIntoView({ block: "nearest" });
+      }, [selectedId]);
+
+      // The two-step delete arms per selection: switching or clearing the
+      // target disarms it, so a stale confirm can never delete a new pick.
+      useEffect(() => {
+        setConfirmDelete(false);
+        setDeleteError(false);
       }, [selectedId]);
 
       // Load the authoritative tag set for the selected memory (entity_attrs-
@@ -1833,13 +2409,12 @@ window.__ModuleLoader__.load({
       const entityQuery = query.trim().startsWith("entity:")
         ? query.trim().slice(7).trim()
         : "";
+      // Search results were filtered server-side (global); the type filter
+      // still narrows them. Browse mode serves the loaded pages as-is —
+      // type/importance filtering happened in the query.
       const visible = remoteItems
-        ? remoteItems
-        : items.filter((m) => {
-            if (type !== "all" && m.type !== type) return false;
-            if (!q) return true;
-            return (m.title || "").toLowerCase().includes(q) || (m.content || "").toLowerCase().includes(q);
-          });
+        ? remoteItems.filter((m) => type === "all" || m.type === type)
+        : items;
 
       const counts = {};
       for (const m of items) counts[m.type] = (counts[m.type] || 0) + 1;
@@ -1874,8 +2449,9 @@ window.__ModuleLoader__.load({
         }
         curDay.items.push(m);
       }
+      for (const mo of months) mo.count = mo.days.reduce((s, d) => s + d.items.length, 0);
 
-      const selected = items.find((m) => m.id === selectedId) || null;
+      const selected = visible.find((m) => m.id === selectedId) || null;
 
       const copyContent = () => {
         if (!selected) return;
@@ -1921,14 +2497,49 @@ window.__ModuleLoader__.load({
         setQuery(`tag:${tag}`);
       };
 
+      // Two-step delete (no window.confirm): the red button arms, a second
+      // click commits POST /api/dsh-mneme/delete. On success the row leaves
+      // every local view (browse pages + search results), the selection
+      // clears and the total shrinks; failures — 404 included — surface as
+      // a transient red note next to the actions.
+      const deleteSelected = () => {
+        if (!selected || deleting) return;
+        const id = selected.id;
+        setDeleting(true);
+        setDeleteError(false);
+        apiFetch("/api/dsh-mneme/delete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id })
+        })
+          .then((res) => { if (!res.ok) throw new Error("http"); })
+          .then(() => {
+            setItems((cur) => cur.filter((m) => m.id !== id));
+            setRemoteItems((cur) => (cur ? cur.filter((m) => m.id !== id) : cur));
+            setTotal((n) => Math.max(0, n - 1));
+            setSelectedId(null);
+            setConfirmDelete(false);
+            setDeleteMsg(true);
+            setTimeout(() => setDeleteMsg(false), 2500);
+          })
+          .catch(() => {
+            setDeleteError(true);
+            setTimeout(() => setDeleteError(false), 4000);
+          })
+          .finally(() => setDeleting(false));
+      };
+
       // Graph → memory jump: land on the browser tab with filters reset so
-      // the target row is visible, selected and scrolled into view.
+      // the target row is visible, selected and scrolled into view. A target
+      // beyond the loaded pages renders as a single-row result set instead
+      // of pulling page after page to find it.
       const jumpToMemory = (target) => {
         if (!target?.id) return;
         setView("memory");
         setType("all");
         setQuery("");
-        setCollapsed({});
+        setRemoteItems(items.some((m) => m.id === target.id) ? null : [target]);
+        setExpandedMonths(null);
         setSelectedId(target.id);
       };
 
@@ -1958,6 +2569,7 @@ window.__ModuleLoader__.load({
         { key: "memory", label: t("memory.explorer.tabMemory") },
         { key: "overview", label: t("memory.explorer.tabOverview") },
         { key: "directory", label: t("memory.explorer.tabDirectory") },
+        { key: "status", label: t("memory.explorer.tabStatus") },
         { key: "graph", label: t("memory.explorer.tabGraph") },
         { key: "settings", label: t("memory.explorer.tabSettings") }
       ];
@@ -1975,7 +2587,11 @@ window.__ModuleLoader__.load({
               },
                 s.key === "graph"
                   ? h(react.Fragment, null, h(GraphNodesIcon, { size: 16 }), s.label)
-                  : s.label
+                  : s.key === "memory" || s.key === "status" || s.key === "settings"
+                    ? h(react.Fragment, null,
+                        h(Icon, { name: s.key === "memory" ? "database" : s.key === "status" ? "activity" : "settings", size: 14, className: "mneme-vtabico" }),
+                        s.label)
+                    : s.label
               ))
           ),
           ),
@@ -1998,20 +2614,33 @@ window.__ModuleLoader__.load({
                 h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(key) }, title: typeLabel(t, key), "aria-hidden": "true" }),
                 h("span", null, typeLabel(t, key)),
                 h("span", { className: "mneme-xcount2" }, String(counts[key]))
-              ))
+              )),
+            h("div", { className: "mneme-xcolhead", style: { marginLeft: 8 } }, t("memory.explorer.importance")),
+            // importance floor chips: filtering happens server-side so the
+            // paged chronological stream and its totals stay consistent
+            [0, 3, 4, 5].map((v) =>
+              h("button", {
+                key: v,
+                className: minImp === v ? "mneme-chip mneme-active" : "mneme-chip",
+                "aria-pressed": String(minImp === v),
+                onClick: () => setMinImp(v)
+              }, v === 0 ? t("memory.tab.all") : `★${v}+`))
           ),
           // 2. 底部三卡片
           h("div", { className: "mneme-xcards" },
             // 左卡：搜索
             h("div", { className: "mneme-card mneme-card--search", role: "region", "aria-label": t("memory.explorer.searchTitle") },
               h("div", { className: "mneme-xcolhead" }, t("memory.explorer.searchTitle")),
-              h("input", {
-                className: "mneme-search mneme-xsearch",
-                "aria-label": t("memory.explorer.search"),
-                placeholder: t("memory.explorer.search"),
-                value: query,
-                onChange: (e) => setQuery(e.target.value)
-              }),
+              h("div", { className: "mneme-xsearchwrap" },
+                h(Icon, { name: "search", size: 14, className: "mneme-xsearchico" }),
+                h("input", {
+                  className: "mneme-search mneme-xsearch",
+                  "aria-label": t("memory.explorer.search"),
+                  placeholder: t("memory.explorer.search"),
+                  value: query,
+                  onChange: (e) => setQuery(e.target.value)
+                })
+              ),
               entityQuery && h("button", {
                 className: "mneme-entitychip",
                 style: { textAlign: "left", justifyContent: "flex-start" },
@@ -2032,7 +2661,8 @@ window.__ModuleLoader__.load({
               ),
               h("div", { className: "mneme-xrow" },
                 h("span", { className: "mneme-xcount" }, t("memory.explorer.count").replace("{n}", String(visible.length))),
-                h("button", { className: "mneme-footbtn", onClick: () => setReloadKey((k) => k + 1) }, t("memory.explorer.refresh"))
+                h("button", { className: "mneme-footbtn", onClick: () => setReloadKey((k) => k + 1) },
+                  h(Icon, { name: "refresh", size: 12 }), t("memory.explorer.refresh"))
               )
             ),
             // 中卡：时间树
@@ -2040,26 +2670,36 @@ window.__ModuleLoader__.load({
               h("div", { className: "mneme-xcolhead" }, t("memory.explorer.timeline")),
               loading
                 ? h("div", { className: "mneme-xempty" }, "…")
-                : months.length === 0
-                  ? h("div", { className: "mneme-xempty" }, t("memory.explorer.empty"))
-                  : months.map((month) =>
-                      h("div", { key: month.key },
+                : visible.length === 0
+                  ? h("div", { className: "mneme-xempty" },
+                      h(Icon, { name: "inbox", size: 20, className: "mneme-xemptyico" }),
+                      t("memory.explorer.empty"))
+                  : months.map((month, mi) => {
+                      // Only the newest month starts expanded; older months
+                      // stay a one-line header until clicked — a several-
+                      // thousand-row store renders a handful of DOM nodes.
+                      const open = expandedMonths ? !!expandedMonths[month.key] : mi === 0;
+                      return h("div", { key: month.key },
                         h("button", {
                           className: "mneme-xmonth",
-                          "aria-expanded": String(!collapsed[month.key]),
-                          onClick: () => setCollapsed((c) => ({ ...c, [month.key]: !c[month.key] }))
+                          "aria-expanded": String(open),
+                          onClick: () => setExpandedMonths((c) => {
+                            const base = c || (months.length ? { [months[0].key]: true } : {});
+                            return { ...base, [month.key]: !open };
+                          })
                         },
-                          h("span", { className: "mneme-xcaret" }, collapsed[month.key] ? "▸" : "▾"),
-                          month.label
+                          h("span", { className: "mneme-xcaret" }, h(Icon, { name: open ? "chevronDown" : "chevronRight", size: 12 })),
+                          h("span", null, month.label),
+                          h("span", { className: "mneme-xmonthcount" }, String(month.count))
                         ),
-                        !collapsed[month.key] && month.days.map((day) =>
+                        open && month.days.map((day) =>
                           h("div", { key: day.key },
                             h("button", {
                               className: "mneme-xday",
                               "aria-expanded": String(!collapsed[day.key]),
                               onClick: () => setCollapsed((c) => ({ ...c, [day.key]: !c[day.key] }))
                             },
-                              h("span", { className: "mneme-xcaret" }, collapsed[day.key] ? "▸" : "▾"),
+                              h("span", { className: "mneme-xcaret" }, h(Icon, { name: collapsed[day.key] ? "chevronRight" : "chevronDown", size: 11 })),
                               day.label
                             ),
                             !collapsed[day.key] && day.items.map((m) => {
@@ -2078,10 +2718,20 @@ window.__ModuleLoader__.load({
                                 h("span", { className: "mneme-xname" }, m.title || m.content?.slice(0, 40))
                               );
                             })
-                          )
-                      )
-                  )
-            )),
+                          ))
+                      );
+                    }),
+              // load-more sentinel: the next 100-row page arrives when this
+              // row scrolls near (or the button is clicked)
+              h("div", { ref: moreRef, className: "mneme-xmore" },
+                canLoadMore
+                  ? h("button", { className: "mneme-footbtn", disabled: loadingMore, onClick: loadMore },
+                      loadingMore ? "…" : `${t("memory.explorer.loadMore")}（${items.length}/${total}）`)
+                  : (!loading && visible.length > 0 && !q && !remoteItems
+                      ? h("span", { className: "mneme-xcount" }, `${items.length} / ${total}`)
+                      : null)
+              )
+            ),
             // 右卡：详情
             h("div", { className: "mneme-card mneme-card--detail", role: "region", "aria-label": t("memory.explorer.detail") },
               selected
@@ -2143,17 +2793,40 @@ window.__ModuleLoader__.load({
                       ),
                       h("div", { className: "mneme-xdactions" },
                         h("button", { className: "mneme-footbtn", onClick: copyContent },
-                          copied ? t("memory.explorer.copied") : t("memory.explorer.copy"))
+                          h(Icon, { name: copied ? "check" : "copy", size: 12 }),
+                          copied ? t("memory.explorer.copied") : t("memory.explorer.copy")),
+                        // two-step delete: red outline arms, solid red commits
+                        confirmDelete
+                          ? h(react.Fragment, null,
+                              h("button", {
+                                className: "mneme-btn mneme-btndangerconfirm",
+                                disabled: deleting,
+                                onClick: deleteSelected
+                              }, t("memory.explorer.confirmDelete")),
+                              h("button", {
+                                className: "mneme-btn",
+                                onClick: () => setConfirmDelete(false)
+                              }, t("memory.explorer.cancel"))
+                            )
+                          : h("button", {
+                              className: "mneme-btn mneme-btndanger",
+                              onClick: () => setConfirmDelete(true)
+                            }, t("memory.explorer.delete")),
+                        deleteError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)" } },
+                          t("memory.explorer.deleteFailed"))
                       ),
                       h(BacklinksPanel, { memory: selected, t, onJump: jumpToMemory })
                     )
                   )
-                : h("div", { className: "mneme-xempty" }, t("memory.explorer.emptyDetail"))
+                : h("div", { className: "mneme-xempty" },
+                    deleteMsg && h("div", { className: "mneme-saved", style: { marginBottom: 6 } }, t("memory.explorer.deleted")),
+                    t("memory.explorer.emptyDetail"))
             )
           )
         ),
         view === "overview" && h(OverviewPanel, { t, onPickType: pickLayerType }),
         view === "directory" && h(DirectoryPanel, { t, onJump: jumpToMemory, collapsed: dirCollapsed, setCollapsed: setDirCollapsed }),
+        view === "status" && h(StatusPanel, { t }),
         view === "graph" && h(GraphPanel, { t, focusEntity: graphFocus, onJumpMemory: jumpToMemory }),
         view === "settings" && h("div", { className: "mneme-xsettings" },
           h("div", { className: "mneme-xsettings-inner" }, h(SettingsContent, { t }))

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -343,4 +343,56 @@ export const Config = z.object({
   recallRecordDefault: z.boolean().default(true),
   // recall_runs 滚动清理保留天数。
   recallRetentionDays: z.natural().min(1).max(3650).default(90),
+
+  // --- standalone external API (v0.7.12) ------------------------------------
+  // A plain node:http server for ecosystem integrations that cannot reach the
+  // DSH-internal webServer. Disabled by default; when enabled the Bearer token
+  // is persisted in the settings kv ("external_api"), auto-generated on first
+  // boot. Bind host: keep the loopback default — moving it to a non-loopback
+  // address exposes the whole memory store to the network and is the
+  // operator's responsibility.
+  externalApiEnabled: z.boolean().default(false),
+  externalApiPort: z.natural().default(8790),
+  externalApiHost: z.string().default("127.0.0.1"),
+
+  // --- light mode preset (v0.7.12) -------------------------------------------
+  // One switch for low-resource setups: turns off every background/semantic
+  // heavy path (dream consolidation, entity extraction, vector pipeline,
+  // reranker, BM25, semantic dedup / selective inject, sleep mode) while
+  // keeping the core loop (autoInject, autoSummarize, hot memory, quality
+  // filter, keyword search). Applied by applyLightModePreset before the config
+  // reaches any service; a persisted panel_mode="light" (settings kv) counts
+  // as lightMode=true too and wins over the bundle config.
+  lightMode: z.boolean().default(false),
 });
+
+// Fields forced to false by the light-mode preset. Everything not listed here
+// (autoInject, autoSummarize, hotMemory*, memoryQualityFilter, dream
+// thresholds/delays, ...) is left untouched — those are the core loop. The
+// light-mode downstream LLM passes (sleepEntityExtractionEnabled, autoTag)
+// stay out of the list on purpose: their drivers (sleepModeEnabled / autoDream)
+// are already off, so they can never fire.
+const LIGHT_MODE_OFF = [
+  "entityExtractionEnabled",
+  "autoDream",
+  "sleepModeEnabled",
+  "rerankEnabled",
+  "autoReindexOnBoot",
+  "hybridInject",
+  "searchSemanticDedup",
+  "selectiveInjectEnabled",
+  "bm25SearchEnabled"
+];
+
+/**
+ * Apply the light-mode preset to a resolved config object (pure function,
+ * exported for tests). When cfg.lightMode is not exactly true the config is
+ * returned unchanged; otherwise a shallow copy carries false for every heavy
+ * feature. Idempotent and side-effect free.
+ */
+export function applyLightModePreset(cfg) {
+  if (cfg?.lightMode !== true) return cfg;
+  const preset = { ...cfg, lightMode: true };
+  for (const key of LIGHT_MODE_OFF) preset[key] = false;
+  return preset;
+}

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -7,13 +7,14 @@ import { createSummarizer } from "./summarize.js";
 import { createDreamScheduler } from "./dream.js";
 import { createSleepScheduler, runSleep } from "./dream/sleep.js";
 import { createApi } from "./api.js";
+import { createStandaloneApi } from "./api-standalone.js";
 import { createSettings } from "./settings.js";
 import { createCommandManager } from "./commands.js";
 import { createEmbedder } from "./embedding.js";
 import { createEmbedderByProvider } from "./local-embedder.js";
 import { LocalReranker } from "./reranker.js";
 import { createVectorIndex } from "./vector-index.js";
-import { Config } from "./config.js";
+import { Config, applyLightModePreset } from "./config.js";
 import { extractEntities } from "./entities/extractor.js";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
@@ -29,12 +30,12 @@ export { Config };
 // has no prototype, is called normally, and its returned disposer is collected
 // and run by the fiber on unload.
 export const apply = (ctx, config) => {
-  const cfg = Config(config);
+  const rawCfg = Config(config);
 
   // Resolve memoryDir: expand leading "~"
-  const memoryDir = cfg.memoryDir.startsWith("~")
-    ? join(homedir(), cfg.memoryDir.slice(1))
-    : cfg.memoryDir;
+  const memoryDir = rawCfg.memoryDir.startsWith("~")
+    ? join(homedir(), rawCfg.memoryDir.slice(1))
+    : rawCfg.memoryDir;
   mkdirSync(memoryDir, { recursive: true });
 
   const store = createStore(join(memoryDir, "memory.db"));
@@ -47,8 +48,8 @@ export const apply = (ctx, config) => {
   // default 90). Best-effort like the failure prune — the audit trail is
   // bookkeeping and a failed purge must never block plugin boot.
   try {
-    if (cfg.llmAudit?.enabled !== false) {
-      const retentionMs = Number.isInteger(cfg.llmAudit?.retentionDays) ? cfg.llmAudit.retentionDays : 90;
+    if (rawCfg.llmAudit?.enabled !== false) {
+      const retentionMs = Number.isInteger(rawCfg.llmAudit?.retentionDays) ? rawCfg.llmAudit.retentionDays : 90;
       store.deleteOldLlmAudits(new Date(Date.now() - retentionMs * 86400000).toISOString());
     }
   } catch { /* non-fatal */ }
@@ -56,15 +57,27 @@ export const apply = (ctx, config) => {
   // 活跃度增长；启动时按 recallRetentionDays（默认 90 天）清一次，防膨胀。
   // 与 llm_audit 同策略：纯 bookkeeping，清理失败绝不阻塞插件启动。
   try {
-    const recallRetentionDays = Number.isInteger(cfg.recallRetentionDays) ? cfg.recallRetentionDays : 90;
+    const recallRetentionDays = Number.isInteger(rawCfg.recallRetentionDays) ? rawCfg.recallRetentionDays : 90;
     store.purgeRecallRunsOlderThan(recallRetentionDays);
   } catch { /* non-fatal */ }
-  const mirror = createMirror(memoryDir);
-  // User-configurable settings (profile, rules) and custom commands share the
-  // same SQLite file but live in dedicated tables, isolated from memories.
-  // Created before the service so the tag-config resolver (issue #31) can merge
-  // the Web panel's persisted toggles over the plugin config at runtime.
+
+  // User-configurable settings (profile, rules, panel mode, standalone API
+  // token) share the same SQLite file in dedicated tables, isolated from
+  // memories. Created before the config is finalized: the tag-config resolver
+  // (issue #31) merges the persisted toggles over the plugin config at
+  // runtime, and the persisted panel_mode participates in light-mode
+  // resolution below.
   const settings = createSettings(store.db);
+
+  // Light mode (v0.7.12): the bundle config flag OR a persisted panel_mode of
+  // "light" (the panel switch wins over the bundle config so it survives
+  // config redeploys). applyLightModePreset turns every heavy background /
+  // semantic feature off and keeps the core loop (autoInject, autoSummarize,
+  // hot memory, quality filter).
+  const lightMode = rawCfg.lightMode === true || settings.getPanelMode() === "light";
+  const cfg = applyLightModePreset({ ...rawCfg, lightMode });
+
+  const mirror = createMirror(memoryDir);
   const service = createService({ store, mirror, config: cfg, logger: ctx.logger, settings });
 
   // F-NEW-03: if the mirror sync failed last run (persisted dirty state), retry
@@ -115,7 +128,13 @@ export const apply = (ctx, config) => {
 
   let embedder = null;
   let reranker = null;
-  if (cfg.embedProvider === "openai") {
+  if (lightMode) {
+    // Light mode: the whole vector pipeline stays off — no embedder (nothing
+    // pulls in ONNX/transformers), no reranker, no boot backfill (the preset
+    // also cleared autoReindexOnBoot). Recall degrades to keyword search and
+    // human mirror edits still merge on boot.
+    applyHumanEdits();
+  } else if (cfg.embedProvider === "openai") {
     // vectorIndex is passed so the legacy OpenAI embedder records the producing
     // model fingerprint after each successful embed (Bug3).
     embedder = createEmbedder({ store, settings, logger: ctx.logger, vectorIndex });
@@ -352,6 +371,19 @@ export const apply = (ctx, config) => {
       list: () => []
     }, embedder, { vectorIndex, reranker }, cfg.apiToken);
     disposers.push(api.dispose);
+  }
+
+  // Standalone external API (v0.7.12): plain node:http server for ecosystem
+  // integrations outside the DSH host. Persisted external_api settings win
+  // over the bundle config (enabled/port); the Bearer token lives in the same
+  // kv and is auto-generated on first boot by createStandaloneApi. Binding a
+  // non-loopback host is the operator's documented responsibility.
+  if ((settings.getExternalApi?.()?.enabled ?? cfg.externalApiEnabled) === true) {
+    const standalone = createStandaloneApi({ service, store, config: cfg, logger: ctx.logger, settings });
+    disposers.push(() => standalone.server.close());
+    standalone.ready.catch((error) => {
+      ctx.logger?.warn?.(`[dsh-mneme] standalone API failed to start: ${String(error)}`);
+    });
   }
 
   // Async disposer: cordis awaits the returned promise on unload (runDisposable),

--- a/dsh-mneme/lib/settings.js
+++ b/dsh-mneme/lib/settings.js
@@ -207,6 +207,46 @@ export function createSettings(db) {
       else if (cur.showSidebarTrigger !== undefined) cfg.showSidebarTrigger = cur.showSidebarTrigger === true;
       setSetting("ui", JSON.stringify(cfg));
       return cfg;
+    },
+
+    /**
+     * Standalone external API settings (kv "external_api"): {enabled, port,
+     * host, token}. The Bearer token is auto-generated on first boot and
+     * persisted here. Partial writes preserve the keys they don't mention.
+     */
+    getExternalApi() {
+      const raw = getSetting("external_api");
+      if (!raw) return undefined;
+      try {
+        const cfg = JSON.parse(raw);
+        return typeof cfg === "object" && cfg !== null ? cfg : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    setExternalApi(patch = {}) {
+      const prev = this.getExternalApi() ?? {};
+      const port = Number(patch.port ?? prev.port);
+      const host = typeof patch.host === "string" && patch.host.trim() ? patch.host.trim() : (prev.host ?? "127.0.0.1");
+      const cfg = {
+        enabled: patch.enabled !== undefined ? patch.enabled === true : prev.enabled === true,
+        port: Number.isInteger(port) && port > 0 ? port : 8790,
+        host,
+        token: String(patch.token ?? prev.token ?? "")
+      };
+      setSetting("external_api", JSON.stringify(cfg));
+      return cfg;
+    },
+
+    /**
+     * Web panel mode (kv "panel_mode"): "light" (low-resource preset) or
+     * "standard" (full feature set). Unset reads as "standard".
+     */
+    getPanelMode() {
+      return getSetting("panel_mode") === "light" ? "light" : "standard";
+    },
+    setPanelMode(mode) {
+      setSetting("panel_mode", mode === "light" ? "light" : "standard");
     }
   };
 }

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -243,7 +243,9 @@ CREATE TABLE IF NOT EXISTS mirror_state (
 );
 `;
 
-const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern", "user", "fact"]);
+// Exported so the standalone API layer (api-standalone.js) can validate
+// incoming memory types against the same set the store enforces.
+export const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern", "user", "fact"]);
 
 // Epistemic status: what kind of evidence a memory rests on. Defaults to
 // 'subjective' so legacy rows (and rows without any signal) stay compatible.
@@ -650,12 +652,21 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
+  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
       clauses.push("type = ?");
       params.push(type);
+    }
+    // Same filters as list() so a paged caller's total matches its rows.
+    if (minImportance != null) {
+      clauses.push("importance >= ?");
+      params.push(minImportance);
+    }
+    if (source != null) {
+      clauses.push("source = ?");
+      params.push(source);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
@@ -1072,12 +1083,22 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
+  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, includeDisposed = false, minImportance = null, source = null } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
       clauses.push("type = ?");
       params.push(type);
+    }
+    // Optional server-side filters: importance floor and exact source match.
+    // Both stay out of the query when unset so existing callers are unaffected.
+    if (minImportance != null) {
+      clauses.push("importance >= ?");
+      params.push(minImportance);
+    }
+    if (source) {
+      clauses.push("source = ?");
+      params.push(source);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
@@ -1090,8 +1111,13 @@ export function createStore(path) {
     }
     const { limit: lim, offset: off } = sanitizePage(limit, offset, 50);
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+    // "chrono" is pure newest-first — the stable order paged browsing (month
+    // tree, infinite scroll) needs; importance ordering would interleave
+    // months across pages. Default keeps the importance-ranked order other
+    // callers rely on.
+    const orderBy = order === "chrono" ? "updated_at DESC, id DESC" : "importance DESC, updated_at DESC, id";
     const rows = db.prepare(
-      `SELECT * FROM memories ${where} ORDER BY importance DESC, updated_at DESC, id LIMIT ? OFFSET ?`
+      `SELECT * FROM memories ${where} ORDER BY ${orderBy} LIMIT ? OFFSET ?`
     ).all(...params, lim, off);
     return rows.map(toRow);
   }

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.10",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.10",
+      "version": "0.7.12",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0"
+      },
+      "bin": {
+        "dsh-mneme": "bin/cli.mjs"
       },
       "devDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.10",
+  "version": "0.7.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -13,6 +13,9 @@
   },
   "type": "module",
   "main": "lib/index.js",
+  "bin": {
+    "dsh-mneme": "bin/cli.mjs"
+  },
   "exports": {
     ".": {
       "default": "./lib/index.js"
@@ -23,6 +26,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "bin",
     "lib",
     "src",
     "scripts",

--- a/dsh-mneme/src/api-standalone.js
+++ b/dsh-mneme/src/api-standalone.js
@@ -1,0 +1,264 @@
+// Standalone HTTP API (v0.7.12): a plain node:http server for ecosystem
+// integrations that live outside the DSH host and cannot reach the plugin's
+// internal webServer routes (/api/dsh-mneme/*). Mirrors the JSON semantics of
+// those routes but with mandatory Bearer-token auth on everything except
+// GET /health, so the store can be exposed safely on loopback.
+//
+// Security: the default bind host is 127.0.0.1. Pointing externalApiHost at a
+// non-loopback address exposes the whole memory store to the network — that is
+// the operator's explicit responsibility (documented in README).
+import { createServer } from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { TYPES } from "./store.js";
+
+const DEFAULT_PORT = 8790;
+const DEFAULT_HOST = "127.0.0.1";
+// Hardcoded release version (package.json is bumped at publish time and may
+// lag the code that ships in between).
+const VERSION = "0.7.12";
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(payload));
+}
+
+/** True when the request carries the configured token. */
+function isAuthorized(req, apiToken) {
+  const raw = req.headers?.authorization ?? req.headers?.["x-dsh-mneme-token"] ?? "";
+  const token = raw.startsWith("Bearer ") ? raw.slice(7).trim() : raw.trim();
+  if (token === "" || token.length !== apiToken.length) return false;
+  // Constant-time comparison: no timing oracle on the token.
+  return timingSafeEqual(Buffer.from(token), Buffer.from(apiToken));
+}
+
+/** Collect the request body as text (tolerant of transport errors). */
+function readBody(req) {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => resolve(body));
+    req.on("error", () => resolve(""));
+  });
+}
+
+/**
+ * Create (and start) the standalone API server.
+ * Accepts { service, store, config, logger, settings, port, host }:
+ *   - token: persisted settings kv "external_api" wins; auto-generated
+ *     (crypto.randomBytes(24).toString("base64url")) and persisted when empty.
+ *   - port:  explicit arg > persisted settings > config.externalApiPort > 8790.
+ *   - host:  explicit arg > config.externalApiHost > "127.0.0.1".
+ * Returns { server, port, host, token, ready }: `port` is the effective bound
+ * port (updated to the OS-assigned one after `ready` resolves when asked to
+ * bind port 0), `ready` resolves once listening and rejects if the bind fails.
+ */
+export function createStandaloneApi({ service, store, config = {}, logger, settings, port, host }) {
+  const persisted = settings?.getExternalApi?.() ?? {};
+
+  let token = typeof persisted.token === "string" ? persisted.token : "";
+  if (!token) {
+    token = randomBytes(24).toString("base64url");
+    // Persist only the token; enabled/port keys stay as they are (merge).
+    try {
+      settings?.setExternalApi?.({ token });
+    } catch (error) {
+      logger?.warn?.(`[dsh-mneme] standalone API token persistence failed: ${String(error)}`);
+    }
+  }
+
+  // Persisted host (set from the panel) wins over the bundle config, same
+  // precedence as port; the explicit argument still wins over both.
+  const boundHost = host
+    ?? (typeof persisted.host === "string" && persisted.host ? persisted.host : undefined)
+    ?? config.externalApiHost
+    ?? DEFAULT_HOST;
+  const persistedPort = Number(persisted.port);
+  const boundPort = port
+    ?? (Number.isInteger(persistedPort) && persistedPort > 0 ? persistedPort : undefined)
+    ?? config.externalApiPort
+    ?? DEFAULT_PORT;
+
+  const server = createServer((req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const pathname = url.pathname;
+
+      // Health is the single unauthenticated probe (monitor checks).
+      if (req.method === "GET" && pathname === "/health") {
+        sendJson(res, 200, { ok: true });
+        return;
+      }
+
+      // Everything else requires the Bearer token.
+      if (!isAuthorized(req, token)) {
+        sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      // --- GET /status: version + store shape + uptime -----------------------
+      if (req.method === "GET" && pathname === "/status") {
+        const byType = {};
+        for (const type of TYPES) byType[type] = service.count(type);
+        let entities = 0;
+        try {
+          entities = store.db.prepare("SELECT count(*) AS c FROM entities").get().c;
+        } catch { /* entities storage unavailable → 0 */ }
+        sendJson(res, 200, {
+          version: VERSION,
+          memories: { total: service.count(), byType },
+          entities,
+          uptime_s: Math.floor(process.uptime())
+        });
+        return;
+      }
+
+      // --- GET /memories: paged + filtered list (same semantics as the
+      //     internal /api/dsh-mneme/list) ------------------------------------
+      if (req.method === "GET" && pathname === "/memories") {
+        const type = url.searchParams.get("type") ?? undefined;
+        const limit = Number(url.searchParams.get("limit") ?? 50);
+        const offset = Number(url.searchParams.get("offset") ?? 0);
+        const order = url.searchParams.get("order") ?? undefined;
+        const minRaw = url.searchParams.get("minImportance");
+        const minImportance = minRaw !== null && minRaw !== "" && !Number.isNaN(Number(minRaw))
+          ? Number(minRaw)
+          : undefined;
+        const source = url.searchParams.get("source") || undefined;
+        const items = service.toApiList(service.list({ type, limit, offset, order, minImportance, source }));
+        // Total honors the same filters so pager math stays correct.
+        sendJson(res, 200, { items, total: service.count(type, { minImportance, source }) });
+        return;
+      }
+
+      // --- GET/DELETE /memories/:id ------------------------------------------
+      const idMatch = pathname.match(/^\/memories\/([^/]+)$/);
+      if (idMatch) {
+        let id = idMatch[1];
+        try { id = decodeURIComponent(id); } catch { /* keep raw */ }
+        if (req.method === "GET") {
+          const row = service.getById(id);
+          if (!row) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          sendJson(res, 200, service.toApiList([row])[0]);
+          return;
+        }
+        if (req.method === "DELETE") {
+          // store.remove deletes silently — precheck for a distinguishable 404.
+          if (!service.getById(id)) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          service.remove(id);
+          sendJson(res, 200, { ok: true });
+          return;
+        }
+        sendJson(res, 404, { error: "not-found" });
+        return;
+      }
+
+      // --- POST /memories: save with title-dedupe (safer than raw save) ------
+      if (req.method === "POST" && pathname === "/memories") {
+        void readBody(req).then((text) => {
+          let body;
+          try {
+            body = JSON.parse(text || "{}");
+          } catch {
+            sendJson(res, 400, { error: "invalid-json" });
+            return;
+          }
+          if (body === null || typeof body !== "object" || Array.isArray(body)) {
+            sendJson(res, 400, { error: "invalid-body" });
+            return;
+          }
+          // Pre-validate what store.save would throw on, so clients get a
+          // clean 400 instead of a leaked SQLite error.
+          if (!TYPES.has(body.type)) {
+            sendJson(res, 400, { error: "invalid-type" });
+            return;
+          }
+          if (typeof body.title !== "string" || !body.title.trim()) {
+            sendJson(res, 400, { error: "missing-title" });
+            return;
+          }
+          if (typeof body.content !== "string") {
+            sendJson(res, 400, { error: "missing-content" });
+            return;
+          }
+          if (body.tags !== undefined && !Array.isArray(body.tags)) {
+            sendJson(res, 400, { error: "tags-must-be-an-array" });
+            return;
+          }
+          try {
+            const { action, memory } = service.saveWithDedupe({
+              type: body.type,
+              title: body.title,
+              content: body.content,
+              importance: body.importance,
+              tags: body.tags,
+              source: body.source
+            });
+            sendJson(res, action === "created" ? 201 : 200, service.toApiList([memory])[0]);
+          } catch (error) {
+            logger?.warn?.(`[dsh-mneme] standalone API save failed: ${String(error)}`);
+            sendJson(res, 500, { error: "internal" });
+          }
+        });
+        return;
+      }
+
+      // --- GET /search: unified recall pipeline (keyword + vector + BM25) ----
+      if (req.method === "GET" && pathname === "/search") {
+        const q = url.searchParams.get("q") ?? "";
+        const limit = Number(url.searchParams.get("topK") ?? url.searchParams.get("limit") ?? 20);
+        const mode = url.searchParams.get("mode") ?? "auto";
+        const rerank = url.searchParams.get("rerank") !== "false";
+        const query = q.trim();
+        if (!query) {
+          sendJson(res, 200, { items: [], mode: "keyword" });
+          return;
+        }
+        // Any vector/rerank failure degrades to keyword inside searchMemories.
+        void Promise.resolve(
+          service.searchMemories(query, { mode, topK: limit, useRerank: rerank })
+        ).then((rows) => {
+          const used = rows.some((m) => m.vector === true) ? "vector" : "keyword";
+          sendJson(res, 200, { items: service.toApiList(rows), mode: used });
+        }).catch(() => {
+          sendJson(res, 200, { items: service.toApiList(service.search(query, { limit })), mode: "keyword" });
+        });
+        return;
+      }
+
+      sendJson(res, 404, { error: "not-found" });
+    } catch {
+      sendJson(res, 500, { error: "internal" });
+    }
+  });
+
+  // A permanent error listener keeps an EADDRINUSE / runtime socket error from
+  // crashing the host process; `ready` still surfaces the first bind failure.
+  server.on("error", (error) => {
+    logger?.warn?.(`[dsh-mneme] standalone API error: ${String(error)}`);
+  });
+  const ready = new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  server.listen(boundPort, boundHost);
+  ready.then(() => {
+    const address = server.address();
+    if (address && typeof address === "object") {
+      logger?.info?.(`[dsh-mneme] standalone API listening on http://${address.address}:${address.port}`);
+    }
+  }).catch(() => { /* already logged by the error handler above */ });
+
+  const api = { server, port: boundPort, host: boundHost, token, ready };
+  // After the OS assigns the real port (bind port 0), reflect it for callers.
+  ready.then(() => {
+    const address = server.address();
+    if (address && typeof address === "object") api.port = address.port;
+  }).catch(() => { /* bind failed: port stays as configured */ });
+  return api;
+}

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -1,9 +1,23 @@
 import { URL } from "node:url";
-import { timingSafeEqual } from "node:crypto";
+import { timingSafeEqual, randomBytes } from "node:crypto";
 
 function sendJson(res, status, payload) {
   res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(payload));
+}
+
+// Defaults for the standalone external API — keep in step with the schema
+// defaults in config.js (externalApiPort / externalApiHost).
+const EXTERNAL_API_DEFAULTS = { enabled: false, port: 8790, host: "127.0.0.1" };
+
+/** Merge persisted external-api kv over the defaults for client display. */
+function fullExternalConfig(kv = {}) {
+  return {
+    enabled: kv.enabled === true,
+    port: Number.isInteger(kv.port) && kv.port > 0 ? kv.port : EXTERNAL_API_DEFAULTS.port,
+    host: kv.host || EXTERNAL_API_DEFAULTS.host,
+    token: kv.token || ""
+  };
 }
 
 /**
@@ -88,8 +102,20 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
         const type = url.searchParams.get("type") ?? undefined;
         const limit = Number(url.searchParams.get("limit") ?? 50);
         const offset = Number(url.searchParams.get("offset") ?? 0);
-        const items = service.toApiList(service.list({ type, limit, offset }));
-        sendJson(res, 200, { items, total: service.count(type) });
+        // order=chrono: pure newest-first for paged browsing; default keeps
+        // the importance-ranked order other callers rely on.
+        const order = url.searchParams.get("order") ?? undefined;
+        // minImportance: numeric lower bound on importance (absent/NaN → no
+        // floor); source: exact match on the source column (empty → no filter).
+        const minRaw = url.searchParams.get("minImportance");
+        const minImportance = minRaw !== null && minRaw !== "" && !Number.isNaN(Number(minRaw))
+          ? Number(minRaw)
+          : undefined;
+        const source = url.searchParams.get("source") || undefined;
+        const items = service.toApiList(service.list({ type, limit, offset, order, minImportance, source }));
+        // Total honors the same filters as the rows, or the pager's
+        // has-more math breaks whenever minImportance/source is active.
+        sendJson(res, 200, { items, total: service.count(type, { minImportance, source }) });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }
@@ -169,6 +195,40 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           });
         }
         sendJson(res, 200, { profile: settings.getProfile() });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- delete one memory by id ---
+  // Mutation route: apiToken-gated like the profile/rules writes above. POST
+  // body is JSON { id }. store.remove deletes silently, so existence is checked
+  // up front to give clients a distinguishable 404 instead of a fake success.
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/delete",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") {
+          sendJson(res, 404, { error: "not-found" });
+          return;
+        }
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then((text) => {
+          const body = parseBody(text);
+          const id = typeof body.id === "string" ? body.id.trim() : "";
+          if (!id) {
+            sendJson(res, 400, { error: "missing-id" });
+            return;
+          }
+          if (!service.getById(id)) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          service.remove(id);
+          sendJson(res, 200, { ok: true });
+        });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }
@@ -704,6 +764,81 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // --- panel mode (v0.7.12): light / standard -------------------------------
+  // Persists the Web panel's feature preset into the settings kv
+  // ("panel_mode"). PUT requires auth like every other settings write; the
+  // value is validated against the enum. index.js applies the light preset on
+  // the next boot (persisted mode wins over the bundle config).
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/mode",
+    handler(req, res) {
+      try {
+        if (req.method === "PUT" || req.method === "POST") {
+          if (!requireAuth(req, res, apiToken)) return;
+          return readBody(req).then((text) => {
+            const body = parseBody(text);
+            if (body.mode !== "light" && body.mode !== "standard") {
+              sendJson(res, 400, { error: "invalid-mode" });
+              return;
+            }
+            settings.setPanelMode(body.mode);
+            sendJson(res, 200, { mode: settings.getPanelMode() });
+          });
+        }
+        sendJson(res, 200, { mode: settings.getPanelMode() });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- external API settings (the standalone server's panel-facing config) ---
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/external-api",
+    handler(req, res) {
+      try {
+        if (req.method === "PUT" || req.method === "POST") {
+          if (!requireAuth(req, res, apiToken)) return;
+          return readBody(req).then((text) => {
+            const body = parseBody(text);
+            const patch = {};
+            if (body.enabled !== undefined) patch.enabled = body.enabled === true;
+            if (body.port !== undefined) {
+              const port = Number(body.port);
+              if (!Number.isInteger(port) || port < 1 || port > 65535) {
+                sendJson(res, 400, { error: "invalid-port" });
+                return;
+              }
+              patch.port = port;
+            }
+            if (body.host !== undefined) {
+              const host = String(body.host).trim();
+              if (!host || host.includes("://")) {
+                sendJson(res, 400, { error: "invalid-host" });
+                return;
+              }
+              patch.host = host;
+            }
+            sendJson(res, 200, { config: fullExternalConfig(settings.setExternalApi(patch)) });
+          });
+        }
+        // GET: always hand back a token — the standalone server generates its
+        // own on first enabled boot, but the panel displays it before that,
+        // so materialize and persist one here.
+        const kv = settings.getExternalApi() ?? {};
+        if (!kv.token) {
+          kv.token = randomBytes(24).toString("base64url");
+          settings.setExternalApi({ token: kv.token });
+        }
+        sendJson(res, 200, { config: fullExternalConfig(kv) });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
   // --- custom commands ---
   register({
     kind: "exact",
@@ -818,7 +953,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   });
 
   return {
-    routes: 20,
+    routes: 25,
     dispose: () => {
       for (const dispose of disposers) dispose();
     }

--- a/dsh-mneme/src/client.js
+++ b/dsh-mneme/src/client.js
@@ -39,6 +39,41 @@ window.__ModuleLoader__.load({
       h("circle", { cx: 12.4, cy: 12, r: 1.8, fill: "currentColor" })
     );
 
+    // Stroke icons, Lucide path data (ISC license) inlined as [tag, attrs]
+    // tuples — the plugin runtime cannot require third-party libraries, so
+    // the data ships with the bundle (the morphicons/lucide pairing the
+    // data package documents, minus the runtime dependency). Stroke picks
+    // up currentColor, so icons follow the host theme tokens.
+    const ICON_PATHS = {
+      database: [["ellipse", { cx: "12", cy: "5", rx: "9", ry: "3" }], ["path", { d: "M3 5V19A9 3 0 0 0 21 19V5" }], ["path", { d: "M3 12A9 3 0 0 0 21 12" }]],
+      waypoints: [["path", { d: "m10.586 5.414-5.172 5.172" }], ["path", { d: "m18.586 13.414-5.172 5.172" }], ["path", { d: "M6 12h12" }], ["circle", { cx: "12", cy: "20", r: "2" }], ["circle", { cx: "12", cy: "4", r: "2" }], ["circle", { cx: "20", cy: "12", r: "2" }], ["circle", { cx: "4", cy: "12", r: "2" }]],
+      settings: [["path", { d: "M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" }], ["circle", { cx: "12", cy: "12", r: "3" }]],
+      search: [["path", { d: "m21 21-4.34-4.34" }], ["circle", { cx: "11", cy: "11", r: "8" }]],
+      refresh: [["path", { d: "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" }], ["path", { d: "M21 3v5h-5" }], ["path", { d: "M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" }], ["path", { d: "M8 16H3v5" }]],
+      chevronDown: [["path", { d: "m6 9 6 6 6-6" }]],
+      chevronRight: [["path", { d: "m9 18 6-6-6-6" }]],
+      copy: [["rect", { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2" }], ["path", { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" }]],
+      check: [["path", { d: "M20 6 9 17l-5-5" }]],
+      inbox: [["polyline", { points: "22 12 16 12 14 15 10 15 8 12 2 12" }], ["path", { d: "M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" }]],
+      activity: [["path", { d: "M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" }]]
+    };
+    const Icon = ({ name, size = 16, className }) => {
+      const parts = ICON_PATHS[name];
+      if (!parts) return null;
+      return h("svg", {
+        width: size,
+        height: size,
+        viewBox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        strokeWidth: 2,
+        strokeLinecap: "round",
+        strokeLinejoin: "round",
+        className,
+        "aria-hidden": "true"
+      }, parts.map(([tag, attrs], i) => h(tag, { key: i, ...attrs })));
+    };
+
     // Unified API fetcher: attaches the optional apiToken (set in the settings
     // view, persisted in localStorage) as a Bearer header. When no token has
     // been configured the header is omitted and the API stays open (default).
@@ -181,7 +216,45 @@ window.__ModuleLoader__.load({
         "memory.wikilink.forward": "此记忆链接到",
         "memory.wikilink.empty": "暂无关联记忆",
         "memory.wikilink.loading": "加载中…",
-        "memory.wikilink.unresolved": "目标记忆不存在"
+        "memory.wikilink.unresolved": "目标记忆不存在",
+        "memory.entity.person": "人物",
+        "memory.entity.project": "项目",
+        "memory.entity.concept": "概念",
+        "memory.entity.technology": "技术",
+        "memory.entity.organization": "组织",
+        "memory.entity.other": "其他",
+        "memory.explorer.tabStatus": "状态",
+        "memory.explorer.loadMore": "加载更多",
+        "memory.explorer.delete": "删除",
+        "memory.explorer.confirmDelete": "确认删除?",
+        "memory.explorer.cancel": "取消",
+        "memory.explorer.deleted": "已删除",
+        "memory.explorer.deleteFailed": "删除失败",
+        "memory.status.memories": "记忆总数",
+        "memory.status.entities": "实体",
+        "memory.status.vector": "向量索引",
+        "memory.status.vectorOn": "已启用",
+        "memory.status.vectorOff": "未启用",
+        "memory.status.llm": "LLM 消耗",
+        "memory.status.llmCalls": "近 7 天 · {n} 次调用",
+        "memory.status.error": "加载失败",
+        "memory.settings.mode.title": "运行模式",
+        "memory.settings.mode.desc": "轻量模式只保留核心的记忆读写与自动注入（关闭 autoDream 巩固、实体抽取、语义搜索等高级功能），适合只想「记住偏好」的轻量使用；标准模式开启全部功能。",
+        "memory.settings.mode.light": "轻量",
+        "memory.settings.mode.standard": "标准",
+        "memory.settings.mode.savedHint": "已保存，重启 DSH 后生效",
+        "memory.settings.mode.offList": "已关闭：巩固（autoDream）· 实体抽取 · 语义搜索",
+        "memory.settings.extapi.title": "外部访问 API",
+        "memory.settings.extapi.desc": "独立 HTTP 服务，供其他插件 / CLI / 桌面工具读写记忆，默认绑定 127.0.0.1。重启 DSH 后生效。",
+        "memory.settings.extapi.enabled": "启用",
+        "memory.settings.extapi.disabled": "停用",
+        "memory.settings.extapi.address": "地址",
+        "memory.settings.extapi.port": "端口",
+        "memory.settings.extapi.token": "Token",
+        "memory.settings.extapi.copy": "复制",
+        "memory.settings.extapi.copied": "已复制",
+        "memory.settings.extapi.savedHint": "已保存，重启 DSH 后生效",
+        "memory.settings.extapi.invalidPort": "端口需为 1-65535 的数字"
       },
       en: {
         "memory.panel.empty": "No memories yet",
@@ -307,7 +380,45 @@ window.__ModuleLoader__.load({
         "memory.wikilink.forward": "This memory links to",
         "memory.wikilink.empty": "No linked memories",
         "memory.wikilink.loading": "Loading…",
-        "memory.wikilink.unresolved": "Target memory not found"
+        "memory.wikilink.unresolved": "Target memory not found",
+        "memory.entity.person": "People",
+        "memory.entity.project": "Projects",
+        "memory.entity.concept": "Concepts",
+        "memory.entity.technology": "Technologies",
+        "memory.entity.organization": "Organizations",
+        "memory.entity.other": "Others",
+        "memory.explorer.tabStatus": "Status",
+        "memory.explorer.loadMore": "Load more",
+        "memory.explorer.delete": "Delete",
+        "memory.explorer.confirmDelete": "Confirm delete?",
+        "memory.explorer.cancel": "Cancel",
+        "memory.explorer.deleted": "Deleted",
+        "memory.explorer.deleteFailed": "Delete failed",
+        "memory.status.memories": "Total memories",
+        "memory.status.entities": "Entities",
+        "memory.status.vector": "Vector index",
+        "memory.status.vectorOn": "Enabled",
+        "memory.status.vectorOff": "Disabled",
+        "memory.status.llm": "LLM Usage",
+        "memory.status.llmCalls": "Last 7 days · {n} calls",
+        "memory.status.error": "Failed to load",
+        "memory.settings.mode.title": "Runtime mode",
+        "memory.settings.mode.desc": "Light mode keeps only the core memory read/write and auto-injection (autoDream consolidation, entity extraction and semantic search are off) — for light use where you just want preferences remembered. Standard mode enables everything.",
+        "memory.settings.mode.light": "Light",
+        "memory.settings.mode.standard": "Standard",
+        "memory.settings.mode.savedHint": "Saved. Takes effect after restarting DSH",
+        "memory.settings.mode.offList": "Off: consolidation (autoDream) · entity extraction · semantic search",
+        "memory.settings.extapi.title": "External API",
+        "memory.settings.extapi.desc": "A standalone HTTP service for other plugins / CLIs / desktop tools to read and write memories, bound to 127.0.0.1 by default. Takes effect after restarting DSH.",
+        "memory.settings.extapi.enabled": "Enable",
+        "memory.settings.extapi.disabled": "Disable",
+        "memory.settings.extapi.address": "Address",
+        "memory.settings.extapi.port": "Port",
+        "memory.settings.extapi.token": "Token",
+        "memory.settings.extapi.copy": "Copy",
+        "memory.settings.extapi.copied": "Copied",
+        "memory.settings.extapi.savedHint": "Saved. Takes effect after restarting DSH",
+        "memory.settings.extapi.invalidPort": "Port must be a number between 1 and 65535"
       }
     };
 
@@ -563,7 +674,35 @@ window.__ModuleLoader__.load({
       ".mneme-overlaybar{flex:none;display:flex;align-items:center;justify-content:flex-start;gap:12px;height:44px;padding:0 12px 0 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
       ".mneme-overlaytitle{font-size:14px;font-weight:600;color:var(--dsw-alias-label-primary)}",
       ".mneme-overlaybody{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}",
-      "@keyframes mneme-fadein{from{opacity:0}to{opacity:1}}"
+      "@keyframes mneme-fadein{from{opacity:0}to{opacity:1}}",
+      // --- explorer refresh: paged month tree, sticky headers, inline icons ---
+      ".mneme-vtabico{flex:none;opacity:.85}",
+      ".mneme-xsearchwrap{position:relative;flex:none}",
+      ".mneme-xsearchico{position:absolute;left:9px;top:50%;transform:translateY(-50%);color:var(--dsw-alias-label-tertiary);pointer-events:none}",
+      ".mneme-xsearchwrap .mneme-xsearch{padding-left:27px}",
+      ".mneme-footbtn{display:inline-flex;align-items:center;gap:4px}",
+      ".mneme-xmonth{position:sticky;top:0;z-index:2;background:var(--dsw-alias-bg-layer-1);display:flex;align-items:center;gap:6px}",
+      ".mneme-xmonthcount{margin-left:auto;color:var(--dsw-alias-label-tertiary);font-weight:400;font-variant-numeric:tabular-nums}",
+      ".mneme-xcaret{display:inline-flex;align-items:center;justify-content:center;color:var(--dsw-alias-label-tertiary)}",
+      ".mneme-xmore{display:flex;justify-content:center;align-items:center;padding:10px 0 24px;min-height:20px}",
+      ".mneme-xemptyico{display:block;margin:0 auto 6px;opacity:.7}",
+      // --- status sub-view: responsive stat-card grid (auto-fill, ~220px min) ---
+      ".mneme-status{flex:1;min-height:0;overflow-y:auto;padding:16px 20px 32px;box-sizing:border-box}",
+      ".mneme-statusgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;max-width:960px}",
+      ".mneme-statuscard{min-width:0;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:14px}",
+      ".mneme-statusnum{font-size:24px;font-weight:600;line-height:32px;color:var(--dsw-alias-label-primary);font-variant-numeric:tabular-nums}",
+      ".mneme-statuscap{margin-top:4px;font-size:13px;line-height:19px;color:var(--dsw-alias-label-tertiary);word-break:break-word}",
+      // --- destructive actions: red outline = delete, solid red = confirm ---
+      ".mneme-btndanger{color:var(--dsw-alias-state-error,#c33);border-color:var(--dsw-alias-state-error,#c33)}",
+      ".mneme-btndanger:hover{background:color-mix(in srgb,var(--dsw-alias-state-error,#c33) 12%,transparent)}",
+      ".mneme-btndangerconfirm{background:var(--dsw-alias-state-error,#c33);border-color:var(--dsw-alias-state-error,#c33);color:#fff}",
+      ".mneme-btndangerconfirm:hover{filter:brightness(.9)}",
+      // --- settings cards: boxed cards for the runtime-mode and external-API
+      // sections — each card owns its fetch/PUT state, so it renders as a
+      // self-contained unit inside the stacked settings view ---
+      ".mneme-set-card{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:14px;margin-bottom:12px}",
+      ".mneme-set-token{font-family:monospace;font-size:12px;padding:7px 10px;border:1px solid var(--dsw-alias-border-l2);border-radius:8px;background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);word-break:break-all;user-select:all}",
+      ".mneme-set-hint{font-size:12px;color:var(--dsw-alias-label-tertiary)}"
     ].join("\n");
     if (typeof document !== "undefined" && document.querySelector(`style[data-plugin-css="${CSS_TAG}"]`) === null) {
       const tag = document.createElement("style");
@@ -1076,6 +1215,21 @@ window.__ModuleLoader__.load({
       const [autoTagSaved, setAutoTagSaved] = react.useState(false);
       const [showSidebarTrigger, setShowSidebarTrigger] = react.useState(true);
       const [sidebarTriggerSaved, setSidebarTriggerSaved] = react.useState(false);
+      // 运行模式 — light vs standard; null = still loading. The card keeps
+      // its own busy/saved/error state so it never blocks the others.
+      const [mode, setMode] = react.useState(null);
+      const [modeBusy, setModeBusy] = react.useState(false);
+      const [modeSaved, setModeSaved] = react.useState(false);
+      const [modeError, setModeError] = react.useState("");
+      // 外部访问 API — config fetched from the backend (the token is generated
+      // and kept server-side); host/port inputs are drafts, PUT only on save.
+      const [extapi, setExtapi] = react.useState(null);
+      const [extapiHost, setExtapiHost] = react.useState("127.0.0.1");
+      const [extapiPort, setExtapiPort] = react.useState("");
+      const [extapiBusy, setExtapiBusy] = react.useState(false);
+      const [extapiSaved, setExtapiSaved] = react.useState(false);
+      const [extapiCopied, setExtapiCopied] = react.useState(false);
+      const [extapiError, setExtapiError] = react.useState("");
 
       const load = react.useCallback(async () => {
         try {
@@ -1100,6 +1254,34 @@ window.__ModuleLoader__.load({
       }, []);
 
       react.useEffect(() => { load(); }, [load]);
+
+      // Runtime mode + external API — two independent fetches: one failing
+      // endpoint only errors its own card, never the other one.
+      react.useEffect(() => {
+        let cancelled = false;
+        const toErr = (err) => (err && err.message) || "failed";
+        apiFetch("/api/dsh-mneme/mode")
+          .then((res) => { if (!res.ok) throw new Error("HTTP " + res.status); return res.json(); })
+          .then((j) => { if (!cancelled) setMode(j.mode === "light" ? "light" : "standard"); })
+          .catch((err) => { if (!cancelled) setModeError(toErr(err)); });
+        apiFetch("/api/dsh-mneme/external-api")
+          .then((res) => { if (!res.ok) throw new Error("HTTP " + res.status); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            const cfg = (j && j.config) || {};
+            const next = {
+              enabled: !!cfg.enabled,
+              host: cfg.host || "127.0.0.1",
+              port: Number(cfg.port) || 0,
+              token: cfg.token || ""
+            };
+            setExtapi(next);
+            setExtapiHost(next.host);
+            setExtapiPort(next.port ? String(next.port) : "");
+          })
+          .catch((err) => { if (!cancelled) setExtapiError(toErr(err)); });
+        return () => { cancelled = true; };
+      }, []);
 
       async function saveProfile() {
         try {
@@ -1216,6 +1398,85 @@ window.__ModuleLoader__.load({
         } catch { /* ignore */ }
       }
 
+      // Runtime mode: optimistic chip flip, rolled back on failure. Both
+      // changes only take effect after a DSH restart — the saved hint says so.
+      async function saveMode(next) {
+        if (modeBusy) return;
+        const prev = mode;
+        setModeBusy(true);
+        setModeError("");
+        setMode(next);
+        try {
+          const res = await apiFetch("/api/dsh-mneme/mode", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: next })
+          });
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          setModeSaved(true);
+          setTimeout(() => setModeSaved(false), 2500);
+        } catch (err) {
+          setMode(prev);
+          setModeError((err && err.message) || "failed");
+        }
+        setModeBusy(false);
+      }
+
+      // External API: the backend owns the token and returns the full config,
+      // so every PUT response refreshes host/port/token from the server.
+      async function putExtapi(body) {
+        setExtapiBusy(true);
+        setExtapiError("");
+        try {
+          const res = await apiFetch("/api/dsh-mneme/external-api", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body)
+          });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(data.error || "HTTP " + res.status);
+          const cfg = data.config || {};
+          const next = {
+            enabled: !!cfg.enabled,
+            host: cfg.host || "127.0.0.1",
+            port: Number(cfg.port) || 0,
+            token: cfg.token || ""
+          };
+          setExtapi(next);
+          setExtapiHost(next.host);
+          setExtapiPort(next.port ? String(next.port) : "");
+          setExtapiSaved(true);
+          setTimeout(() => setExtapiSaved(false), 2500);
+        } catch (err) {
+          setExtapiError((err && err.message) || "failed");
+        }
+        setExtapiBusy(false);
+      }
+
+      function saveExtapiEnabled(enabled) {
+        if (extapiBusy) return;
+        putExtapi({ enabled });
+      }
+
+      function saveExtapiAddress() {
+        if (extapiBusy) return;
+        const raw = String(extapiPort).trim();
+        const port = Number(raw);
+        if (!/^\d+$/.test(raw) || port < 1 || port > 65535) {
+          setExtapiError(t("memory.settings.extapi.invalidPort"));
+          return;
+        }
+        putExtapi({ port, host: extapiHost.trim() || "127.0.0.1" });
+      }
+
+      function copyExtapiToken() {
+        const token = extapi ? extapi.token || "" : "";
+        navigator.clipboard?.writeText(token).then(
+          () => { setExtapiCopied(true); setTimeout(() => setExtapiCopied(false), 1500); },
+          () => {}
+        );
+      }
+
       return h("div", null,
         h("section", { className: "mneme-set-sec" },
           h("div", { className: "mneme-set-title" }, t("memory.settings.profile")),
@@ -1288,6 +1549,86 @@ window.__ModuleLoader__.load({
               cmdError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error, #c33)" } }, cmdError)
             )
           )
+        ),
+        // 运行模式 — light vs standard chip radios; each click PUTs and the
+        // change only lands after a DSH restart (green saved hint says so).
+        h("section", { className: "mneme-set-card" },
+          h("div", { className: "mneme-set-title" }, t("memory.settings.mode.title")),
+          h("div", { className: "mneme-set-desc" }, t("memory.settings.mode.desc")),
+          modeError && h("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)", marginBottom: 8 } }, modeError),
+          mode === null && !modeError
+            ? h("div", { className: "mneme-set-hint" }, "…")
+            : h(react.Fragment, null,
+                h("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" } },
+                  h("button", {
+                    className: mode === "light" ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: modeBusy,
+                    onClick: () => saveMode("light")
+                  }, t("memory.settings.mode.light")),
+                  h("button", {
+                    className: mode === "standard" ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: modeBusy,
+                    onClick: () => saveMode("standard")
+                  }, t("memory.settings.mode.standard")),
+                  modeSaved && h("span", { className: "mneme-saved" }, t("memory.settings.mode.savedHint"))
+                ),
+                mode === "light" && h("div", { className: "mneme-set-hint", style: { marginTop: 8 } },
+                  t("memory.settings.mode.offList"))
+              )
+        ),
+        // 外部访问 API — standalone HTTP service for plugins/CLI/desktop tools;
+        // the token is generated and kept by the backend, so it is read-only
+        // here with a copy affordance. Changes need a DSH restart.
+        h("section", { className: "mneme-set-card" },
+          h("div", { className: "mneme-set-title" }, t("memory.settings.extapi.title")),
+          h("div", { className: "mneme-set-desc" }, t("memory.settings.extapi.desc")),
+          extapiError && h("div", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)", marginBottom: 8 } }, extapiError),
+          extapi === null && !extapiError
+            ? h("div", { className: "mneme-set-hint" }, "…")
+            : h(react.Fragment, null,
+                h("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" } },
+                  h("button", {
+                    className: extapi && extapi.enabled ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: extapiBusy,
+                    onClick: () => saveExtapiEnabled(true)
+                  }, t("memory.settings.extapi.enabled")),
+                  h("button", {
+                    className: extapi && !extapi.enabled ? "mneme-chip mneme-active" : "mneme-chip",
+                    disabled: extapiBusy,
+                    onClick: () => saveExtapiEnabled(false)
+                  }, t("memory.settings.extapi.disabled")),
+                  extapiSaved && h("span", { className: "mneme-saved" }, t("memory.settings.extapi.savedHint"))
+                ),
+                extapi && extapi.enabled && h(react.Fragment, null,
+                  h("div", { className: "mneme-set-hint", style: { marginTop: 10 } },
+                    `${t("memory.settings.extapi.address")}: http://${extapi.host}:${extapi.port}`),
+                  h("div", { style: { display: "flex", gap: 8, marginTop: 8 } },
+                    h("input", {
+                      className: "mneme-set-input",
+                      style: { marginBottom: 0, flex: 2, minWidth: 0, width: "auto" },
+                      value: extapiHost,
+                      placeholder: "127.0.0.1",
+                      onChange: (e) => setExtapiHost(e.target.value)
+                    }),
+                    h("input", {
+                      className: "mneme-set-input",
+                      style: { marginBottom: 0, flex: 1, minWidth: 0, width: "auto" },
+                      value: extapiPort,
+                      placeholder: t("memory.settings.extapi.port"),
+                      inputMode: "numeric",
+                      onChange: (e) => setExtapiPort(e.target.value)
+                    }),
+                    h("button", { className: "mneme-btn", disabled: extapiBusy, onClick: saveExtapiAddress },
+                      t("memory.settings.vectorSave"))
+                  ),
+                  h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginTop: 10 } },
+                    h("div", { className: "mneme-set-token", style: { flex: 1, minWidth: 0 } }, extapi.token || "—"),
+                    h("button", { className: "mneme-btn", onClick: copyExtapiToken },
+                      t("memory.settings.extapi.copy")),
+                    extapiCopied && h("span", { className: "mneme-saved" }, t("memory.settings.extapi.copied"))
+                  )
+                )
+              )
         ),
         h("section", { className: "mneme-set-sec" },
           h("div", { className: "mneme-set-title" }, t("memory.settings.autoTagTitle")),
@@ -1734,12 +2075,160 @@ window.__ModuleLoader__.load({
     }
 
     const EXPLORER_TYPES = ["preference", "project", "decision", "summary", "history", "user", "fact"];
+    const PAGE_SIZE = 100; // browse page size — the tree grows by 100-row pages
+
+    // --- Status sub-view: a responsive grid of stat cards. Every card owns
+    // its fetch, loading ("…") and error state, so one failing endpoint
+    // never blanks or blocks the others. ---
+    function StatusCard({ t, title, loading, error, num, cap }) {
+      return h("div", { className: "mneme-statuscard" },
+        h("div", { className: "mneme-xcolhead" }, title),
+        loading
+          ? h("div", { className: "mneme-statusnum" }, "…")
+          : error
+            ? h("div", { className: "mneme-statuscap", style: { color: "var(--dsw-alias-state-error,#c33)" } }, t("memory.status.error"))
+            : h(react.Fragment, null,
+                h("div", { className: "mneme-statusnum" }, num),
+                cap ? h("div", { className: "mneme-statuscap" }, cap) : null
+              )
+      );
+    }
+
+    // 记忆总数 — list total plus per-type subtotals; each subtotal request
+    // may fail independently (rendered as "—") without sinking the card.
+    function MemoriesStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, total: 0, byType: [] });
+      useEffect(() => {
+        let cancelled = false;
+        const one = (ty) =>
+          apiFetch(`/api/dsh-mneme/list?limit=1&order=chrono${ty ? `&type=${encodeURIComponent(ty)}` : ""}`)
+            .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); });
+        one()
+          .then((all) => {
+            if (cancelled) return null;
+            const total = all.total || 0;
+            return Promise.all(EXPLORER_TYPES.map((ty) =>
+              one(ty).then((j) => [ty, j.total || 0]).catch(() => [ty, null])
+            )).then((byType) => {
+              if (!cancelled) setState({ loading: false, error: false, total, byType });
+            });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, total: 0, byType: [] }); });
+        return () => { cancelled = true; };
+      }, []);
+      const cap = state.byType
+        .map(([ty, n]) => `${typeLabel(t, ty)} ${n === null ? "—" : n}`)
+        .join(" · ");
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.memories"),
+        loading: state.loading,
+        error: state.error,
+        num: state.total.toLocaleString(),
+        cap
+      });
+    }
+
+    // 实体 — directory snapshot grouped by entity type.
+    function EntitiesStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, total: 0, byType: [] });
+      useEffect(() => {
+        let cancelled = false;
+        const order = ["organization", "person", "project", "technology", "concept"];
+        apiFetch("/api/dsh-mneme/entities?limit=500")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            const list = Array.isArray(j.entities) ? j.entities : [];
+            const counts = new Map();
+            for (const e of list) {
+              const key = order.includes(e.type) ? e.type : "other";
+              counts.set(key, (counts.get(key) || 0) + 1);
+            }
+            const byType = order.concat("other")
+              .filter((k) => counts.has(k))
+              .map((k) => [k, counts.get(k)]);
+            setState({ loading: false, error: false, total: list.length, byType });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, total: 0, byType: [] }); });
+        return () => { cancelled = true; };
+      }, []);
+      const cap = state.byType.map(([ty, n]) => `${entityTypeLabel(t, ty)} ${n}`).join(" · ");
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.entities"),
+        loading: state.loading,
+        error: state.error,
+        num: state.total.toLocaleString(),
+        cap
+      });
+    }
+
+    // 向量索引 — whether semantic recall is switched on.
+    function VectorStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, enabled: false });
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/vector-config")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((j) => { if (!cancelled) setState({ loading: false, error: false, enabled: !!j.config?.enabled }); })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, enabled: false }); });
+        return () => { cancelled = true; };
+      }, []);
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.vector"),
+        loading: state.loading,
+        error: state.error,
+        num: state.enabled ? t("memory.status.vectorOn") : t("memory.status.vectorOff"),
+        cap: ""
+      });
+    }
+
+    // LLM 消耗 — calls + tokens over the trailing 7 days.
+    function LlmStatusCard({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, calls: 0, tokens: 0 });
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/semantic/llm-audit/stats?days=7")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            const s = j && typeof j === "object" ? (j.stats || j) : {};
+            setState({ loading: false, error: false, calls: Number(s.total_calls ?? 0), tokens: Number(s.total_tokens ?? 0) });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, calls: 0, tokens: 0 }); });
+        return () => { cancelled = true; };
+      }, []);
+      return h(StatusCard, {
+        t,
+        title: t("memory.status.llm"),
+        loading: state.loading,
+        error: state.error,
+        num: state.tokens.toLocaleString(),
+        cap: t("memory.status.llmCalls").replace("{n}", state.calls.toLocaleString())
+      });
+    }
+
+    function StatusPanel({ t }) {
+      return h("div", { className: "mneme-status" },
+        h("div", { className: "mneme-statusgrid" },
+          h(MemoriesStatusCard, { t }),
+          h(EntitiesStatusCard, { t }),
+          h(VectorStatusCard, { t }),
+          h(LlmStatusCard, { t })
+        )
+      );
+    }
 
     function MemoryExplorer({ t }) {
-      const [view, setView] = useState("memory"); // memory | overview | directory | graph | settings
-      const [items, setItems] = useState([]);
+      const [view, setView] = useState("memory"); // memory | overview | directory | status | graph | settings
+      const [items, setItems] = useState([]); // loaded browse pages, chrono desc
+      const [total, setTotal] = useState(0); // server count for the current type filter
       const [loading, setLoading] = useState(true);
+      const [loadingMore, setLoadingMore] = useState(false);
       const [type, setType] = useState("all");
+      const [minImp, setMinImp] = useState(0); // importance floor: 0 = all, else 3/4/5
       const [query, setQuery] = useState("");
       const [semantic, setSemantic] = useState(false);
       const [vecEnabled, setVecEnabled] = useState(false);
@@ -1747,12 +2236,18 @@ window.__ModuleLoader__.load({
       const [remoteItems, setRemoteItems] = useState(null);
       const [selectedId, setSelectedId] = useState(null);
       const [collapsed, setCollapsed] = useState({});
+      // paged month tree: null = 仅最新一个月展开, else a per-month override map
+      const [expandedMonths, setExpandedMonths] = useState(null);
       // v0.6.3 directory sub-view: its own folder-collapse state, kept in
       // MemoryExplorer so switching tabs does not lose it and jumpToMemory's
       // time-tree reset (setCollapsed({})) cannot clobber it.
       const [dirCollapsed, setDirCollapsed] = useState({});
       const [copied, setCopied] = useState(false);
       const [reloadKey, setReloadKey] = useState(0);
+      const [confirmDelete, setConfirmDelete] = useState(false); // two-step delete armed
+      const [deleting, setDeleting] = useState(false);
+      const [deleteError, setDeleteError] = useState(false);
+      const [deleteMsg, setDeleteMsg] = useState(false); // transient "deleted" notice
       const [graphFocus, setGraphFocus] = useState("");
       // v0.6.2 tag editing state for the detail pane. The authoritative tag set
       // lives server-side (entity_attrs), so it is fetched per selected memory
@@ -1762,6 +2257,7 @@ window.__ModuleLoader__.load({
       const [tagInput, setTagInput] = useState("");
       const [tagAdding, setTagAdding] = useState(false);
       const itemRefs = useRef(new Map());
+      const moreRef = useRef(null);
 
       useEffect(() => {
         apiFetch("/api/dsh-mneme/vector-config")
@@ -1770,36 +2266,116 @@ window.__ModuleLoader__.load({
           .catch(() => {});
       }, []);
 
+      // One query string behind every browse-list fetch (initial page,
+      // loadMore, auto-refresh): the type filter and the importance floor
+      // always travel together, so counts and pagination stay consistent.
+      const filterQS = (type === "all" ? "" : `&type=${encodeURIComponent(type)}`)
+        + (minImp ? `&minImportance=${minImp}` : "");
+      const listUrl = (offset) => `/api/dsh-mneme/list?limit=${PAGE_SIZE}&offset=${offset}${filterQS}&order=chrono`;
+
+      // Browse = paged, pure-chronological pages (order=chrono). The default
+      // importance ordering would interleave months across pages and break
+      // the month tree; type/importance filters run server-side so pages
+      // stay consistent however large the store grows.
       useEffect(() => {
         let cancelled = false;
         setLoading(true);
-        apiFetch("/api/dsh-mneme/list?limit=500")
-          .then((res) => (res.ok ? res.json() : { items: [] }))
-          .then((d) => { if (!cancelled) { setItems(d.items || []); setLoading(false); } })
-          .catch(() => { if (!cancelled) { setItems([]); setLoading(false); } });
+        apiFetch(listUrl(0))
+          .then((res) => (res.ok ? res.json() : { items: [], total: 0 }))
+          .then((d) => {
+            if (cancelled) return;
+            setItems(d.items || []);
+            setTotal(d.total || 0);
+            setExpandedMonths(null); // 新数据回到「仅最新月展开」
+            setLoading(false);
+          })
+          .catch(() => { if (!cancelled) { setItems([]); setTotal(0); setLoading(false); } });
         return () => { cancelled = true; };
-      }, [reloadKey]);
+      }, [reloadKey, filterQS]);
 
-      // Semantic search: server-side ranking replaces the client filter
-      // while enabled and a query is present (debounced). tag: queries always
-      // go server-side (searchMemories resolves them without vector support),
-      // so they bypass the semantic toggle and use the same search endpoint.
+      const canLoadMore = !query.trim() && !remoteItems && items.length < total;
+      const loadMore = useCallback(() => {
+        if (loadingMore || query.trim() || remoteItems) return;
+        if (items.length >= total) return;
+        setLoadingMore(true);
+        apiFetch(listUrl(items.length))
+          .then((res) => (res.ok ? res.json() : { items: [] }))
+          .then((d) => setItems((cur) => cur.concat(d.items || [])))
+          .catch(() => {})
+          .finally(() => setLoadingMore(false));
+      }, [items.length, total, loadingMore, query, remoteItems, filterQS]);
+
+      // Infinite scroll: a sentinel just past the loaded rows pulls the next
+      // page while browsing (search results arrive complete already). The
+      // scroll container is the timeline card.
       useEffect(() => {
-        const q = query.trim();
-        if ((!semantic && !q.startsWith("tag:")) || !q || q.startsWith("entity:")) { setRemoteItems(null); return; }
+        const el = moreRef.current;
+        if (!el || !canLoadMore) return undefined;
+        const io = new IntersectionObserver((entries) => {
+          if (entries.some((e) => e.isIntersecting)) loadMore();
+        }, { root: el.closest(".mneme-card--tree"), rootMargin: "240px" });
+        io.observe(el);
+        return () => io.disconnect();
+      }, [canLoadMore, loadMore]);
+
+      // Search hits the server so matches are global — not limited to the
+      // loaded pages: keyword = literal text; vector = semantic ranking
+      // (the pipeline falls back to keyword when no embedder is available).
+      // tag: queries ride the same endpoint (the server resolves them
+      // without vector support); entity: is the graph grammar and just
+      // clears the list.
+      useEffect(() => {
+        const query0 = query.trim();
+        if (!query0 || query0.startsWith("entity:")) { setRemoteItems(null); return; }
         let cancelled = false;
         const timer = setTimeout(() => {
-          apiFetch(`/api/dsh-mneme/search?q=${encodeURIComponent(q)}&mode=vector&topK=${searchTopK}`)
+          const mode = semantic ? "vector" : "keyword";
+          apiFetch(`/api/dsh-mneme/search?q=${encodeURIComponent(query0)}&mode=${mode}&topK=${searchTopK}`)
             .then((res) => (res.ok ? res.json() : { items: [] }))
             .then((d) => { if (!cancelled) setRemoteItems(d.items || []); })
             .catch(() => { if (!cancelled) setRemoteItems([]); });
         }, 250);
         return () => { cancelled = true; clearTimeout(timer); };
-      }, [semantic, query, searchTopK]);
+      }, [query, semantic, searchTopK]);
+
+      // Live view: while the memory tab is open, quietly re-fetch page 1
+      // every 30s (and on every activation) so fresh memories surface
+      // without a manual refresh. Later pages stay as loaded.
+      const refreshFirstPage = useCallback(() => {
+        if (query.trim() || remoteItems) return;
+        apiFetch(listUrl(0))
+          .then((res) => (res.ok ? res.json() : null))
+          .then((d) => {
+            if (!d) return;
+            setTotal(d.total || 0);
+            setItems((cur) => {
+              const fresh = d.items || [];
+              const seen = new Set(fresh.map((m) => m.id));
+              return fresh.concat(cur.filter((m) => !seen.has(m.id)));
+            });
+          })
+          .catch(() => {});
+      }, [query, remoteItems, filterQS]);
+
+      useEffect(() => {
+        if (view !== "memory") return undefined;
+        refreshFirstPage();
+        const iv = setInterval(() => {
+          if (document.visibilityState === "visible") refreshFirstPage();
+        }, 30000);
+        return () => clearInterval(iv);
+      }, [view, refreshFirstPage]);
 
       useEffect(() => {
         if (!selectedId) return;
         itemRefs.current.get(selectedId)?.scrollIntoView({ block: "nearest" });
+      }, [selectedId]);
+
+      // The two-step delete arms per selection: switching or clearing the
+      // target disarms it, so a stale confirm can never delete a new pick.
+      useEffect(() => {
+        setConfirmDelete(false);
+        setDeleteError(false);
       }, [selectedId]);
 
       // Load the authoritative tag set for the selected memory (entity_attrs-
@@ -1833,13 +2409,12 @@ window.__ModuleLoader__.load({
       const entityQuery = query.trim().startsWith("entity:")
         ? query.trim().slice(7).trim()
         : "";
+      // Search results were filtered server-side (global); the type filter
+      // still narrows them. Browse mode serves the loaded pages as-is —
+      // type/importance filtering happened in the query.
       const visible = remoteItems
-        ? remoteItems
-        : items.filter((m) => {
-            if (type !== "all" && m.type !== type) return false;
-            if (!q) return true;
-            return (m.title || "").toLowerCase().includes(q) || (m.content || "").toLowerCase().includes(q);
-          });
+        ? remoteItems.filter((m) => type === "all" || m.type === type)
+        : items;
 
       const counts = {};
       for (const m of items) counts[m.type] = (counts[m.type] || 0) + 1;
@@ -1874,8 +2449,9 @@ window.__ModuleLoader__.load({
         }
         curDay.items.push(m);
       }
+      for (const mo of months) mo.count = mo.days.reduce((s, d) => s + d.items.length, 0);
 
-      const selected = items.find((m) => m.id === selectedId) || null;
+      const selected = visible.find((m) => m.id === selectedId) || null;
 
       const copyContent = () => {
         if (!selected) return;
@@ -1921,14 +2497,49 @@ window.__ModuleLoader__.load({
         setQuery(`tag:${tag}`);
       };
 
+      // Two-step delete (no window.confirm): the red button arms, a second
+      // click commits POST /api/dsh-mneme/delete. On success the row leaves
+      // every local view (browse pages + search results), the selection
+      // clears and the total shrinks; failures — 404 included — surface as
+      // a transient red note next to the actions.
+      const deleteSelected = () => {
+        if (!selected || deleting) return;
+        const id = selected.id;
+        setDeleting(true);
+        setDeleteError(false);
+        apiFetch("/api/dsh-mneme/delete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id })
+        })
+          .then((res) => { if (!res.ok) throw new Error("http"); })
+          .then(() => {
+            setItems((cur) => cur.filter((m) => m.id !== id));
+            setRemoteItems((cur) => (cur ? cur.filter((m) => m.id !== id) : cur));
+            setTotal((n) => Math.max(0, n - 1));
+            setSelectedId(null);
+            setConfirmDelete(false);
+            setDeleteMsg(true);
+            setTimeout(() => setDeleteMsg(false), 2500);
+          })
+          .catch(() => {
+            setDeleteError(true);
+            setTimeout(() => setDeleteError(false), 4000);
+          })
+          .finally(() => setDeleting(false));
+      };
+
       // Graph → memory jump: land on the browser tab with filters reset so
-      // the target row is visible, selected and scrolled into view.
+      // the target row is visible, selected and scrolled into view. A target
+      // beyond the loaded pages renders as a single-row result set instead
+      // of pulling page after page to find it.
       const jumpToMemory = (target) => {
         if (!target?.id) return;
         setView("memory");
         setType("all");
         setQuery("");
-        setCollapsed({});
+        setRemoteItems(items.some((m) => m.id === target.id) ? null : [target]);
+        setExpandedMonths(null);
         setSelectedId(target.id);
       };
 
@@ -1958,6 +2569,7 @@ window.__ModuleLoader__.load({
         { key: "memory", label: t("memory.explorer.tabMemory") },
         { key: "overview", label: t("memory.explorer.tabOverview") },
         { key: "directory", label: t("memory.explorer.tabDirectory") },
+        { key: "status", label: t("memory.explorer.tabStatus") },
         { key: "graph", label: t("memory.explorer.tabGraph") },
         { key: "settings", label: t("memory.explorer.tabSettings") }
       ];
@@ -1975,7 +2587,11 @@ window.__ModuleLoader__.load({
               },
                 s.key === "graph"
                   ? h(react.Fragment, null, h(GraphNodesIcon, { size: 16 }), s.label)
-                  : s.label
+                  : s.key === "memory" || s.key === "status" || s.key === "settings"
+                    ? h(react.Fragment, null,
+                        h(Icon, { name: s.key === "memory" ? "database" : s.key === "status" ? "activity" : "settings", size: 14, className: "mneme-vtabico" }),
+                        s.label)
+                    : s.label
               ))
           ),
           ),
@@ -1998,20 +2614,33 @@ window.__ModuleLoader__.load({
                 h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(key) }, title: typeLabel(t, key), "aria-hidden": "true" }),
                 h("span", null, typeLabel(t, key)),
                 h("span", { className: "mneme-xcount2" }, String(counts[key]))
-              ))
+              )),
+            h("div", { className: "mneme-xcolhead", style: { marginLeft: 8 } }, t("memory.explorer.importance")),
+            // importance floor chips: filtering happens server-side so the
+            // paged chronological stream and its totals stay consistent
+            [0, 3, 4, 5].map((v) =>
+              h("button", {
+                key: v,
+                className: minImp === v ? "mneme-chip mneme-active" : "mneme-chip",
+                "aria-pressed": String(minImp === v),
+                onClick: () => setMinImp(v)
+              }, v === 0 ? t("memory.tab.all") : `★${v}+`))
           ),
           // 2. 底部三卡片
           h("div", { className: "mneme-xcards" },
             // 左卡：搜索
             h("div", { className: "mneme-card mneme-card--search", role: "region", "aria-label": t("memory.explorer.searchTitle") },
               h("div", { className: "mneme-xcolhead" }, t("memory.explorer.searchTitle")),
-              h("input", {
-                className: "mneme-search mneme-xsearch",
-                "aria-label": t("memory.explorer.search"),
-                placeholder: t("memory.explorer.search"),
-                value: query,
-                onChange: (e) => setQuery(e.target.value)
-              }),
+              h("div", { className: "mneme-xsearchwrap" },
+                h(Icon, { name: "search", size: 14, className: "mneme-xsearchico" }),
+                h("input", {
+                  className: "mneme-search mneme-xsearch",
+                  "aria-label": t("memory.explorer.search"),
+                  placeholder: t("memory.explorer.search"),
+                  value: query,
+                  onChange: (e) => setQuery(e.target.value)
+                })
+              ),
               entityQuery && h("button", {
                 className: "mneme-entitychip",
                 style: { textAlign: "left", justifyContent: "flex-start" },
@@ -2032,7 +2661,8 @@ window.__ModuleLoader__.load({
               ),
               h("div", { className: "mneme-xrow" },
                 h("span", { className: "mneme-xcount" }, t("memory.explorer.count").replace("{n}", String(visible.length))),
-                h("button", { className: "mneme-footbtn", onClick: () => setReloadKey((k) => k + 1) }, t("memory.explorer.refresh"))
+                h("button", { className: "mneme-footbtn", onClick: () => setReloadKey((k) => k + 1) },
+                  h(Icon, { name: "refresh", size: 12 }), t("memory.explorer.refresh"))
               )
             ),
             // 中卡：时间树
@@ -2040,26 +2670,36 @@ window.__ModuleLoader__.load({
               h("div", { className: "mneme-xcolhead" }, t("memory.explorer.timeline")),
               loading
                 ? h("div", { className: "mneme-xempty" }, "…")
-                : months.length === 0
-                  ? h("div", { className: "mneme-xempty" }, t("memory.explorer.empty"))
-                  : months.map((month) =>
-                      h("div", { key: month.key },
+                : visible.length === 0
+                  ? h("div", { className: "mneme-xempty" },
+                      h(Icon, { name: "inbox", size: 20, className: "mneme-xemptyico" }),
+                      t("memory.explorer.empty"))
+                  : months.map((month, mi) => {
+                      // Only the newest month starts expanded; older months
+                      // stay a one-line header until clicked — a several-
+                      // thousand-row store renders a handful of DOM nodes.
+                      const open = expandedMonths ? !!expandedMonths[month.key] : mi === 0;
+                      return h("div", { key: month.key },
                         h("button", {
                           className: "mneme-xmonth",
-                          "aria-expanded": String(!collapsed[month.key]),
-                          onClick: () => setCollapsed((c) => ({ ...c, [month.key]: !c[month.key] }))
+                          "aria-expanded": String(open),
+                          onClick: () => setExpandedMonths((c) => {
+                            const base = c || (months.length ? { [months[0].key]: true } : {});
+                            return { ...base, [month.key]: !open };
+                          })
                         },
-                          h("span", { className: "mneme-xcaret" }, collapsed[month.key] ? "▸" : "▾"),
-                          month.label
+                          h("span", { className: "mneme-xcaret" }, h(Icon, { name: open ? "chevronDown" : "chevronRight", size: 12 })),
+                          h("span", null, month.label),
+                          h("span", { className: "mneme-xmonthcount" }, String(month.count))
                         ),
-                        !collapsed[month.key] && month.days.map((day) =>
+                        open && month.days.map((day) =>
                           h("div", { key: day.key },
                             h("button", {
                               className: "mneme-xday",
                               "aria-expanded": String(!collapsed[day.key]),
                               onClick: () => setCollapsed((c) => ({ ...c, [day.key]: !c[day.key] }))
                             },
-                              h("span", { className: "mneme-xcaret" }, collapsed[day.key] ? "▸" : "▾"),
+                              h("span", { className: "mneme-xcaret" }, h(Icon, { name: collapsed[day.key] ? "chevronRight" : "chevronDown", size: 11 })),
                               day.label
                             ),
                             !collapsed[day.key] && day.items.map((m) => {
@@ -2078,10 +2718,20 @@ window.__ModuleLoader__.load({
                                 h("span", { className: "mneme-xname" }, m.title || m.content?.slice(0, 40))
                               );
                             })
-                          )
-                      )
-                  )
-            )),
+                          ))
+                      );
+                    }),
+              // load-more sentinel: the next 100-row page arrives when this
+              // row scrolls near (or the button is clicked)
+              h("div", { ref: moreRef, className: "mneme-xmore" },
+                canLoadMore
+                  ? h("button", { className: "mneme-footbtn", disabled: loadingMore, onClick: loadMore },
+                      loadingMore ? "…" : `${t("memory.explorer.loadMore")}（${items.length}/${total}）`)
+                  : (!loading && visible.length > 0 && !q && !remoteItems
+                      ? h("span", { className: "mneme-xcount" }, `${items.length} / ${total}`)
+                      : null)
+              )
+            ),
             // 右卡：详情
             h("div", { className: "mneme-card mneme-card--detail", role: "region", "aria-label": t("memory.explorer.detail") },
               selected
@@ -2143,17 +2793,40 @@ window.__ModuleLoader__.load({
                       ),
                       h("div", { className: "mneme-xdactions" },
                         h("button", { className: "mneme-footbtn", onClick: copyContent },
-                          copied ? t("memory.explorer.copied") : t("memory.explorer.copy"))
+                          h(Icon, { name: copied ? "check" : "copy", size: 12 }),
+                          copied ? t("memory.explorer.copied") : t("memory.explorer.copy")),
+                        // two-step delete: red outline arms, solid red commits
+                        confirmDelete
+                          ? h(react.Fragment, null,
+                              h("button", {
+                                className: "mneme-btn mneme-btndangerconfirm",
+                                disabled: deleting,
+                                onClick: deleteSelected
+                              }, t("memory.explorer.confirmDelete")),
+                              h("button", {
+                                className: "mneme-btn",
+                                onClick: () => setConfirmDelete(false)
+                              }, t("memory.explorer.cancel"))
+                            )
+                          : h("button", {
+                              className: "mneme-btn mneme-btndanger",
+                              onClick: () => setConfirmDelete(true)
+                            }, t("memory.explorer.delete")),
+                        deleteError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)" } },
+                          t("memory.explorer.deleteFailed"))
                       ),
                       h(BacklinksPanel, { memory: selected, t, onJump: jumpToMemory })
                     )
                   )
-                : h("div", { className: "mneme-xempty" }, t("memory.explorer.emptyDetail"))
+                : h("div", { className: "mneme-xempty" },
+                    deleteMsg && h("div", { className: "mneme-saved", style: { marginBottom: 6 } }, t("memory.explorer.deleted")),
+                    t("memory.explorer.emptyDetail"))
             )
           )
         ),
         view === "overview" && h(OverviewPanel, { t, onPickType: pickLayerType }),
         view === "directory" && h(DirectoryPanel, { t, onJump: jumpToMemory, collapsed: dirCollapsed, setCollapsed: setDirCollapsed }),
+        view === "status" && h(StatusPanel, { t }),
         view === "graph" && h(GraphPanel, { t, focusEntity: graphFocus, onJumpMemory: jumpToMemory }),
         view === "settings" && h("div", { className: "mneme-xsettings" },
           h("div", { className: "mneme-xsettings-inner" }, h(SettingsContent, { t }))

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -343,4 +343,56 @@ export const Config = z.object({
   recallRecordDefault: z.boolean().default(true),
   // recall_runs 滚动清理保留天数。
   recallRetentionDays: z.natural().min(1).max(3650).default(90),
+
+  // --- standalone external API (v0.7.12) ------------------------------------
+  // A plain node:http server for ecosystem integrations that cannot reach the
+  // DSH-internal webServer. Disabled by default; when enabled the Bearer token
+  // is persisted in the settings kv ("external_api"), auto-generated on first
+  // boot. Bind host: keep the loopback default — moving it to a non-loopback
+  // address exposes the whole memory store to the network and is the
+  // operator's responsibility.
+  externalApiEnabled: z.boolean().default(false),
+  externalApiPort: z.natural().default(8790),
+  externalApiHost: z.string().default("127.0.0.1"),
+
+  // --- light mode preset (v0.7.12) -------------------------------------------
+  // One switch for low-resource setups: turns off every background/semantic
+  // heavy path (dream consolidation, entity extraction, vector pipeline,
+  // reranker, BM25, semantic dedup / selective inject, sleep mode) while
+  // keeping the core loop (autoInject, autoSummarize, hot memory, quality
+  // filter, keyword search). Applied by applyLightModePreset before the config
+  // reaches any service; a persisted panel_mode="light" (settings kv) counts
+  // as lightMode=true too and wins over the bundle config.
+  lightMode: z.boolean().default(false),
 });
+
+// Fields forced to false by the light-mode preset. Everything not listed here
+// (autoInject, autoSummarize, hotMemory*, memoryQualityFilter, dream
+// thresholds/delays, ...) is left untouched — those are the core loop. The
+// light-mode downstream LLM passes (sleepEntityExtractionEnabled, autoTag)
+// stay out of the list on purpose: their drivers (sleepModeEnabled / autoDream)
+// are already off, so they can never fire.
+const LIGHT_MODE_OFF = [
+  "entityExtractionEnabled",
+  "autoDream",
+  "sleepModeEnabled",
+  "rerankEnabled",
+  "autoReindexOnBoot",
+  "hybridInject",
+  "searchSemanticDedup",
+  "selectiveInjectEnabled",
+  "bm25SearchEnabled"
+];
+
+/**
+ * Apply the light-mode preset to a resolved config object (pure function,
+ * exported for tests). When cfg.lightMode is not exactly true the config is
+ * returned unchanged; otherwise a shallow copy carries false for every heavy
+ * feature. Idempotent and side-effect free.
+ */
+export function applyLightModePreset(cfg) {
+  if (cfg?.lightMode !== true) return cfg;
+  const preset = { ...cfg, lightMode: true };
+  for (const key of LIGHT_MODE_OFF) preset[key] = false;
+  return preset;
+}

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -7,13 +7,14 @@ import { createSummarizer } from "./summarize.js";
 import { createDreamScheduler } from "./dream.js";
 import { createSleepScheduler, runSleep } from "./dream/sleep.js";
 import { createApi } from "./api.js";
+import { createStandaloneApi } from "./api-standalone.js";
 import { createSettings } from "./settings.js";
 import { createCommandManager } from "./commands.js";
 import { createEmbedder } from "./embedding.js";
 import { createEmbedderByProvider } from "./local-embedder.js";
 import { LocalReranker } from "./reranker.js";
 import { createVectorIndex } from "./vector-index.js";
-import { Config } from "./config.js";
+import { Config, applyLightModePreset } from "./config.js";
 import { extractEntities } from "./entities/extractor.js";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
@@ -29,12 +30,12 @@ export { Config };
 // has no prototype, is called normally, and its returned disposer is collected
 // and run by the fiber on unload.
 export const apply = (ctx, config) => {
-  const cfg = Config(config);
+  const rawCfg = Config(config);
 
   // Resolve memoryDir: expand leading "~"
-  const memoryDir = cfg.memoryDir.startsWith("~")
-    ? join(homedir(), cfg.memoryDir.slice(1))
-    : cfg.memoryDir;
+  const memoryDir = rawCfg.memoryDir.startsWith("~")
+    ? join(homedir(), rawCfg.memoryDir.slice(1))
+    : rawCfg.memoryDir;
   mkdirSync(memoryDir, { recursive: true });
 
   const store = createStore(join(memoryDir, "memory.db"));
@@ -47,8 +48,8 @@ export const apply = (ctx, config) => {
   // default 90). Best-effort like the failure prune — the audit trail is
   // bookkeeping and a failed purge must never block plugin boot.
   try {
-    if (cfg.llmAudit?.enabled !== false) {
-      const retentionMs = Number.isInteger(cfg.llmAudit?.retentionDays) ? cfg.llmAudit.retentionDays : 90;
+    if (rawCfg.llmAudit?.enabled !== false) {
+      const retentionMs = Number.isInteger(rawCfg.llmAudit?.retentionDays) ? rawCfg.llmAudit.retentionDays : 90;
       store.deleteOldLlmAudits(new Date(Date.now() - retentionMs * 86400000).toISOString());
     }
   } catch { /* non-fatal */ }
@@ -56,15 +57,27 @@ export const apply = (ctx, config) => {
   // 活跃度增长；启动时按 recallRetentionDays（默认 90 天）清一次，防膨胀。
   // 与 llm_audit 同策略：纯 bookkeeping，清理失败绝不阻塞插件启动。
   try {
-    const recallRetentionDays = Number.isInteger(cfg.recallRetentionDays) ? cfg.recallRetentionDays : 90;
+    const recallRetentionDays = Number.isInteger(rawCfg.recallRetentionDays) ? rawCfg.recallRetentionDays : 90;
     store.purgeRecallRunsOlderThan(recallRetentionDays);
   } catch { /* non-fatal */ }
-  const mirror = createMirror(memoryDir);
-  // User-configurable settings (profile, rules) and custom commands share the
-  // same SQLite file but live in dedicated tables, isolated from memories.
-  // Created before the service so the tag-config resolver (issue #31) can merge
-  // the Web panel's persisted toggles over the plugin config at runtime.
+
+  // User-configurable settings (profile, rules, panel mode, standalone API
+  // token) share the same SQLite file in dedicated tables, isolated from
+  // memories. Created before the config is finalized: the tag-config resolver
+  // (issue #31) merges the persisted toggles over the plugin config at
+  // runtime, and the persisted panel_mode participates in light-mode
+  // resolution below.
   const settings = createSettings(store.db);
+
+  // Light mode (v0.7.12): the bundle config flag OR a persisted panel_mode of
+  // "light" (the panel switch wins over the bundle config so it survives
+  // config redeploys). applyLightModePreset turns every heavy background /
+  // semantic feature off and keeps the core loop (autoInject, autoSummarize,
+  // hot memory, quality filter).
+  const lightMode = rawCfg.lightMode === true || settings.getPanelMode() === "light";
+  const cfg = applyLightModePreset({ ...rawCfg, lightMode });
+
+  const mirror = createMirror(memoryDir);
   const service = createService({ store, mirror, config: cfg, logger: ctx.logger, settings });
 
   // F-NEW-03: if the mirror sync failed last run (persisted dirty state), retry
@@ -115,7 +128,13 @@ export const apply = (ctx, config) => {
 
   let embedder = null;
   let reranker = null;
-  if (cfg.embedProvider === "openai") {
+  if (lightMode) {
+    // Light mode: the whole vector pipeline stays off — no embedder (nothing
+    // pulls in ONNX/transformers), no reranker, no boot backfill (the preset
+    // also cleared autoReindexOnBoot). Recall degrades to keyword search and
+    // human mirror edits still merge on boot.
+    applyHumanEdits();
+  } else if (cfg.embedProvider === "openai") {
     // vectorIndex is passed so the legacy OpenAI embedder records the producing
     // model fingerprint after each successful embed (Bug3).
     embedder = createEmbedder({ store, settings, logger: ctx.logger, vectorIndex });
@@ -352,6 +371,19 @@ export const apply = (ctx, config) => {
       list: () => []
     }, embedder, { vectorIndex, reranker }, cfg.apiToken);
     disposers.push(api.dispose);
+  }
+
+  // Standalone external API (v0.7.12): plain node:http server for ecosystem
+  // integrations outside the DSH host. Persisted external_api settings win
+  // over the bundle config (enabled/port); the Bearer token lives in the same
+  // kv and is auto-generated on first boot by createStandaloneApi. Binding a
+  // non-loopback host is the operator's documented responsibility.
+  if ((settings.getExternalApi?.()?.enabled ?? cfg.externalApiEnabled) === true) {
+    const standalone = createStandaloneApi({ service, store, config: cfg, logger: ctx.logger, settings });
+    disposers.push(() => standalone.server.close());
+    standalone.ready.catch((error) => {
+      ctx.logger?.warn?.(`[dsh-mneme] standalone API failed to start: ${String(error)}`);
+    });
   }
 
   // Async disposer: cordis awaits the returned promise on unload (runDisposable),

--- a/dsh-mneme/src/settings.js
+++ b/dsh-mneme/src/settings.js
@@ -207,6 +207,46 @@ export function createSettings(db) {
       else if (cur.showSidebarTrigger !== undefined) cfg.showSidebarTrigger = cur.showSidebarTrigger === true;
       setSetting("ui", JSON.stringify(cfg));
       return cfg;
+    },
+
+    /**
+     * Standalone external API settings (kv "external_api"): {enabled, port,
+     * host, token}. The Bearer token is auto-generated on first boot and
+     * persisted here. Partial writes preserve the keys they don't mention.
+     */
+    getExternalApi() {
+      const raw = getSetting("external_api");
+      if (!raw) return undefined;
+      try {
+        const cfg = JSON.parse(raw);
+        return typeof cfg === "object" && cfg !== null ? cfg : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    setExternalApi(patch = {}) {
+      const prev = this.getExternalApi() ?? {};
+      const port = Number(patch.port ?? prev.port);
+      const host = typeof patch.host === "string" && patch.host.trim() ? patch.host.trim() : (prev.host ?? "127.0.0.1");
+      const cfg = {
+        enabled: patch.enabled !== undefined ? patch.enabled === true : prev.enabled === true,
+        port: Number.isInteger(port) && port > 0 ? port : 8790,
+        host,
+        token: String(patch.token ?? prev.token ?? "")
+      };
+      setSetting("external_api", JSON.stringify(cfg));
+      return cfg;
+    },
+
+    /**
+     * Web panel mode (kv "panel_mode"): "light" (low-resource preset) or
+     * "standard" (full feature set). Unset reads as "standard".
+     */
+    getPanelMode() {
+      return getSetting("panel_mode") === "light" ? "light" : "standard";
+    },
+    setPanelMode(mode) {
+      setSetting("panel_mode", mode === "light" ? "light" : "standard");
     }
   };
 }

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -243,7 +243,9 @@ CREATE TABLE IF NOT EXISTS mirror_state (
 );
 `;
 
-const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern", "user", "fact"]);
+// Exported so the standalone API layer (api-standalone.js) can validate
+// incoming memory types against the same set the store enforces.
+export const TYPES = new Set(["preference", "project", "decision", "history", "summary", "pattern", "user", "fact"]);
 
 // Epistemic status: what kind of evidence a memory rests on. Defaults to
 // 'subjective' so legacy rows (and rows without any signal) stay compatible.
@@ -650,12 +652,21 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
+  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
       clauses.push("type = ?");
       params.push(type);
+    }
+    // Same filters as list() so a paged caller's total matches its rows.
+    if (minImportance != null) {
+      clauses.push("importance >= ?");
+      params.push(minImportance);
+    }
+    if (source != null) {
+      clauses.push("source = ?");
+      params.push(source);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
@@ -1072,12 +1083,22 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, includeForgotten = false, includeArchived = false, includeDisposed = false } = {}) {
+  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, includeDisposed = false, minImportance = null, source = null } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
       clauses.push("type = ?");
       params.push(type);
+    }
+    // Optional server-side filters: importance floor and exact source match.
+    // Both stay out of the query when unset so existing callers are unaffected.
+    if (minImportance != null) {
+      clauses.push("importance >= ?");
+      params.push(minImportance);
+    }
+    if (source) {
+      clauses.push("source = ?");
+      params.push(source);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
@@ -1090,8 +1111,13 @@ export function createStore(path) {
     }
     const { limit: lim, offset: off } = sanitizePage(limit, offset, 50);
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+    // "chrono" is pure newest-first — the stable order paged browsing (month
+    // tree, infinite scroll) needs; importance ordering would interleave
+    // months across pages. Default keeps the importance-ranked order other
+    // callers rely on.
+    const orderBy = order === "chrono" ? "updated_at DESC, id DESC" : "importance DESC, updated_at DESC, id";
     const rows = db.prepare(
-      `SELECT * FROM memories ${where} ORDER BY importance DESC, updated_at DESC, id LIMIT ? OFFSET ?`
+      `SELECT * FROM memories ${where} ORDER BY ${orderBy} LIMIT ? OFFSET ?`
     ).all(...params, lim, off);
     return rows.map(toRow);
   }

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -155,10 +155,10 @@ test("graph toggle uses a node-graph glyph, not the share icon", () => {
 });
 
 // Every memory feature lives in the main-area library now: the explorer
-// hosts three sub-views (browse / graph / settings) switched by tabs whose
-// labels come from dedicated dictionary keys.
-test("explorer hosts browse, graph and settings sub-views", () => {
-  for (const key of ["tabMemory", "tabGraph", "tabSettings"]) {
+// hosts six sub-views (browse / overview / directory / status / graph /
+// settings) switched by tabs whose labels come from dedicated dictionary keys.
+test("explorer hosts browse, overview, directory, status, graph and settings sub-views", () => {
+  for (const key of ["tabMemory", "tabOverview", "tabDirectory", "tabStatus", "tabGraph", "tabSettings"]) {
     assert.ok(
       clientSource.includes(`"memory.explorer.${key}"`),
       `sub-view labels must come from memory.explorer.${key}`
@@ -167,6 +167,10 @@ test("explorer hosts browse, graph and settings sub-views", () => {
   assert.ok(
     clientSource.includes('h(GraphPanel, { t, focusEntity: graphFocus, onJumpMemory: jumpToMemory })'),
     "the graph panel must be embedded as a sub-view"
+  );
+  assert.ok(
+    clientSource.includes('h(StatusPanel, { t })'),
+    "the status panel must be embedded as a sub-view"
   );
   assert.ok(
     clientSource.includes('h(SettingsContent, { t })'),
@@ -306,10 +310,18 @@ test("detail pane renders editable tag chips backed by the tags endpoint", () =>
   );
 });
 
-test("tag: queries run server-side regardless of the semantic toggle", () => {
+// The browse search is fully server-side now: every query rides the search
+// endpoint — keyword = literal text (default), vector = semantic ranking via
+// the semantic toggle — so matches are global, not limited to loaded pages.
+// tag: chips still set a tag:<tag> query which rides the same endpoint.
+test("search runs server-side for every query (keyword default, vector via the semantic toggle)", () => {
   assert.ok(
-    clientSource.includes('(!semantic && !q.startsWith("tag:"))'),
-    "tag: must bypass the semantic toggle and use the search endpoint"
+    clientSource.includes('const mode = semantic ? "vector" : "keyword";'),
+    "the search mode must flip between keyword and vector with the semantic toggle"
+  );
+  assert.ok(
+    clientSource.includes("&mode=${mode}"),
+    "the search endpoint must receive the selected mode"
   );
   assert.ok(
     clientSource.includes('setQuery(`tag:${tag}`)'),
@@ -438,4 +450,231 @@ test("sidebar trigger is hidden when showSidebarTrigger is false (issue #38)", (
     clientSource.includes('"memory.settings.sidebarTriggerTitle"'),
     "settings panel must expose a sidebar-trigger toggle"
   );
+});
+
+// --- 0.7.11/0.7.12 panel port: paged chrono browse + month collapse, server
+// search, status sub-view, two-step delete + importance filter, runtime-mode /
+// external-API setting cards and the inline stroke icon system ---
+
+// Browse streams 100-row pure-chronological pages (order=chrono): the default
+// importance ordering would interleave months across pages and break the
+// month tree. A sentinel auto-pulls the next page; a button does it manually.
+test("browse loads 100-row chronological pages with a load-more sentinel", () => {
+  assert.ok(
+    clientSource.includes("const PAGE_SIZE = 100;"),
+    "the browse page size must be 100 rows"
+  );
+  assert.ok(
+    clientSource.includes("&order=chrono"),
+    "browse pages must stream in pure chronological order"
+  );
+  assert.ok(
+    /apiFetch\(listUrl\(items\.length\)\)/.test(clientSource),
+    "loadMore must fetch the next offset page"
+  );
+  assert.ok(
+    clientSource.includes("new IntersectionObserver"),
+    "a sentinel must auto-pull the next page on scroll"
+  );
+  assert.ok(
+    clientSource.includes('"memory.explorer.loadMore"'),
+    "the load-more affordance must be localized"
+  );
+});
+
+// Only the newest month starts expanded; older months stay one-line sticky
+// headers (with a per-month count) until clicked.
+test("month tree collapses to the newest month with sticky headers and counts", () => {
+  assert.ok(
+    clientSource.includes("const [expandedMonths, setExpandedMonths] = useState(null);"),
+    "null expandedMonths must mean only the newest month is open"
+  );
+  assert.ok(
+    clientSource.includes("const open = expandedMonths ? !!expandedMonths[month.key] : mi === 0;"),
+    "the newest month (mi === 0) must start open, older ones closed"
+  );
+  assert.ok(
+    clientSource.includes(".mneme-xmonth{position:sticky"),
+    "month headers must stick to the top of the timeline card"
+  );
+  assert.ok(
+    clientSource.includes('"mneme-xmonthcount"'),
+    "each month header must carry its entry count"
+  );
+});
+
+// The memory sub-view refreshes on activation and quietly re-fetches page 1
+// every 30s while visible; hidden pages must not trigger fetches.
+test("memory sub-view refreshes on activation and polls quietly every 30s", () => {
+  assert.ok(
+    clientSource.includes('if (document.visibilityState === "visible") refreshFirstPage();'),
+    "the 30s poll must pause while the page is hidden"
+  );
+  assert.ok(
+    clientSource.includes("}, 30000);"),
+    "the live-view poll interval is 30 seconds"
+  );
+  assert.ok(
+    clientSource.includes("if (view !== \"memory\") return undefined;"),
+    "the live-view polling must only run while the browse tab is open"
+  );
+});
+
+// Importance floor chips (全部/★3+/★4+/★5) filter server-side together with
+// the type filter so pagination and totals stay consistent.
+test("importance filter chips travel server-side with the type filter", () => {
+  assert.ok(
+    clientSource.includes("&minImportance=${minImp}"),
+    "the importance floor must be a server-side query parameter"
+  );
+  assert.ok(
+    /\[0, 3, 4, 5\]\.map/.test(clientSource),
+    "the filter bar must offer the all/★3+/★4+/★5 chips"
+  );
+  assert.ok(
+    clientSource.includes('t("memory.explorer.importance")'),
+    "the chip group must be labeled with the localized importance heading"
+  );
+});
+
+// The detail pane delete is a two-step confirm (red outline arms, solid red
+// commits) posting to /delete; success removes the row locally and shrinks
+// the total, failure surfaces a transient error note.
+test("detail delete is a two-step confirm posting /delete", () => {
+  assert.ok(
+    clientSource.includes('apiFetch("/api/dsh-mneme/delete"'),
+    "the detail pane must POST to the delete endpoint"
+  );
+  assert.ok(
+    clientSource.includes('"memory.explorer.confirmDelete"') &&
+      clientSource.includes('"memory.explorer.cancel"'),
+    "the confirm/cancel step must be localized"
+  );
+  assert.ok(
+    clientSource.includes("setTotal((n) => Math.max(0, n - 1))"),
+    "a successful delete must shrink the server total locally"
+  );
+  assert.ok(
+    clientSource.includes(".mneme-btndanger{"),
+    "the delete affordance must use the red outline/solid danger styles"
+  );
+  assert.ok(
+    !/window\.confirm\(/.test(clientSource.slice(clientSource.indexOf("const deleteSelected"))),
+    "the detail delete path must not rely on window.confirm"
+  );
+});
+
+// The status sub-view is a grid of four stat cards, each with its own
+// fetch/loading/error state so one failing endpoint never blocks the others.
+test("status sub-view renders four independent stat cards", () => {
+  for (const ep of [
+    "/api/dsh-mneme/list?limit=1&order=chrono",
+    "/api/dsh-mneme/entities?limit=500",
+    "/api/dsh-mneme/vector-config",
+    "/api/dsh-mneme/semantic/llm-audit/stats?days=7"
+  ]) {
+    assert.ok(
+      clientSource.includes(ep),
+      `status cards must fetch ${ep}`
+    );
+  }
+  assert.ok(
+    clientSource.includes("function StatusCard({ t, title, loading, error, num, cap })"),
+    "every status card must own its loading/error state"
+  );
+});
+
+// Two boxed settings cards: runtime mode (light/standard chips, PUT /mode,
+// restart hint, light-mode off-list) and the external access API (enable
+// chips, host/port with validation, server-owned read-only token with copy).
+test("settings ship runtime-mode and external-API cards", () => {
+  assert.ok(
+    clientSource.includes('apiFetch("/api/dsh-mneme/mode"'),
+    "the mode card must read /mode"
+  );
+  assert.ok(
+    clientSource.includes("body: JSON.stringify({ mode: next })"),
+    "the mode card must PUT the selected mode"
+  );
+  assert.ok(
+    clientSource.includes('"memory.settings.mode.offList"'),
+    "light mode must show the disabled-features hint"
+  );
+  assert.ok(
+    clientSource.includes('apiFetch("/api/dsh-mneme/external-api"'),
+    "the external-API card must read /external-api"
+  );
+  assert.ok(
+    clientSource.includes('t("memory.settings.extapi.invalidPort")'),
+    "the port input must be validated (1-65535)"
+  );
+  assert.ok(
+    clientSource.includes("mneme-set-token"),
+    "the server-owned token must render read-only with a copy affordance"
+  );
+  assert.ok(
+    clientSource.includes(".mneme-set-card{"),
+    "the two cards must use the boxed card style"
+  );
+});
+
+// The explorer ships an inline Lucide stroke icon system (no runtime
+// dependency): path data tuples rendered by the Icon component, replacing
+// text arrows and ad-hoc glyphs across the panel.
+test("the explorer ships an inline stroke icon system", () => {
+  assert.ok(
+    clientSource.includes("const ICON_PATHS = {"),
+    "stroke icon path data must ship inline"
+  );
+  for (const name of ["database", "waypoints", "settings", "search", "refresh", "chevronDown", "chevronRight", "copy", "check", "inbox", "activity"]) {
+    assert.ok(
+      clientSource.includes(`${name}: [["`),
+      `the ${name} icon must be defined`
+    );
+  }
+  assert.ok(
+    clientSource.includes("h(Icon, { name: open ? \"chevronDown\" : \"chevronRight\""),
+    "month carets must render through the Icon component"
+  );
+});
+
+// Every ported label ships in both dictionaries.
+test("ported features ship localized labels in both dictionaries", () => {
+  for (const key of [
+    "memory.explorer.tabStatus",
+    "memory.explorer.loadMore",
+    "memory.explorer.delete",
+    "memory.explorer.confirmDelete",
+    "memory.explorer.cancel",
+    "memory.explorer.deleted",
+    "memory.explorer.deleteFailed",
+    "memory.status.memories",
+    "memory.status.entities",
+    "memory.status.vector",
+    "memory.status.vectorOn",
+    "memory.status.vectorOff",
+    "memory.status.llm",
+    "memory.status.llmCalls",
+    "memory.status.error",
+    "memory.settings.mode.title",
+    "memory.settings.mode.light",
+    "memory.settings.mode.standard",
+    "memory.settings.mode.savedHint",
+    "memory.settings.mode.offList",
+    "memory.settings.extapi.title",
+    "memory.settings.extapi.enabled",
+    "memory.settings.extapi.disabled",
+    "memory.settings.extapi.address",
+    "memory.settings.extapi.port",
+    "memory.settings.extapi.token",
+    "memory.settings.extapi.copy",
+    "memory.settings.extapi.copied",
+    "memory.settings.extapi.savedHint",
+    "memory.settings.extapi.invalidPort"
+  ]) {
+    assert.ok(
+      clientSource.includes(`"${key}"`),
+      `${key} key must exist`
+    );
+  }
 });

--- a/dsh-mneme/test/settings.test.js
+++ b/dsh-mneme/test/settings.test.js
@@ -142,3 +142,27 @@ test("ui config coerces non-boolean to false", () => {
   assert.deepEqual(settings.getUiConfig(), { showSidebarTrigger: false });
   store.close();
 });
+
+test("panel mode defaults to standard and round-trips", () => {
+  const { store, settings } = setup();
+  assert.equal(settings.getPanelMode(), "standard");
+  settings.setPanelMode("light");
+  assert.equal(settings.getPanelMode(), "light");
+  settings.setPanelMode("standard");
+  assert.equal(settings.getPanelMode(), "standard");
+  store.close();
+});
+
+test("external api settings persist token and merge partial writes", () => {
+  const { store, settings } = setup();
+  assert.equal(settings.getExternalApi(), undefined);
+  settings.setExternalApi({ enabled: true, port: 9000, token: "tok-1" });
+  assert.deepEqual(settings.getExternalApi(), { enabled: true, port: 9000, host: "127.0.0.1", token: "tok-1" });
+  // Token-only write preserves the other keys.
+  settings.setExternalApi({ token: "tok-2" });
+  assert.deepEqual(settings.getExternalApi(), { enabled: true, port: 9000, host: "127.0.0.1", token: "tok-2" });
+  // Host write persists and survives the next partial merge.
+  settings.setExternalApi({ host: "0.0.0.0" });
+  assert.deepEqual(settings.getExternalApi(), { enabled: true, port: 9000, host: "0.0.0.0", token: "tok-2" });
+  store.close();
+});

--- a/dsh-mneme/test/standalone-api.test.js
+++ b/dsh-mneme/test/standalone-api.test.js
@@ -1,0 +1,326 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createStore } from "../src/store.js";
+import { createService } from "../src/service.js";
+import { createSettings } from "../src/settings.js";
+import { createStandaloneApi } from "../src/api-standalone.js";
+import { Config, applyLightModePreset } from "../src/config.js";
+
+// Real HTTP server on an OS-assigned port (port: 0), driven with fetch.
+async function setup() {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const settings = createSettings(store.db);
+  const api = createStandaloneApi({ service, store, config: {}, settings, logger: null, port: 0 });
+  await api.ready;
+  const base = `http://127.0.0.1:${api.port}`;
+  const auth = { authorization: `Bearer ${api.token}` };
+  return {
+    store,
+    service,
+    settings,
+    api,
+    base,
+    auth,
+    close: () => {
+      // Drop pooled keep-alive sockets so node --test can drain the loop.
+      api.server.closeIdleConnections?.();
+      api.server.close();
+      store.close();
+    }
+  };
+}
+
+// --- auth ---------------------------------------------------------------------
+
+test("GET /health is open without a token; every other route 401s", async () => {
+  const { base, close } = await setup();
+  try {
+    const health = await fetch(`${base}/health`);
+    assert.equal(health.status, 200);
+    assert.deepEqual(await health.json(), { ok: true });
+
+    for (const path of ["/status", "/memories", "/memories/x", "/search?q=x"]) {
+      const res = await fetch(`${base}${path}`);
+      assert.equal(res.status, 401, `${path} requires a token`);
+      assert.deepEqual(await res.json(), { error: "unauthorized" });
+    }
+
+    const bad = await fetch(`${base}/status`, { headers: { authorization: "Bearer wrong-token" } });
+    assert.equal(bad.status, 401, "wrong token rejected");
+  } finally {
+    close();
+  }
+});
+
+test("token is persisted into settings kv and reused across restarts", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const settings = createSettings(store.db);
+  const first = createStandaloneApi({ service, store, config: {}, settings, port: 0 });
+  await first.ready;
+  try {
+    assert.equal(settings.getExternalApi().token, first.token, "generated token persisted");
+    assert.ok(first.token.length >= 20, "token is a real random value");
+    const second = createStandaloneApi({ service, store, config: {}, settings, port: 0 });
+    await second.ready;
+    assert.equal(second.token, first.token, "restart reuses the persisted token");
+    second.server.closeIdleConnections?.();
+    second.server.close();
+  } finally {
+    first.server.closeIdleConnections?.();
+    first.server.close();
+    store.close();
+  }
+});
+
+// --- CRUD loop ------------------------------------------------------------------
+
+test("POST/GET/DELETE /memories round trip", async () => {
+  const { base, auth, close } = await setup();
+  try {
+    const post = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "preference", title: "语言", content: "始终用中文回复", importance: 4, tags: ["交流"] })
+    });
+    assert.equal(post.status, 201);
+    const created = await post.json();
+    assert.ok(created.id, "row id returned");
+    assert.equal(created.title, "语言");
+    assert.equal(created.importance, 4);
+
+    const list = await fetch(`${base}/memories?limit=10`, { headers: auth });
+    assert.equal(list.status, 200);
+    const listBody = await list.json();
+    assert.equal(listBody.total, 1);
+    assert.equal(listBody.items.length, 1);
+
+    const got = await fetch(`${base}/memories/${created.id}`, { headers: auth });
+    assert.equal(got.status, 200);
+    assert.equal((await got.json()).content, "始终用中文回复");
+
+    const del = await fetch(`${base}/memories/${created.id}`, { method: "DELETE", headers: auth });
+    assert.equal(del.status, 200);
+    assert.deepEqual(await del.json(), { ok: true });
+
+    const gone = await fetch(`${base}/memories/${created.id}`, { headers: auth });
+    assert.equal(gone.status, 404, "deleted row reads back as 404");
+    const delAgain = await fetch(`${base}/memories/${created.id}`, { method: "DELETE", headers: auth });
+    assert.equal(delAgain.status, 404, "deleting a missing row is 404, not a fake ok");
+  } finally {
+    close();
+  }
+});
+
+test("POST /memories dedupes same title within a type (200 + merged content)", async () => {
+  const { base, auth, close } = await setup();
+  try {
+    const first = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "project", title: "mneme", content: "v1 内容" })
+    });
+    assert.equal(first.status, 201);
+    const row1 = await first.json();
+
+    const second = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "project", title: "mneme", content: "v2 追加" })
+    });
+    assert.equal(second.status, 200, "merge, not a second creation");
+    const row2 = await second.json();
+    assert.equal(row2.id, row1.id, "same row reused");
+    assert.ok(row2.content.includes("v1 内容") && row2.content.includes("v2 追加"), "content appended");
+
+    const list = await fetch(`${base}/memories`, { headers: auth });
+    assert.equal((await list.json()).total, 1, "no duplicate row created");
+  } finally {
+    close();
+  }
+});
+
+test("POST /memories validation: invalid type, bad JSON, non-array tags → 400", async () => {
+  const { base, auth, close } = await setup();
+  try {
+    const badType = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "diary", title: "t", content: "c" })
+    });
+    assert.equal(badType.status, 400);
+    assert.deepEqual(await badType.json(), { error: "invalid-type" });
+
+    const badJson = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: "{not json"
+    });
+    assert.equal(badJson.status, 400);
+    assert.deepEqual(await badJson.json(), { error: "invalid-json" });
+
+    const badTags = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "project", title: "t", content: "c", tags: "x" })
+    });
+    assert.equal(badTags.status, 400);
+    assert.deepEqual(await badTags.json(), { error: "tags-must-be-an-array" });
+
+    const noTitle = await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "project", content: "c" })
+    });
+    assert.equal(noTitle.status, 400);
+    assert.deepEqual(await noTitle.json(), { error: "missing-title" });
+  } finally {
+    close();
+  }
+});
+
+// --- list filters / status / search ---------------------------------------------
+
+test("GET /memories honors type + minImportance filters and paging", async () => {
+  const { base, auth, service, close } = await setup();
+  try {
+    service.saveWithDedupe({ type: "preference", title: "低", content: "i2", importance: 2 });
+    service.saveWithDedupe({ type: "preference", title: "高", content: "i5", importance: 5 });
+    service.saveWithDedupe({ type: "project", title: "项目", content: "i4", importance: 4 });
+
+    const byType = await fetch(`${base}/memories?type=preference`, { headers: auth });
+    assert.equal((await byType.json()).total, 2);
+
+    const byImportance = await fetch(`${base}/memories?minImportance=4`, { headers: auth });
+    const filtered = await byImportance.json();
+    assert.equal(filtered.total, 2);
+    assert.deepEqual(filtered.items.map((m) => m.title).sort(), ["项目", "高"]);
+
+    const paged = await fetch(`${base}/memories?limit=2&offset=0&order=chrono`, { headers: auth });
+    const page = await paged.json();
+    assert.equal(page.items.length, 2);
+    assert.equal(page.total, 3);
+  } finally {
+    close();
+  }
+});
+
+test("GET /status reports version, per-type totals, entities and uptime", async () => {
+  const { base, auth, service, close } = await setup();
+  try {
+    service.saveWithDedupe({ type: "preference", title: "p", content: "c" });
+    service.saveWithDedupe({ type: "project", title: "j", content: "c" });
+    service.saveWithDedupe({ type: "project", title: "j2", content: "c" });
+
+    const res = await fetch(`${base}/status`, { headers: auth });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.version, "0.7.12");
+    assert.equal(body.memories.total, 3);
+    assert.equal(body.memories.byType.preference, 1);
+    assert.equal(body.memories.byType.project, 2);
+    assert.equal(body.entities, 0, "no extraction wired → empty entity table");
+    assert.ok(Number.isInteger(body.uptime_s));
+  } finally {
+    close();
+  }
+});
+
+test("GET /search finds saved memories; empty q returns empty keyword result", async () => {
+  const { base, auth, close } = await setup();
+  try {
+    await fetch(`${base}/memories`, {
+      method: "POST",
+      headers: { ...auth, "content-type": "application/json" },
+      body: JSON.stringify({ type: "project", title: "记忆插件", content: "SQLite 全文检索" })
+    });
+
+    const res = await fetch(`${base}/search?q=${encodeURIComponent("全文检索")}&mode=keyword`, { headers: auth });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.mode, "keyword");
+    assert.equal(body.items.length, 1);
+    assert.equal(body.items[0].title, "记忆插件");
+
+    const empty = await fetch(`${base}/search?q=`, { headers: auth });
+    assert.deepEqual(await empty.json(), { items: [], mode: "keyword" });
+  } finally {
+    close();
+  }
+});
+
+test("unknown path returns 404 json", async () => {
+  const { base, auth, close } = await setup();
+  try {
+    const res = await fetch(`${base}/nope`, { headers: auth });
+    assert.equal(res.status, 404);
+    assert.deepEqual(await res.json(), { error: "not-found" });
+  } finally {
+    close();
+  }
+});
+
+// --- light-mode preset (applyLightModePreset) ------------------------------------
+
+const LIGHT_OFF_FIELDS = [
+  "entityExtractionEnabled",
+  "autoDream",
+  "sleepModeEnabled",
+  "rerankEnabled",
+  "autoReindexOnBoot",
+  "hybridInject",
+  "searchSemanticDedup",
+  "selectiveInjectEnabled",
+  "bm25SearchEnabled"
+];
+
+test("applyLightModePreset turns heavy features off and keeps the core loop", () => {
+  const cfg = applyLightModePreset(Config({ lightMode: true }));
+  for (const field of LIGHT_OFF_FIELDS) {
+    assert.equal(cfg[field], false, `${field} forced off in light mode`);
+  }
+  // Core loop preserved.
+  assert.equal(cfg.autoInject, true);
+  assert.equal(cfg.autoSummarize, true);
+  assert.equal(cfg.hotMemoryEnabled, true);
+  assert.equal(cfg.memoryQualityFilter.enabled, true);
+  // Unrelated knobs untouched.
+  assert.equal(cfg.dreamThresholdCount, 10);
+  assert.equal(cfg.dreamDelayMs, 2000);
+  assert.equal(cfg.maxInjectedItems, 5);
+});
+
+test("applyLightModePreset keeps explicit non-preset values and is a no-op without lightMode", () => {
+  const tuned = applyLightModePreset(Config({ lightMode: true, dreamThresholdCount: 30, maxInjectedItems: 8 }));
+  assert.equal(tuned.dreamThresholdCount, 30, "operator values survive the preset");
+  assert.equal(tuned.maxInjectedItems, 8);
+
+  const plain = Config({});
+  assert.equal(applyLightModePreset(plain), plain, "identity when lightMode is unset");
+  const off = Config({ lightMode: false });
+  assert.equal(applyLightModePreset(off), off, "identity when lightMode is false");
+});
+
+test("persisted panel_mode=light wins over a bundle config that did not ask for it", () => {
+  const store = createStore(":memory:");
+  const settings = createSettings(store.db);
+  try {
+    // Panel switched to light in a previous session; bundle config says nothing.
+    settings.setPanelMode("light");
+    const rawCfg = Config({});
+    const lightMode = rawCfg.lightMode === true || settings.getPanelMode() === "light";
+    const cfg = applyLightModePreset({ ...rawCfg, lightMode });
+    assert.equal(lightMode, true, "persisted mode forces light");
+    assert.equal(cfg.autoDream, false);
+    assert.equal(cfg.entityExtractionEnabled, false);
+    assert.equal(cfg.autoInject, true, "core injection stays on");
+
+    // standard (default) never forces the preset even with a light bundle flag off.
+    settings.setPanelMode("standard");
+    const raw2 = Config({});
+    assert.equal(raw2.lightMode === true || settings.getPanelMode() === "light", false);
+  } finally {
+    store.close();
+  }
+});


### PR DESCRIPTION
## 这是什么

把本地快速迭代线上的 **0.7.11 + 0.7.12** 全部增量移植到 0.7.10 主线（npm 上两版已发布，本 PR 使 git 主线与 registry 对齐）。

## 0.7.12 — 🌐 独立外部 API + CLI + 轻量模式

- **独立外部 API**：插件自持 HTTP 服务（默认 `127.0.0.1:8790`，仅回环绑定，Bearer token 自动生成持久化）。路由：`GET /health`（免鉴权）、`GET /status`、`GET/POST/DELETE /memories`、`GET /memories/:id`、`GET /search`。exact 路由 22 → 25。
- **CLI `dsh-mneme`**（`bin/cli.mjs`，零依赖）：status / list / search / get / add / delete / config set|show|path；配置 参数 > 环境变量 > `~/.dsh-mneme/cli.json`。
- **轻量模式**：`applyLightModePreset` 关闭 9 项重资源字段（autoDream/睡眠/实体抽取/rerank/bm25/选择性注入/语义去重/自动重建索引/hybrid 注入），保留 autoInject/autoSummarize/hot memory/质量过滤；`panel_mode` 持久化优先于 bundle 配置；设置面板一键切换。
- **设置面板**：「运行模式」与「外部访问 API」两张新卡（中英双语）。

## 0.7.11 — 🐛 修复 + 面板改版

- **#72**：图谱模拟改用 viewBox 用户单位，最大化窗口节点可见。
- **#59**：snapshotEvents 兼容垫片（与主线 0.7.8/0.7.9 修复同语义，合并后无回退）。
- **面板改版**：chrono 分页 + 无限滚动、月份默认折叠吸顶、服务端全局搜索、30s 自动刷新、状态子页、删除两步确认、重要性过滤芯片、内联 Lucide 图标。
- 实体抽取默认开；双语 README。

## 兼容保留（远程 0.7.10 功能逐项验证在位）

user/fact/pattern 分层类型、总览/目录视图、wikilink 与标签系统、0.7.10 色点体系与图谱平移缩放、设置页重排、侧边栏激活修复、root 壳版本同步机制（prepack/check-sync）。

## 测试

**全套 838 通过 / 0 失败**（远程基线 817 + standalone-api 10 + settings/mode 2 + client 新增 9；远程 client 旧断言按新面板结构更新 2 处，其余未动）。

## ⚠️ 审核要点

- `dsh-mneme/lib/` 为 sync 产物，`scripts/check-sync.js` 已过；`lib/client.js` 与 `src/client.js` 字节一致。
- cordis.patch.yml 新增 `entityExtractionEnabled: true`（默认行为变化：新记忆会自动抽取实体，多 1 次/条的 LLM 调用）。
- 轻量模式/外部 API 均默认关闭，不影响存量用户。
- 建议合并后按 v0.7.12 tag 走新的 release.yml 流水线补建 GitHub Release（npm 侧已发布，publish 作业会命中 skip 守卫）。