### PR TITLE
test: peer-worker 对 SQLITE_BUSY 线性重试——Windows 并发写不再随机 database is locked

### DIFF
--- a/dsh-mneme/test/helpers/peer-worker.mjs
+++ b/dsh-mneme/test/helpers/peer-worker.mjs
@@ -5,6 +5,21 @@
 import { createStore } from "../../src/store.js";
 
 const [, , dbPath, iterations] = process.argv;
-const store = createStore(dbPath);
-for (let i = 0; i < Number(iterations); i++) store.incrementGeneration();
+
+// Windows CI 上 8 进程并发写同一 generation 行时，busy_timeout(5s) 到期仍偶发
+// SQLITE_BUSY（"database is locked"）。锁是瞬时资源竞争，线性重试即可收敛；
+// incrementGeneration 是单条原子 UPDATE（失败即未执行），重试不会重复计数。
+async function withBusyRetry(fn) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return fn();
+    } catch (err) {
+      if (!/database is locked|SQLITE_BUSY/i.test(String(err?.message ?? err)) || attempt >= 40) throw err;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+}
+
+const store = await withBusyRetry(() => createStore(dbPath));
+for (let i = 0; i < Number(iterations); i++) await withBusyRetry(() => store.incrementGeneration());
 store.close();


### PR DESCRIPTION
## 问题

Windows CI 偶发 `database is locked`（在 #78 观察）：8 进程并发写同一 `generation` 行时，`busy_timeout(5s)` 到期仍锁超时，测试随机标红。

## 改动

- `test/helpers/peer-worker.mjs`：打开 store 与每次 `incrementGeneration` 各 40×250ms 线性重试 SQLITE_BUSY
- `incrementGeneration` 是单条原子 UPDATE，失败即未执行，重试不会重复计数
- 仅测试 helper，不动 production，无需 sync lib

## 验证

本地 `peer-blockers` 6/6 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when initializing local data and updating generation values during temporary database lock conditions.
  * Operations now retry briefly before failing if the database remains unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->