### PR TITLE
fix: 恢复 c8 覆盖率配置 + README 测试数同步 617

### DIFF
--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@modusensus/dsh-mneme?color=blue&label=npm)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Awesome](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
-[![tests](https://img.shields.io/badge/tests-815%20passed-success)](https://github.com/modusensus/dsh-mneme)
+[![tests](https://img.shields.io/badge/tests-617%20passed-success)](https://github.com/modusensus/dsh-mneme)
 [![CI](https://img.shields.io/github/actions/workflow/status/modusensus/dsh-mneme/test.yml)](https://github.com/modusensus/dsh-mneme/actions)
 [![node](https://img.shields.io/badge/node-24%2B-blue)](https://nodejs.org)
 [![npm downloads](https://img.shields.io/npm/dm/@modusensus/dsh-mneme?color=blue&label=downloads)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
@@ -543,7 +543,7 @@ src/
 ├── client.js         # Web 面板 bundle（ModuleLoader 自注册；v0.7.6 起 src 正源）
 └── index.js          # 插件接线
 lib/                  # src 的同步分发产物（npm run sync；发布前由 root prepack 的 check-sync.js 校验一致性，无手写例外）
-test/                 # 815 个 node:test 测试（含 lib-smoke.test.js：lib 产物冒烟 + src↔lib 一致性断言；审计与三轴线压测不变量）
+test/                 # 617 个 node:test 测试（审计与三轴线压测不变量；src↔lib 一致性由 scripts/check-sync.js 发布闸门校验）
 scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压测 · sync-lib.js 同步 · check-sync.js 发布闸门 · benchmark-recall.js 召回基准
 ```
 
@@ -552,7 +552,7 @@ scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压
 ```bash
 cd dsh-mneme
 npm install        # 安装 peer 依赖（以 devDependencies 形式，用于本地测试）
-npm test           # 运行 815 个测试
+npm test           # 运行 617 个测试
 npm run stress     # 三轴线压测：长会话检索 / 冲突仲裁 / 多 Agent 并发（离线 mock LLM）
 npm run sync       # 把 src/ 同步到 lib/（发布时由 prepack 钩子自动执行）
 ```

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -73,6 +73,17 @@
     "e2e": "node scripts/e2e-dsh.js",
     "stress": "node scripts/stress-dsh.js"
   },
+  "c8": {
+    "reporter": [
+      "text",
+      "lcov"
+    ],
+    "exclude": [
+      "lib/**",
+      "test/**",
+      "**/*.test.js"
+    ]
+  },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
     "morphicons": "^1.7.1"


### PR DESCRIPTION
## 背景
Codecov 徽章显示 `coverage: 0%` 红色，README 测试数还停在 815。

## 根因
v0.7.12 近重写把 `package.json` 的 `c8` 配置字段删成空，v0.7.13 CI 修复只补回了 c8 devDependency + `test:coverage` 脚本，**漏了 reporter**：
- c8 默认 reporter 不含 `lcov` → CI 不生成 `coverage/lcov.info`（0 字节）
- `codecov-action` 上传空/错误报告 → Codecov 解析 0% → 徽章红
- 最近 5 个 main commit（v0.7.13 起）Codecov 覆盖率全 0.0

## 修复
- `dsh-mneme/package.json`：恢复 294ff03 的 c8 配置（`reporter: ["text","lcov"]` + `exclude: ["lib/**","test/**","**/*.test.js"]`）
- `dsh-mneme/README.md`：测试数 815→617（badge / 结构说明 / 开发小节三处），并同步去掉第 546 行已删除的 `lib-smoke.test.js` 引用

## 验证
- 本地 `npm run test:coverage`（CI 同款命令）实测生成 **155KB lcov.info / 24 个 SF 文件**（修复前 0 字节）
- 617 测试全绿；`coverage/` 已被 .gitignore 忽略，不入库
