### PR TITLE
test: peer-C Windows 清理 EPERM 兜底——句柄释放慢不再把 flaky 标红

### DIFF
--- a/dsh-mneme/test/peer-blockers.test.js
+++ b/dsh-mneme/test/peer-blockers.test.js
@@ -115,8 +115,14 @@ test("peer-C: 多进程并发原子递增——8 进程×10 次 incrementGenerat
     }
   } finally {
     // Windows：8 个 SQLite 子进程退出后 -shm/-wal 句柄延迟释放，删目录偶发 EPERM；
-    // maxRetries 让 rm 自动重试（Node 文档：EBUSY/EPERM 等会重试），不影响并发逻辑。
-    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    // rm 带 maxRetries 自动重试（30×100ms 共 3s），仍失败则放行——清理只是收尾，
+    // 并发断言正确性由上方 generation 断言保证，残留临时目录交给 OS/CI 回收，
+    // 绝不让句柄释放慢把 flaky 标红。
+    try {
+      rmSync(dir, { recursive: true, force: true, maxRetries: 30, retryDelay: 100 });
+    } catch (err) {
+      if (!["EPERM", "EBUSY", "EACCES"].includes(err.code)) throw err;
+    }
   }
 });
 


### PR DESCRIPTION
## 背景
main 上 v0.7.14 / Release 格式统一 两个 commit 的 CI 各红一次（`test (windows-latest, 24)`），定位到 **peer-C 并发测试在 finally 清理临时目录时 EPERM**。

## 根因
8 个 SQLite 子进程退出后 `-shm`/`-wal` 句柄在 Windows 上延迟释放，`rmSync` 删临时目录偶发 `EPERM`。并发断言本身通过（`generation == 80` 不丢增量），挂的是收尾清理。

## 修复
`dsh-mneme/test/peer-blockers.test.js` peer-C finally：
- `rmSync` `maxRetries` 5×200ms（共 1s）→ **30×100ms（共 3s）**
- 仍 `EPERM`/`EBUSY`/`EACCES` 则**放行**（不再抛）：清理只是收尾，断言正确性由 generation 断言保证，残留临时目录交给 OS/CI 回收

## 验证
- 本地 `node --test test/peer-blockers.test.js` 6/6 全绿
- 不碰 src/lib/UI
