### PR TITLE
feat: 记忆库面板重设计——非全屏 sheet/卡片视图/详情抽屉/功能开关/状态工作台

### DIFF
--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -1,10 +1,34 @@
 import { URL } from "node:url";
+import { readFileSync } from "node:fs";
 import { timingSafeEqual, randomBytes } from "node:crypto";
+import { FEATURE_FLAG_SPEC } from "./settings.js";
+import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 
-function sendJson(res, status, payload) {
-  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+// headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
+function sendJson(res, status, payload, headers = {}) {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8", ...headers });
   res.end(JSON.stringify(payload));
 }
+
+// 附件下载响应（导出端点）：Content-Type 与文件名（含日期后缀）由调用方给定。
+function sendAttachment(res, status, contentType, filename, body) {
+  res.writeHead(status, {
+    "Content-Type": contentType,
+    "Content-Disposition": `attachment; filename="${filename}"`
+  });
+  res.end(body);
+}
+
+// 导出 JSON 的 version 字段：读插件根的 package.json（src/ 与 lib/ 都在根下
+// 一层，相对 import.meta.url 解析一致）。读取失败（打包/受限环境）降级为
+// "unknown"，导出本身仍然可用。
+const PACKAGE_VERSION = (() => {
+  try {
+    return JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+})();
 
 // Defaults for the standalone external API — keep in step with the schema
 // defaults in config.js (externalApiPort / externalApiHost).
@@ -70,8 +94,42 @@ function parseBody(text) {
   }
 }
 
-export function createApi(ctx, service, settings, commands, embedder, semantic = null, apiToken = "") {
+export function createApi(ctx, service, settings, commands, embedder, semantic = null, apiToken = "", config = null) {
   const disposers = [];
+
+  // feature flags 快照（GET/PUT 共用）：overrides 是持久化的用户显式覆盖；
+  // effective 是启动配置在白名单键上被 overrides 覆盖后的最终值。config 缺席
+  // （旧调用方直连、未传 cfg）时只报被覆盖的键，不把不存在的默认值编造给前端。
+  const flagKeys = [
+    ...FEATURE_FLAG_SPEC.booleans,
+    ...Object.keys(FEATURE_FLAG_SPEC.ints),
+    ...FEATURE_FLAG_SPEC.strings,
+    ...FEATURE_FLAG_SPEC.urls,
+    ...Object.keys(FEATURE_FLAG_SPEC.enums)
+  ];
+  // 嵌套键在 kv 里按点号平铺（"memoryQualityFilter.enabled"），运行时 cfg 里
+  // 是嵌套对象，effective 从对象子字段取值；其余键照旧从 cfg 顶层取。
+  const NESTED_FLAG_PATHS = {
+    "memoryQualityFilter.enabled": ["memoryQualityFilter", "enabled"],
+    "llmAudit.enabled": ["llmAudit", "enabled"]
+  };
+  function configFlagValue(key) {
+    const path = NESTED_FLAG_PATHS[key];
+    if (path) return config?.[path[0]]?.[path[1]];
+    return config?.[key];
+  }
+  function featureSnapshot() {
+    const overrides = settings.getFeatureFlags();
+    const effective = {};
+    for (const key of flagKeys) {
+      if (overrides[key] !== undefined) effective[key] = overrides[key];
+      else {
+        const value = configFlagValue(key);
+        if (value !== undefined) effective[key] = value;
+      }
+    }
+    return { overrides, effective };
+  }
 
   // Ensure the service has an embedder when the API layer was handed one
   // (tests wire the embedder through the API instead of index.js). Without
@@ -112,10 +170,26 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           ? Number(minRaw)
           : undefined;
         const source = url.searchParams.get("source") || undefined;
-        const items = service.toApiList(service.list({ type, limit, offset, order, minImportance, source }));
+        // updatedFrom/updatedTo：updated_at 闭区间过滤（ISO 日期或完整时间戳）。
+        // 边界归一化在 store 的 updatedAtBounds（list/count 共用同一纯函数）
+        // 完成，非法值在那里被忽略——这里原样透传即可。
+        const updatedFrom = url.searchParams.get("updatedFrom") ?? undefined;
+        const updatedTo = url.searchParams.get("updatedTo") ?? undefined;
+        // archived=only：只看归档（状态页的归档列表用）。归档行不进默认列表，
+        // 所以这是独立的视图开关，而不是 includeArchived 的混看模式。
+        const onlyArchived = url.searchParams.get("archived") === "only";
+        const rows = service.list({ type, limit, offset, order, minImportance, source, updatedFrom, updatedTo, onlyArchived });
+        // 面板行在 wire DTO 之上补 archived/quality_score——模型工具的输出
+        // schema 严格复用 toApiList，扩展只发生在 HTTP 层。
+        const items = service.toApiList(rows).map((m, i) => ({
+          ...m,
+          archived: rows[i].archived === true || rows[i].archived === 1,
+          quality_score: rows[i].quality_score ?? null
+        }));
         // Total honors the same filters as the rows, or the pager's
-        // has-more math breaks whenever minImportance/source is active.
-        sendJson(res, 200, { items, total: service.count(type, { minImportance, source }) });
+        // has-more math breaks whenever minImportance/source/updated-at
+        // bounds are active.
+        sendJson(res, 200, { items, total: service.count(type, { minImportance, source, updatedFrom, updatedTo, onlyArchived }) });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }
@@ -213,6 +287,90 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           }
           service.remove(id);
           sendJson(res, 200, { ok: true });
+        });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 编辑/归档一条记忆（面板写路径，与 /delete 对称命名）-------------------
+  // POST body {id, title?, content?, importance?, tags?, archived?}。字段校验
+  // 只做类型/范围检查：字段出现（!== undefined）就必须合法，宁 400 不静默纠正
+  // ——静默丢字段会让面板误以为保存成功。写入走 service 的正规更新路径：
+  // updated_at 由 store 的单调时钟推进；content 被改写时旧版本按 human_override
+  // 入档（与镜像人工编辑回灌 mergeHumanEdits 的语义对齐，FIFO 上限 20）；
+  // archived 走 setArchived。两条路径都会触发镜像重渲染（afterSync）。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/update",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") {
+          sendJson(res, 404, { error: "not-found" });
+          return;
+        }
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then((text) => {
+          const body = parseBody(text);
+          const id = typeof body.id === "string" ? body.id.trim() : "";
+          if (!id) {
+            sendJson(res, 400, { error: "missing-id" });
+            return;
+          }
+          const patch = {};
+          if (body.title !== undefined) {
+            if (typeof body.title !== "string" || !body.title.trim()) {
+              sendJson(res, 400, { error: "invalid-title" });
+              return;
+            }
+            patch.title = body.title.trim();
+          }
+          if (body.content !== undefined) {
+            if (typeof body.content !== "string" || !body.content.trim()) {
+              sendJson(res, 400, { error: "invalid-content" });
+              return;
+            }
+            patch.content = body.content.trim();
+          }
+          if (body.importance !== undefined) {
+            if (!Number.isInteger(body.importance) || body.importance < 1 || body.importance > 5) {
+              sendJson(res, 400, { error: "invalid-importance" });
+              return;
+            }
+            patch.importance = body.importance;
+          }
+          if (body.tags !== undefined) {
+            if (!Array.isArray(body.tags) || !body.tags.every((t) => typeof t === "string")) {
+              sendJson(res, 400, { error: "invalid-tags" });
+              return;
+            }
+            patch.tags = body.tags;
+          }
+          if (body.archived !== undefined && typeof body.archived !== "boolean") {
+            sendJson(res, 400, { error: "invalid-archived" });
+            return;
+          }
+          if (Object.keys(patch).length === 0 && body.archived === undefined) {
+            sendJson(res, 400, { error: "no-fields" });
+            return;
+          }
+          const existing = service.getById(id);
+          if (!existing) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          // 内容被改写时旧版本先入档（human_override），人工修正不静默销毁旧值。
+          if (patch.content !== undefined && patch.content !== existing.content) {
+            const history = Array.isArray(existing.content_history) ? existing.content_history : [];
+            patch.content_history = [
+              { content: existing.content ?? "", source: "human_override", updated_at: new Date().toISOString() },
+              ...history
+            ].slice(0, 20);
+          }
+          if (Object.keys(patch).length) service.update(id, patch);
+          if (body.archived !== undefined) service.setArchived(id, body.archived);
+          sendJson(res, 200, { memory: service.getById(id) });
         });
       } catch {
         sendJson(res, 500, { error: "internal" });
@@ -501,6 +659,144 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // --- 一条记忆的关联实体（记忆详情侧栏）-------------------------------------
+  // 只读：entity_attrs.memory_id 反查实体（store 一条 JOIN 完成，按提及去重）。
+  // 与目录 /entities 不同，这里以记忆为锚点，回答"这条记忆提到了谁"。记忆不
+  // 存在或无关联一律返回空数组——详情侧栏不需要区分这两种情况。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/memories/entities",
+    handler(req, res) {
+      try {
+        const url = new URL(req.url, "http://localhost");
+        const memoryId = (url.searchParams.get("memoryId") ?? "").trim();
+        if (!memoryId) {
+          sendJson(res, 400, { error: "missing-memory-id" });
+          return;
+        }
+        sendJson(res, 200, { entities: service.entitiesForMemory?.(memoryId) ?? [] });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 导出（面板备份/迁移）---------------------------------------------------
+  // 只读。json：全字段行（含 archived/forgotten，布尔化），updated_at DESC；
+  // markdown：按类型分节，块格式与磁盘镜像完全同构（renderMirrorText 与
+  // mirror.sync 共用同一条渲染路径），因此导出文本可以被 /import 原样吃回。
+  // 全量一次性取回（store.all 按 updated_at DESC）——导出是一次性备份动作，
+  // 不需要流式。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/export",
+    handler(req, res) {
+      try {
+        const url = new URL(req.url, "http://localhost");
+        const format = url.searchParams.get("format") ?? "json";
+        if (format !== "json" && format !== "markdown") {
+          sendJson(res, 400, { error: "invalid-format" });
+          return;
+        }
+        const rows = service.all?.() ?? [];
+        const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+        if (format === "json") {
+          sendJson(res, 200, {
+            exported_at: new Date().toISOString(),
+            version: PACKAGE_VERSION,
+            count: rows.length,
+            memories: rows
+          }, { "Content-Disposition": `attachment; filename="dsh-mneme-export-${stamp}.json"` });
+          return;
+        }
+        const byType = {};
+        for (const row of rows) {
+          if (TYPE_FILE[row.type]) (byType[row.type] ??= []).push(row);
+        }
+        const sections = [];
+        for (const type of Object.keys(TYPE_FILE)) {
+          if (byType[type]?.length) sections.push(renderMirrorText(type, byType[type]));
+        }
+        sendAttachment(res, 200, "text/markdown; charset=utf-8", `dsh-mneme-export-${stamp}.md`, sections.join("\n"));
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 导入（Markdown 镜像回填）----------------------------------------------
+  // 写路径（requireAuth）。body {type, markdown}：type 是镜像 TYPE_FILE 键
+  // （preference/project/decision/history/summary），markdown 是与镜像文件同构
+  // 的文本。解析复用 readHumanEdits 的纯函数核心 parseHumanEdits（同一实现，
+  // 行为一致是硬约束），合并走 mergeHumanEdits（只吃 title/content；digest 命
+  // 中或无差异的条目在 service 侧自动跳过）。解析出 0 条不算错误。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/import",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") {
+          sendJson(res, 404, { error: "not-found" });
+          return;
+        }
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then((text) => {
+          const body = parseBody(text);
+          if (typeof body.type !== "string" || !Object.hasOwn(TYPE_FILE, body.type)) {
+            sendJson(res, 400, { error: "invalid-type" });
+            return;
+          }
+          if (typeof body.markdown !== "string" || !body.markdown.trim()) {
+            sendJson(res, 400, { error: "invalid-markdown" });
+            return;
+          }
+          const edits = parseHumanEdits(body.markdown);
+          service.mergeHumanEdits(body.type, edits);
+          sendJson(res, 200, { merged: edits.length, type: body.type });
+        });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 巩固状态（dream 面板）--------------------------------------------------
+  // 只读：最近巩固运行（最多 5 条，created_at DESC）+ 未解决冲突队列。
+  // pendingMemoryIds 从未解决冲突行提取涉及的记忆 id，去重后上限 200，避免积
+  // 压很大时响应失控。listDreamRuns/listConflictPending 走 service 现成的审计
+  // 只读通道（bookkeeping 语义，不触发写钩子）。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/dream-status",
+    handler(req, res) {
+      try {
+        const runs = (service.listDreamRuns?.({ limit: 5 }) ?? []).map((r) => ({
+          created_at: r.created_at,
+          status: r.status,
+          provider: r.provider ?? null,
+          model: r.model ?? null,
+          error: r.error ?? null
+        }));
+        const pendingConflicts = service.countConflictPending?.() ?? 0;
+        const ids = new Set();
+        for (const row of service.listConflictPending?.({ limit: 200, includeResolved: false }) ?? []) {
+          if (ids.size >= 200) break;
+          if (row.memory_a) ids.add(row.memory_a);
+          if (ids.size >= 200) break;
+          if (row.memory_b) ids.add(row.memory_b);
+        }
+        sendJson(res, 200, {
+          lastRun: runs[0] ?? null,
+          runs,
+          pendingConflicts,
+          pendingMemoryIds: [...ids].slice(0, 200)
+        });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
   // --- health: mirror sync state (F-NEW-03 / v0.3.6) ---
   // Auth-gated; only returns a sanitized error code (never raw last_error which
   // may leak paths/token-like strings/internal hosts). On state read failure it
@@ -624,6 +920,41 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // --- feature flags（功能开关：面板逐项开关后端能力）-------------------------
+  // 读路由保持开放（与 mode/list 一致），前端无需 token 即可渲染开关状态；PUT
+  // 与其他设置写一致走 requireAuth。空/非对象 patch 直接 400：它不携带任何
+  // 意图，静默成功只会掩盖前端 bug。校验失败（未知键/类型/越界）的 400 把键
+  // 名放进 error，前端能直接定位写坏的开关。生效节奏与 panel_mode 相同：
+  // 持久化后下次启动合并进 cfg，本次启动的运行时行为不变。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/features",
+    handler(req, res) {
+      try {
+        if (req.method === "PUT" || req.method === "POST") {
+          if (!requireAuth(req, res, apiToken)) return;
+          return readBody(req).then((text) => {
+            const body = parseBody(text);
+            if (typeof body !== "object" || body === null || Array.isArray(body) || Object.keys(body).length === 0) {
+              sendJson(res, 400, { error: "invalid-patch" });
+              return;
+            }
+            try {
+              settings.setFeatureFlags(body);
+            } catch (error) {
+              sendJson(res, 400, { error: error.message });
+              return;
+            }
+            sendJson(res, 200, featureSnapshot());
+          });
+        }
+        sendJson(res, 200, featureSnapshot());
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
   // --- custom commands ---
   register({
     kind: "exact",
@@ -662,7 +993,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   });
 
   return {
-    routes: 17,
+    routes: 23,
     dispose: () => {
       for (const dispose of disposers) dispose();
     }

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -158,7 +158,7 @@ window.__ModuleLoader__.load({
         "memory.explorer.importance": "重要性",
         "memory.explorer.topK": "返回数量",
         "memory.explorer.topKOption": "返回 {n} 条",
-        "memory.card.open": "在主区记忆库中查看全文",
+        "memory.card.open": "在记忆库中查看全文",
         "memory.time.now": "刚刚",
         "memory.time.seconds": "{n}秒前",
         "memory.time.minutes": "{n}分钟前",
@@ -212,6 +212,136 @@ window.__ModuleLoader__.load({
         "memory.settings.extapi.copied": "已复制",
         "memory.settings.extapi.savedHint": "已保存，重启 DSH 后生效",
         "memory.settings.extapi.invalidPort": "端口需为 1-65535 的数字",
+        "memory.tab.rejected_solution": "被否决方案",
+        "memory.tab.pitfall": "踩坑记录",
+        "memory.tab.constraint": "工程约束",
+        "memory.features.title": "功能开关",
+        "memory.features.desc": "按需启停后端能力，改动保存后重启 DSH 生效。",
+        "memory.features.group.core": "核心",
+        "memory.features.group.enhance": "记忆增强",
+        "memory.features.group.dream": "巩固与睡眠",
+        "memory.features.group.advanced": "高级",
+        "memory.features.advancedToggle": "高级（注入策略 · 反思 · 实验项）",
+        "memory.features.restartHint": "重启 DSH 后生效",
+        "memory.features.loadFailed": "加载失败",
+        "memory.features.autoInject": "自动注入",
+        "memory.features.autoInject.hint": "每轮对话自动携带相关记忆",
+        "memory.features.autoSummarize": "自动总结",
+        "memory.features.autoSummarize.hint": "对话结束自动提炼记忆条目",
+        "memory.features.hotMemoryEnabled": "热记忆",
+        "memory.features.hotMemoryEnabled.hint": "最近几轮对话原文随注入携带，不写入长期记忆",
+        "memory.features.entityExtractionEnabled": "实体抽取",
+        "memory.features.entityExtractionEnabled.hint": "从记忆中提取人物/项目/概念，图谱随之生长",
+        "memory.features.codingRetrospect": "编码记忆蒸馏",
+        "memory.features.codingRetrospect.hint": "用完整转录（含工具调用与报错）提炼踩坑、约束与被否决方案",
+        "memory.features.rerankEnabled": "结果重排",
+        "memory.features.rerankEnabled.hint": "本地重排模型对召回结果精排，更慢更准",
+        "memory.features.searchSemanticDedup": "语义去重",
+        "memory.features.searchSemanticDedup.hint": "搜索结果中意思相近的条目只保留一条",
+        "memory.features.autoDream": "记忆巩固",
+        "memory.features.autoDream.hint": "后台自动合并、沉淀碎片记忆",
+        "memory.features.sleepModeEnabled": "睡眠模式",
+        "memory.features.sleepModeEnabled.hint": "空闲时段做分层压缩与整理",
+        "memory.features.hybridInject": "混合注入",
+        "memory.features.hybridInject.hint": "关键词 + 向量双路召回后合并注入",
+        "memory.features.selectiveInjectEnabled": "选择性注入",
+        "memory.features.selectiveInjectEnabled.hint": "按相关性筛选，只注入值得携带的记忆",
+        "memory.features.adaptiveThresholdEnabled": "自适应阈值",
+        "memory.features.adaptiveThresholdEnabled.hint": "按召回质量动态调整相关性门槛",
+        "memory.features.reflectionUpdateEnabled": "反思更新",
+        "memory.features.reflectionUpdateEnabled.hint": "巩固时允许修正已有记忆",
+        "memory.features.distill": "蒸馏与限流",
+        "memory.features.distillRateLimitIntervalMs": "蒸馏放行间隔 (ms)",
+        "memory.features.distillRateLimitRetries": "429 重试次数",
+        "memory.features.distillRateLimitBaseDelayMs": "退避起始延迟 (ms)",
+        "memory.features.distillMaxChars": "转录截断上限（字符）",
+        "memory.features.codingBoostFactor": "编码记忆加权",
+        "memory.features.memoryQualityFilter.enabled": "记忆质量过滤",
+        "memory.features.memoryQualityFilter.enabled.hint": "低价值记忆自动归档，注入按质量降权",
+        "memory.features.llmAudit.enabled": "后台调用审计",
+        "memory.features.llmAudit.enabled.hint": "记录巩固/总结的后台模型调用与 token 消耗",
+        "memory.features.bm25SearchEnabled": "BM25 关键词检索",
+        "memory.features.bm25SearchEnabled.hint": "传统关键词打分检索，与向量召回互补",
+        "memory.features.conflictFreezeEnabled": "冲突冻结",
+        "memory.features.conflictFreezeEnabled.hint": "巩固发现互相矛盾的记忆时先冻结待确认",
+        "memory.features.trustEpistemicWeighting": "可信度加权",
+        "memory.features.trustEpistemicWeighting.hint": "按来源可信度调整召回排序（实验性）",
+        "memory.features.reflectionFailureTracking": "反思失败追踪",
+        "memory.features.reflectionFailureTracking.hint": "记录巩固决策的失败样本供后续改进",
+        "memory.features.embedRoute": "语义检索路线",
+        "memory.features.embedProvider": "Embedding 提供方",
+        "memory.features.embedProvider.openai": "OpenAI 兼容接口",
+        "memory.features.embedProvider.local": "本地模型（离线）",
+        "memory.features.embedProvider.ollama": "Ollama",
+        "memory.features.embedProvider.openai.hint": "接口地址 / Key / 模型在「向量搜索」卡片配置",
+        "memory.features.embedProvider.local.hint": "首次使用会下载模型，之后完全离线",
+        "memory.features.embedProvider.ollama.hint": "需要本机 Ollama 服务在运行",
+        "memory.features.localEmbedModel": "本地 embedding 模型",
+        "memory.features.ollamaBaseUrl": "Ollama 服务地址",
+        "memory.features.ollamaModel": "Ollama 模型名",
+        "memory.features.dreamProvider": "巩固模型 Provider",
+        "memory.features.dreamModel": "巩固用模型名",
+        "memory.features.dreamModelHint": "留空 = 跟随主对话模型；只影响记忆巩固（autoDream）用的模型",
+        "memory.explorer.viewCards": "卡片",
+        "memory.explorer.viewTimeline": "时间线",
+        "memory.explorer.viewAria": "视图切换",
+        "memory.explorer.dateLabel": "时间",
+        "memory.explorer.date.all": "全部时间",
+        "memory.explorer.date.7d": "近 7 天",
+        "memory.explorer.date.30d": "近 30 天",
+        "memory.explorer.date.90d": "近 90 天",
+        "memory.explorer.more": "更多操作",
+        "memory.explorer.exportJson": "导出 JSON",
+        "memory.explorer.exportMarkdown": "导出 Markdown",
+        "memory.explorer.importMd": "导入 Markdown 镜像…",
+        "memory.explorer.importTitle": "导入 Markdown 镜像",
+        "memory.explorer.importHint": "选择一个镜像类型的 Markdown 文件，解析其中的人工编辑并合并进记忆库。",
+        "memory.explorer.importType": "镜像类型",
+        "memory.explorer.importPick": "选择文件…",
+        "memory.explorer.importConfirm": "导入",
+        "memory.explorer.importCancel": "取消",
+        "memory.explorer.importing": "导入中…",
+        "memory.explorer.imported": "已合并 {n} 条编辑",
+        "memory.explorer.importFailed": "导入失败",
+        "memory.explorer.importNoFile": "请先选择文件",
+        "memory.explorer.exportFailed": "导出失败",
+        "memory.explorer.conflictBadge": "冲突",
+        "memory.explorer.archivedBadge": "已归档",
+        "memory.explorer.detail.edit": "编辑",
+        "memory.explorer.detail.save": "保存",
+        "memory.explorer.detail.cancel": "取消",
+        "memory.explorer.detail.archive": "归档",
+        "memory.explorer.detail.archived": "已归档",
+        "memory.explorer.detail.archiveFailed": "操作失败",
+        "memory.explorer.detail.saved": "已保存，镜像同步更新",
+        "memory.explorer.detail.quality": "质量分",
+        "memory.explorer.detail.entities": "关联实体",
+        "memory.explorer.detail.entitiesEmpty": "开启实体抽取后，相关人物/项目会出现在这里",
+        "memory.explorer.detail.closeAria": "关闭详情",
+        "memory.explorer.detail.editTitle": "标题",
+        "memory.explorer.detail.editContent": "内容",
+        "memory.explorer.detail.editImportance": "重要性",
+        "memory.status.dream": "最近巩固",
+        "memory.status.dreamNever": "尚未运行",
+        "memory.status.conflicts": "待确认冲突",
+        "memory.status.conflictsHint": "冻结的矛盾记忆，等待人工确认",
+        "memory.status.workbench": "工作动态",
+        "memory.status.dreamConsolidate": "记忆巩固",
+        "memory.status.summarize": "总结提炼",
+        "memory.status.tokens": "{n} tokens",
+        "memory.status.deposited": "沉淀 {n} 条记忆",
+        "memory.status.failed": "失败",
+        "memory.status.success": "成功",
+        "memory.status.skipped": "跳过",
+        "memory.status.emptyFeed": "还没有后台活动：对话结束后会自动提炼记忆",
+        "memory.status.consolidated": "沉淀的记忆",
+        "memory.status.consolidatedEmpty": "autoDream / autoSummarize 沉淀的记忆会出现在这里",
+        "memory.status.archivedMemories": "已归档的记忆",
+        "memory.status.archivedEmpty": "没有归档的记忆",
+        "memory.status.restore": "恢复",
+        "memory.settings.extapi.reveal": "显示",
+        "memory.settings.extapi.hide": "隐藏",
+        "memory.settings.extapi.maskHint": "Token 已遮蔽；「复制」可复制完整值",
         "memory.explorer.delete": "删除",
         "memory.explorer.confirmDelete": "确认删除?",
         "memory.explorer.cancel": "取消",
@@ -292,7 +422,7 @@ window.__ModuleLoader__.load({
         "memory.explorer.importance": "Importance",
         "memory.explorer.topK": "Results limit",
         "memory.explorer.topKOption": "Return {n}",
-        "memory.card.open": "Open full text in the Memory tab",
+        "memory.card.open": "Open full text in the memory library",
         "memory.time.now": "just now",
         "memory.time.seconds": "{n}s ago",
         "memory.time.minutes": "{n}m ago",
@@ -346,6 +476,136 @@ window.__ModuleLoader__.load({
         "memory.settings.extapi.copied": "Copied",
         "memory.settings.extapi.savedHint": "Saved. Takes effect after restarting DSH",
         "memory.settings.extapi.invalidPort": "Port must be a number between 1 and 65535",
+        "memory.tab.rejected_solution": "Rejected solutions",
+        "memory.tab.pitfall": "Pitfalls",
+        "memory.tab.constraint": "Constraints",
+        "memory.features.title": "Features",
+        "memory.features.desc": "Toggle backend capabilities. Changes take effect after restarting DSH.",
+        "memory.features.group.core": "Core",
+        "memory.features.group.enhance": "Enhancement",
+        "memory.features.group.dream": "Consolidation",
+        "memory.features.group.advanced": "Advanced",
+        "memory.features.advancedToggle": "Advanced (injection · reflection · experimental)",
+        "memory.features.restartHint": "Takes effect after restarting DSH",
+        "memory.features.loadFailed": "Failed to load",
+        "memory.features.autoInject": "Auto injection",
+        "memory.features.autoInject.hint": "Carry relevant memories into every turn",
+        "memory.features.autoSummarize": "Auto summarization",
+        "memory.features.autoSummarize.hint": "Distill memory entries when a conversation ends",
+        "memory.features.hotMemoryEnabled": "Hot memory",
+        "memory.features.hotMemoryEnabled.hint": "Carry the last few turns verbatim; never written to long-term memory",
+        "memory.features.entityExtractionEnabled": "Entity extraction",
+        "memory.features.entityExtractionEnabled.hint": "Extract people / projects / concepts so the graph grows by itself",
+        "memory.features.codingRetrospect": "Coding retrospection",
+        "memory.features.codingRetrospect.hint": "Distill pitfalls, constraints and rejected solutions from full transcripts (tools and errors included)",
+        "memory.features.rerankEnabled": "Reranking",
+        "memory.features.rerankEnabled.hint": "Rerank recalled results with a local model — slower, more precise",
+        "memory.features.searchSemanticDedup": "Semantic dedup",
+        "memory.features.searchSemanticDedup.hint": "Keep one entry when search hits near-duplicates",
+        "memory.features.autoDream": "Memory consolidation",
+        "memory.features.autoDream.hint": "Merge and settle fragmented memories in the background",
+        "memory.features.sleepModeEnabled": "Sleep mode",
+        "memory.features.sleepModeEnabled.hint": "Layered compaction during idle periods",
+        "memory.features.hybridInject": "Hybrid injection",
+        "memory.features.hybridInject.hint": "Merge keyword + vector recall before injecting",
+        "memory.features.selectiveInjectEnabled": "Selective injection",
+        "memory.features.selectiveInjectEnabled.hint": "Only inject memories worth carrying, filtered by relevance",
+        "memory.features.adaptiveThresholdEnabled": "Adaptive threshold",
+        "memory.features.adaptiveThresholdEnabled.hint": "Adjust the relevance floor with recall quality",
+        "memory.features.reflectionUpdateEnabled": "Reflective update",
+        "memory.features.reflectionUpdateEnabled.hint": "Allow consolidation to revise existing memories",
+        "memory.features.distill": "Distillation & rate limiting",
+        "memory.features.distillRateLimitIntervalMs": "Distill spacing (ms)",
+        "memory.features.distillRateLimitRetries": "429 retries",
+        "memory.features.distillRateLimitBaseDelayMs": "Backoff base delay (ms)",
+        "memory.features.distillMaxChars": "Transcript cap (chars)",
+        "memory.features.codingBoostFactor": "Coding boost factor",
+        "memory.features.memoryQualityFilter.enabled": "Memory quality filter",
+        "memory.features.memoryQualityFilter.enabled.hint": "Archive low-value memories automatically; injection downranks by quality",
+        "memory.features.llmAudit.enabled": "Background call audit",
+        "memory.features.llmAudit.enabled.hint": "Log background model calls and token usage from consolidation / summaries",
+        "memory.features.bm25SearchEnabled": "BM25 keyword search",
+        "memory.features.bm25SearchEnabled.hint": "Classic keyword scoring, complementary to vector recall",
+        "memory.features.conflictFreezeEnabled": "Conflict freezing",
+        "memory.features.conflictFreezeEnabled.hint": "Freeze contradictory memories for confirmation during consolidation",
+        "memory.features.trustEpistemicWeighting": "Credibility weighting",
+        "memory.features.trustEpistemicWeighting.hint": "Adjust recall ranking by source credibility (experimental)",
+        "memory.features.reflectionFailureTracking": "Reflection failure tracking",
+        "memory.features.reflectionFailureTracking.hint": "Record failed consolidation decisions for later improvement",
+        "memory.features.embedRoute": "Semantic search route",
+        "memory.features.embedProvider": "Embedding provider",
+        "memory.features.embedProvider.openai": "OpenAI-compatible API",
+        "memory.features.embedProvider.local": "Local model (offline)",
+        "memory.features.embedProvider.ollama": "Ollama",
+        "memory.features.embedProvider.openai.hint": "Endpoint / key / model live in the Vector Search card below",
+        "memory.features.embedProvider.local.hint": "First use downloads the model; fully offline afterwards",
+        "memory.features.embedProvider.ollama.hint": "Requires a local Ollama server",
+        "memory.features.localEmbedModel": "Local embedding model",
+        "memory.features.ollamaBaseUrl": "Ollama server URL",
+        "memory.features.ollamaModel": "Ollama model",
+        "memory.features.dreamProvider": "Consolidation provider",
+        "memory.features.dreamModel": "Consolidation model",
+        "memory.features.dreamModelHint": "Leave empty to follow the main conversation model; only affects autoDream consolidation",
+        "memory.explorer.viewCards": "Cards",
+        "memory.explorer.viewTimeline": "Timeline",
+        "memory.explorer.viewAria": "Switch view",
+        "memory.explorer.dateLabel": "Time",
+        "memory.explorer.date.all": "All time",
+        "memory.explorer.date.7d": "Last 7 days",
+        "memory.explorer.date.30d": "Last 30 days",
+        "memory.explorer.date.90d": "Last 90 days",
+        "memory.explorer.more": "More actions",
+        "memory.explorer.exportJson": "Export JSON",
+        "memory.explorer.exportMarkdown": "Export Markdown",
+        "memory.explorer.importMd": "Import Markdown mirror…",
+        "memory.explorer.importTitle": "Import Markdown mirror",
+        "memory.explorer.importHint": "Pick a Markdown mirror file; its manual edits are parsed and merged into the store.",
+        "memory.explorer.importType": "Mirror type",
+        "memory.explorer.importPick": "Choose file…",
+        "memory.explorer.importConfirm": "Import",
+        "memory.explorer.importCancel": "Cancel",
+        "memory.explorer.importing": "Importing…",
+        "memory.explorer.imported": "Merged {n} edits",
+        "memory.explorer.importFailed": "Import failed",
+        "memory.explorer.importNoFile": "Choose a file first",
+        "memory.explorer.exportFailed": "Export failed",
+        "memory.explorer.conflictBadge": "Conflict",
+        "memory.explorer.archivedBadge": "Archived",
+        "memory.explorer.detail.edit": "Edit",
+        "memory.explorer.detail.save": "Save",
+        "memory.explorer.detail.cancel": "Cancel",
+        "memory.explorer.detail.archive": "Archive",
+        "memory.explorer.detail.archived": "Archived",
+        "memory.explorer.detail.archiveFailed": "Action failed",
+        "memory.explorer.detail.saved": "Saved; mirrors re-rendered",
+        "memory.explorer.detail.quality": "Quality",
+        "memory.explorer.detail.entities": "Related entities",
+        "memory.explorer.detail.entitiesEmpty": "Turn on entity extraction and related people / projects appear here",
+        "memory.explorer.detail.closeAria": "Close details",
+        "memory.explorer.detail.editTitle": "Title",
+        "memory.explorer.detail.editContent": "Content",
+        "memory.explorer.detail.editImportance": "Importance",
+        "memory.status.dream": "Last consolidation",
+        "memory.status.dreamNever": "Not yet run",
+        "memory.status.conflicts": "Pending conflicts",
+        "memory.status.conflictsHint": "Frozen contradictory memories awaiting confirmation",
+        "memory.status.workbench": "Activity",
+        "memory.status.dreamConsolidate": "Consolidation",
+        "memory.status.summarize": "Summarization",
+        "memory.status.tokens": "{n} tokens",
+        "memory.status.deposited": "{n} memories deposited",
+        "memory.status.failed": "failed",
+        "memory.status.success": "success",
+        "memory.status.skipped": "skipped",
+        "memory.status.emptyFeed": "No background activity yet: memories are distilled after conversations",
+        "memory.status.consolidated": "Deposited memories",
+        "memory.status.consolidatedEmpty": "Memories deposited by autoDream / autoSummarize appear here",
+        "memory.status.archivedMemories": "Archived memories",
+        "memory.status.archivedEmpty": "Nothing archived",
+        "memory.status.restore": "Restore",
+        "memory.settings.extapi.reveal": "Reveal",
+        "memory.settings.extapi.hide": "Hide",
+        "memory.settings.extapi.maskHint": "Token masked; Copy still copies the full value",
         "memory.explorer.delete": "Delete",
         "memory.explorer.confirmDelete": "Confirm delete?",
         "memory.explorer.cancel": "Cancel",
@@ -428,18 +688,18 @@ window.__ModuleLoader__.load({
       ".mneme-entitychip:hover{background:color-mix(in srgb,var(--dsw-alias-state-business-primary) 10%,transparent)}",
       // --- main-area memory library page ---
       ".mneme-x{flex:1;min-height:0;height:100%;width:100%;box-sizing:border-box;display:flex;flex-direction:column;background:var(--dsw-alias-bg-layer-1);--dsh-scrollbar-thumb:var(--dsw-alias-scrollbar-bg-l2);--dsh-scrollbar-thumb-hover:var(--dsw-alias-scrollbar-hover-l2)}",
-      ".mneme-xbar{flex:none;display:flex;align-items:center;gap:6px;border-bottom:1px solid var(--dsw-alias-border-l2);padding:0 16px}",
+      ".mneme-xbar{position:relative;flex:none;display:flex;align-items:center;justify-content:center;gap:6px;border-bottom:1px solid var(--dsw-alias-border-l2);padding:0 16px;min-height:52px}",
       ".mneme-filterbar{flex:none;display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
-      ".mneme-vtabs{display:flex;align-items:stretch;height:38px}",
-      ".mneme-vtab{position:relative;border:0;background:none;cursor:pointer;padding:0 10px;color:var(--dsw-alias-label-tertiary);font-family:inherit;font-size:13px;font-weight:500;line-height:16px;display:inline-flex;align-items:center;gap:6px}",
+      ".mneme-vtabs{display:flex;align-items:stretch;height:46px}",
+      ".mneme-vtab{position:relative;border:0;background:none;cursor:pointer;padding:0 16px;color:var(--dsw-alias-label-tertiary);font-family:inherit;font-size:14px;font-weight:500;line-height:20px;display:inline-flex;align-items:center;gap:7px}",
       ".mneme-vtab:hover{color:var(--dsw-alias-label-primary)}",
       ".mneme-vtab.mneme-active{color:var(--dsw-alias-state-business-primary)}",
-      ".mneme-vtab.mneme-active::after{content:\"\";position:absolute;left:8px;right:8px;bottom:-1px;height:2px;border-radius:2px;background:var(--dsw-alias-state-business-primary)}",
-      ".mneme-xtools{margin-left:auto;display:flex;align-items:center;gap:8px;padding:0 0 0 12px}",
+      ".mneme-vtab.mneme-active::after{content:\"\";position:absolute;left:10px;right:10px;bottom:-1px;height:2.5px;border-radius:2px;background:var(--dsw-alias-state-business-primary)}",
+      ".mneme-xtools{position:absolute;right:14px;top:50%;transform:translateY(-50%);display:flex;align-items:center;gap:8px;padding:0}",
       ".mneme-xcount{flex:none;font-size:12px;line-height:16px;color:var(--dsw-alias-label-tertiary);white-space:nowrap}",
       // --- three-column browse layout: hairline separators, no outer box ---
       ".mneme-xmain{flex:1;min-height:0;display:flex;flex-direction:row;overflow:hidden}",
-      ".mneme-xside{flex:none;width:236px;min-width:0;min-height:0;overflow-y:auto;padding:12px;border-right:1px solid var(--dsw-alias-border-l2);box-sizing:border-box;display:flex;flex-direction:column;gap:8px}",
+      ".mneme-xside{flex:none;width:236px;min-width:0;min-height:0;overflow-y:auto;padding:16px 14px;border-right:1px solid var(--dsw-alias-border-l2);box-sizing:border-box;display:flex;flex-direction:column;gap:8px}",
       ".mneme-xside--filter{width:214px}",
       ".mneme-xbrowse{flex:1;min-width:0;min-height:0;display:flex;flex-direction:column;overflow:hidden}",
       ".mneme-xrow{display:flex;align-items:center;gap:8px;flex-wrap:wrap}",
@@ -525,7 +785,7 @@ window.__ModuleLoader__.load({
       ".mneme-relname{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
       // --- settings: quiet stacked sections, one concern per section ---
       ".mneme-set{flex:1;min-height:0;overflow-y:auto;padding:8px 24px 48px;box-sizing:border-box}",
-      ".mneme-set-inner{max-width:680px}",
+      ".mneme-set-inner{max-width:720px;margin:0 auto}",
       ".mneme-set-sec{padding:20px 0 24px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
       ".mneme-set-sec:last-child{border-bottom:none}",
       ".mneme-set-title{font-size:14px;font-weight:600;color:var(--dsw-alias-label-primary);margin-bottom:4px}",
@@ -550,16 +810,95 @@ window.__ModuleLoader__.load({
       ".mneme-set-cmddesc{font-size:12px;line-height:17px;color:var(--dsw-alias-label-tertiary);margin-top:1px;word-break:break-word}",
       // --- settings sub-view ---
       ".mneme-set{flex:1;min-height:0;overflow-y:auto;padding:8px 24px 48px;box-sizing:border-box}",
-      // --- hero fallback: full-viewport memory library when no tab ring exists ---
-      // The host hides the whole conversation tab ring while a session is
-      // blank (hero screen), so the sidebar entry cannot activate the tab
-      // there. This surface reuses the exact MemoryExplorer UI at full size —
-      // not a side drawer — so the library stays reachable from any state.
-      ".mneme-overlay{position:fixed;inset:0;z-index:1000;display:flex;flex-direction:column;background:var(--dsw-alias-bg-layer-1);animation:mneme-fadein .12s ease-out}",
-      ".mneme-overlaybar{flex:none;display:flex;align-items:center;justify-content:space-between;height:44px;padding:0 12px 0 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
-      ".mneme-overlaytitle{font-size:14px;font-weight:600;color:var(--dsw-alias-label-primary)}",
+      // --- 记忆库页面：居中 sheet，非全屏 ---
+      // 从对话直接打开一页记忆库：背板压暗 + 居中圆角卡片（上限 1180×880），
+      // 对话仍留在背板之后，任何状态下（含新会话 hero、无 tab 环）都可用。
+      // portal 到 <body>，宿主侧边栏的层叠上下文裁不住它。
+      ".mneme-backdrop{position:fixed;inset:0;z-index:999;background:color-mix(in srgb,var(--dsw-alias-label-primary) 16%,transparent);backdrop-filter:blur(2px);animation:mneme-fadein .14s ease-out}",
+      ".mneme-overlay{position:fixed;z-index:1000;left:50%;top:50%;transform:translate(-50%,-50%);width:min(1240px,calc(100vw - 88px));height:min(920px,calc(100vh - 64px));display:flex;flex-direction:column;border:1px solid var(--dsw-alias-border-l2);border-radius:16px;overflow:hidden;background:var(--dsw-alias-bg-layer-1);box-shadow:0 24px 64px color-mix(in srgb,var(--dsw-alias-label-primary) 22%,transparent);animation:mneme-pop .18s cubic-bezier(.2,.9,.3,1)}",
+      ".mneme-overlaybar{flex:none;display:flex;align-items:center;justify-content:space-between;height:48px;padding:0 12px 0 18px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
+      ".mneme-overlaytitle{font-size:14px;font-weight:600;color:var(--dsw-alias-label-primary);display:flex;align-items:center;gap:8px}",
       ".mneme-overlaybody{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}",
       "@keyframes mneme-fadein{from{opacity:0}to{opacity:1}}",
+      "@keyframes mneme-pop{from{opacity:0;transform:translate(-50%,-50%) scale(.98)}to{opacity:1;transform:translate(-50%,-50%) scale(1)}}",
+      // --- 侧边栏顶部入口：借宿主「新会话」按钮的原生类名对齐 ---
+      // wrapper display:contents 隐身，按钮成为侧边栏弹性布局的直接子元素；
+      // 盒模型/间距/收起态 rail 几何全部继承宿主，我们只覆盖配色为次级观感。
+      ".mneme-topentry{display:contents}",
+      ".mneme-topentry-native{background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary)}",
+      ".mneme-topentry-native:hover{background:var(--dsw-alias-interactive-bg-hover);color:var(--dsw-alias-label-primary)}",
+      ".mneme-topentry-native .mneme-topentry-label{flex:1;min-width:0;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}",
+      // --- 功能开关：一行一开关，Claude 式安静排版 ---
+      ".mneme-featgroup{flex:none;font-size:12px;font-weight:600;letter-spacing:.02em;color:var(--dsw-alias-label-tertiary);margin:16px 0 2px}",
+      ".mneme-featrow{display:flex;align-items:center;gap:14px;padding:11px 2px;border-bottom:1px solid var(--dsw-alias-border-l1)}",
+      ".mneme-featrow:last-child{border-bottom:none}",
+      ".mneme-featmain{flex:1;min-width:0}",
+      ".mneme-featname{font-size:13.5px;font-weight:500;line-height:20px;color:var(--dsw-alias-label-primary)}",
+      ".mneme-feathint{font-size:12.5px;line-height:18px;color:var(--dsw-alias-label-tertiary);margin-top:2px}",
+      ".mneme-switch{position:relative;flex:none;width:36px;height:22px;border-radius:11px;border:none;cursor:pointer;background:var(--dsw-alias-interactive-bg-active);transition:background .15s}",
+      ".mneme-switch::after{content:\"\";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:var(--dsw-alias-bg-layer-1,#fff);box-shadow:0 1px 3px color-mix(in srgb,var(--dsw-alias-label-primary) 25%,transparent);transition:transform .15s}",
+      ".mneme-switch.mneme-on{background:var(--dsw-alias-state-business-primary)}",
+      ".mneme-switch.mneme-on::after{transform:translateX(14px)}",
+      ".mneme-switch:disabled{opacity:.5;cursor:default}",
+      ".mneme-featnum{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:9px 2px;border-bottom:1px solid var(--dsw-alias-border-l1)}",
+      ".mneme-featnum:last-child{border-bottom:none}",
+      ".mneme-featnumlabel{font-size:13px;line-height:20px;color:var(--dsw-alias-label-secondary)}",
+      ".mneme-numinput{box-sizing:border-box;width:110px;height:30px;padding:0 10px;border-radius:8px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);font-family:inherit;font-size:13px;outline:none;text-align:right;transition:border-color .12s,box-shadow .12s}",
+      ".mneme-numinput:focus{border-color:var(--dsw-alias-state-business-primary);box-shadow:0 0 0 3px color-mix(in srgb,var(--dsw-alias-state-business-primary) 15%,transparent)}",
+      // 字符串开关的输入框（provider/model 等）与其子块容器
+      ".mneme-strinput{box-sizing:border-box;width:240px;max-width:60%;height:30px;padding:0 10px;border-radius:8px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);font-family:inherit;font-size:13px;outline:none;text-align:left;transition:border-color .12s,box-shadow .12s}",
+      ".mneme-strinput:focus{border-color:var(--dsw-alias-state-business-primary);box-shadow:0 0 0 3px color-mix(in srgb,var(--dsw-alias-state-business-primary) 15%,transparent)}",
+      ".mneme-featsub{margin:2px 0 8px;padding:10px 12px;border:1px solid var(--dsw-alias-border-l1);border-radius:10px;display:flex;flex-direction:column;gap:6px}",
+      ".mneme-featsub .mneme-featnum{padding:6px 0;border-bottom:none}",
+      ".mneme-featsubhint{font-size:12px;line-height:17px;color:var(--dsw-alias-label-tertiary)}",
+      // --- 交互式记忆库：工具栏 / 卡片网格 / 详情抽屉 / 更多菜单 ---
+      // sheet 边距放宽：与窗口边缘保持呼吸距离，居中不顶满。
+      // 视图切换（卡片/时间线）分段控件挂在子页栏右侧。
+      ".mneme-seg{display:inline-flex;align-items:center;border:1px solid var(--dsw-alias-border-l2);border-radius:8px;overflow:hidden}",
+      ".mneme-seg button{border:none;background:none;color:var(--dsw-alias-label-tertiary);cursor:pointer;font-family:inherit;font-size:12px;line-height:16px;padding:5px 10px;display:inline-flex;align-items:center;gap:5px}",
+      ".mneme-seg button:hover{color:var(--dsw-alias-label-primary)}",
+      ".mneme-seg button.mneme-active{background:var(--dsw-alias-interactive-bg-active);color:var(--dsw-alias-label-primary);font-weight:500}",
+      // 卡片网格：响应式 auto-fill，卡片悬停轻浮起
+      ".mneme-cards{flex:1;min-height:0;overflow-y:auto;display:grid;grid-template-columns:repeat(auto-fill,minmax(252px,1fr));gap:14px;padding:20px 24px 32px;align-content:start}",
+      ".mneme-card{display:flex;flex-direction:column;gap:7px;min-width:0;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;padding:12px 13px;background:var(--dsw-alias-bg-layer-1);cursor:pointer;font-family:inherit;text-align:left;transition:border-color .12s,box-shadow .12s,transform .12s}",
+      ".mneme-card:hover{border-color:color-mix(in srgb,var(--dsw-alias-state-business-primary) 45%,var(--dsw-alias-border-l2));box-shadow:0 6px 20px color-mix(in srgb,var(--dsw-alias-label-primary) 10%,transparent);transform:translateY(-1px)}",
+      ".mneme-card.mneme-active{border-color:var(--dsw-alias-state-business-primary)}",
+      ".mneme-cardhead{display:flex;align-items:center;gap:6px;font-size:11.5px;line-height:16px;color:var(--dsw-alias-label-tertiary)}",
+      ".mneme-cardtitle{font-size:13.5px;font-weight:600;line-height:19px;color:var(--dsw-alias-label-primary);word-break:break-word;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}",
+      ".mneme-cardexcerpt{font-size:12.5px;line-height:18px;color:var(--dsw-alias-label-secondary);word-break:break-word;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}",
+      ".mneme-cardfoot{display:flex;align-items:center;gap:8px;margin-top:auto;font-size:11.5px;line-height:16px;color:var(--dsw-alias-label-tertiary)}",
+      ".mneme-cardsrc{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+      // 徽章：冲突待确认 / 已归档
+      ".mneme-badge{flex:none;display:inline-flex;align-items:center;gap:4px;height:18px;padding:0 7px;border-radius:6px;font-size:11px;line-height:14px}",
+      ".mneme-badge--conflict{color:var(--dsw-alias-state-error,#c33);background:color-mix(in srgb,var(--dsw-alias-state-error,#c33) 10%,transparent);border:1px solid color-mix(in srgb,var(--dsw-alias-state-error,#c33) 30%,transparent)}",
+      ".mneme-badge--archived{color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-interactive-bg-hover)}",
+      // 详情抽屉：sheet 内右侧滑出，覆盖在浏览区之上
+      ".mneme-xmain{position:relative}",
+      "@keyframes mneme-slidein{from{opacity:0;transform:translateX(16px)}to{opacity:1;transform:translateX(0)}}",
+      ".mneme-drawer{position:absolute;top:0;right:0;bottom:0;width:min(432px,52%);display:flex;flex-direction:column;border-left:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);box-shadow:-16px 0 40px color-mix(in srgb,var(--dsw-alias-label-primary) 10%,transparent);animation:mneme-slidein .18s ease-out;z-index:6}",
+      ".mneme-drawerbar{flex:none;display:flex;align-items:center;gap:8px;height:44px;padding:0 10px 0 16px;border-bottom:1px solid var(--dsw-alias-border-l2)}",
+      ".mneme-drawertype{display:inline-flex;align-items:center;gap:6px;font-size:12.5px;font-weight:500;color:var(--dsw-alias-label-secondary)}",
+      ".mneme-drawerbody{flex:1;min-height:0;overflow-y:auto;padding:20px 22px 28px}",
+      ".mneme-drawertitle{width:100%;font-size:16px;font-weight:600;line-height:23px;color:var(--dsw-alias-label-primary);word-break:break-word}",
+      ".mneme-drawertitle-input{width:100%;box-sizing:border-box;font-size:15px;font-weight:600;line-height:22px;padding:7px 10px;border-radius:8px;border:1px solid var(--dsw-alias-state-business-primary);background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);font-family:inherit;outline:none;box-shadow:0 0 0 3px color-mix(in srgb,var(--dsw-alias-state-business-primary) 15%,transparent)}",
+      ".mneme-dmeta{display:grid;grid-template-columns:auto 1fr;gap:4px 14px;margin-top:12px;font-size:12.5px;line-height:19px}",
+      ".mneme-dmetakey{color:var(--dsw-alias-label-tertiary)}",
+      ".mneme-dmetaval{color:var(--dsw-alias-label-secondary);min-width:0;word-break:break-word}",
+      ".mneme-dcontent{margin-top:14px;font-size:13.5px;line-height:1.75;color:var(--dsw-alias-label-primary);white-space:pre-wrap;word-break:break-word}",
+      ".mneme-dcontent-input{width:100%;box-sizing:border-box;min-height:180px;font-size:13.5px;line-height:1.7;padding:9px 11px;border-radius:8px;border:1px solid var(--dsw-alias-state-business-primary);background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);font-family:inherit;outline:none;resize:vertical;box-shadow:0 0 0 3px color-mix(in srgb,var(--dsw-alias-state-business-primary) 15%,transparent)}",
+      ".mneme-dentities{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}",
+      ".mnementity-chip{display:inline-flex;align-items:center;gap:5px;height:24px;padding:0 9px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;font-size:12px;line-height:16px;color:var(--dsw-alias-label-secondary);cursor:default}",
+      ".mneme-dactions{flex:none;display:flex;flex-wrap:wrap;gap:8px;padding:10px 16px;border-top:1px solid var(--dsw-alias-border-l2)}",
+      // 更多操作菜单（导入/导出）与导入弹层
+      ".mneme-menuwrap{position:relative}",
+      ".mneme-menu{position:absolute;right:0;top:calc(100% + 6px);min-width:180px;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;background:var(--dsw-alias-bg-layer-1);box-shadow:0 12px 32px color-mix(in srgb,var(--dsw-alias-label-primary) 16%,transparent);padding:5px;z-index:20;animation:mneme-fadein .1s ease-out}",
+      ".mneme-menu button{display:flex;align-items:center;gap:8px;width:100%;border:none;background:none;color:var(--dsw-alias-label-primary);cursor:pointer;font-family:inherit;font-size:13px;line-height:18px;padding:8px 10px;border-radius:8px;text-align:left}",
+      ".mneme-menu button:hover{background:var(--dsw-alias-interactive-bg-hover)}",
+      ".mneme-impdialog{position:absolute;right:0;top:calc(100% + 6px);width:300px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;background:var(--dsw-alias-bg-layer-1);box-shadow:0 12px 32px color-mix(in srgb,var(--dsw-alias-label-primary) 16%,transparent);padding:14px;z-index:20;animation:mneme-fadein .1s ease-out}",
+      ".mneme-improw{display:flex;align-items:center;gap:8px;margin-top:10px}",
+      // 瞬时操作提示（删除/归档）：挂在浏览层底部居中，不被抽屉卸载吞掉
+      ".mneme-x{position:relative}",
+      ".mneme-toast{position:absolute;left:50%;bottom:20px;transform:translateX(-50%);background:var(--dsw-alias-label-primary);color:var(--dsw-alias-bg-layer-1);font-size:12.5px;line-height:18px;padding:7px 16px;border-radius:10px;z-index:30;box-shadow:0 8px 24px color-mix(in srgb,var(--dsw-alias-label-primary) 25%,transparent);animation:mneme-fadein .15s ease-out}",
       // --- explorer refresh: paged month tree, sticky headers, inline icons ---
       ".mneme-vtabico{flex:none;opacity:.85}",
       ".mneme-xsearchwrap{position:relative;flex:none}",
@@ -572,9 +911,21 @@ window.__ModuleLoader__.load({
       ".mneme-xmore{display:flex;justify-content:center;align-items:center;padding:10px 0 24px;min-height:20px}",
       ".mneme-xemptyico{display:block;margin:0 auto 6px;opacity:.7}",
       // --- status sub-view: responsive stat-card grid (auto-fill, ~220px min) ---
-      ".mneme-status{flex:1;min-height:0;overflow-y:auto;padding:16px 20px 32px;box-sizing:border-box}",
-      ".mneme-statusgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;max-width:960px}",
+      ".mneme-status{flex:1;min-height:0;overflow-y:auto;padding:20px 24px 40px;box-sizing:border-box}",
+      ".mneme-statusgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;max-width:1000px;margin:0 auto}",
       ".mneme-statuscard{min-width:0;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:14px}",
+      // --- 状态页工作台：让用户看见插件在干活（动态/沉淀/归档） ---
+      ".mneme-wbhead{margin:28px auto 10px;font-size:13px;font-weight:600;color:var(--dsw-alias-label-primary);max-width:1000px}",
+      ".mneme-wblist{max-width:1000px;display:flex;flex-direction:column;gap:6px}",
+      ".mneme-wbrow{display:flex;gap:10px;align-items:flex-start;padding:10px 14px;border:1px solid var(--dsw-alias-border-l1);border-radius:10px}",
+      ".mneme-wbdot{flex:none;width:8px;height:8px;border-radius:50%;margin-top:6px;background:var(--dsw-alias-state-success,#2a9d6a)}",
+      ".mneme-wbdot--err{background:var(--dsw-alias-state-error,#c33)}",
+      ".mneme-wbmain{min-width:0;flex:1}",
+      ".mneme-wbtitle{font-size:13px;line-height:19px;color:var(--dsw-alias-label-primary)}",
+      ".mneme-wbsub{font-size:12px;line-height:17px;color:var(--dsw-alias-label-tertiary);margin-top:1px}",
+      ".mneme-wbmemo{display:flex;gap:10px;align-items:center;padding:10px 14px;border:1px solid var(--dsw-alias-border-l1);border-radius:10px}",
+      ".mneme-wbmemo .mneme-xdot{flex:none}",
+      ".mneme-wbmemo-main{min-width:0;flex:1}",
       ".mneme-statusnum{font-size:24px;font-weight:600;line-height:32px;color:var(--dsw-alias-label-primary);font-variant-numeric:tabular-nums}",
       ".mneme-statuscap{margin-top:4px;font-size:13px;line-height:19px;color:var(--dsw-alias-label-tertiary);word-break:break-word}",
       // --- destructive actions: red outline = delete, solid red = confirm ---
@@ -623,7 +974,12 @@ window.__ModuleLoader__.load({
       project: "#22c55e",
       decision: "#3b82f6",
       summary: "#a855f7",
-      history: "#94a3b8"
+      history: "#94a3b8",
+      // codingRetrospect 的三类编码记忆：警示色区分度最高——踩坑/被否决方案
+      // 天然带"注意"语义，工程约束用冷色表达"规则"。
+      rejected_solution: "#fb923c",
+      pitfall: "#ef4444",
+      constraint: "#0ea5e9"
     };
     function memoryTypeColor(type) {
       return MEMORY_TYPE_COLORS[type] || "#94a3b8";
@@ -1110,6 +1466,185 @@ window.__ModuleLoader__.load({
     }
 
 
+    // --- 功能开关卡片（可插拔后端能力）---
+    // GET /features 拿 overrides + effective，PUT 提交增量；启动时 index.js
+    // 把持久化的 kv 合并进配置，因此每个开关都标注「重启 DSH 后生效」。
+    // 分组排版：核心/增强/巩固常驻，注入策略等收进「高级」折叠，普通用户
+    // 不被专业项淹没。429 调速器参数、distillMaxChars、codingBoostFactor
+    // 属调优噪音，按对齐结论留在配置文件，不上 UI。
+    const FEATURE_GROUPS = [
+      { key: "group.core", items: ["autoInject", "autoSummarize", "hotMemoryEnabled", "memoryQualityFilter.enabled", "llmAudit.enabled"] },
+      { key: "group.enhance", items: ["entityExtractionEnabled", "codingRetrospect", "rerankEnabled", "searchSemanticDedup", "bm25SearchEnabled"] },
+      { key: "group.dream", items: ["autoDream", "sleepModeEnabled"] }
+    ];
+    const FEATURE_ADVANCED_BOOLS = ["hybridInject", "selectiveInjectEnabled", "adaptiveThresholdEnabled", "reflectionUpdateEnabled", "reflectionFailureTracking", "conflictFreezeEnabled", "trustEpistemicWeighting"];
+    // 字符串键（blur/Enter 提交，空串合法 = 跟随默认）：巩固模型与语义
+    // 检索路线。embedProvider 是枚举，用下拉单独渲染。
+    const FEATURE_STRINGS = ["dreamProvider", "dreamModel", "localEmbedModel", "ollamaBaseUrl", "ollamaModel"];
+    const EMBED_PROVIDERS = ["openai", "local", "ollama"];
+
+    function FeatureRow({ name, hint, on, disabled, onToggle }) {
+      return h("div", { className: "mneme-featrow" },
+        h("div", { className: "mneme-featmain" },
+          h("div", { className: "mneme-featname" }, name),
+          h("div", { className: "mneme-feathint" }, hint)
+        ),
+        h("button", {
+          type: "button",
+          className: on ? "mneme-switch mneme-on" : "mneme-switch",
+          role: "switch",
+          "aria-checked": String(on),
+          "aria-label": name,
+          disabled,
+          onClick: onToggle
+        })
+      );
+    }
+
+    function FeaturesCard({ t }) {
+      const [state, setState] = useState(null); // { overrides, effective }
+      const [error, setError] = useState("");
+      const [busy, setBusy] = useState(false);
+      const [savedTick, setSavedTick] = useState(false);
+      const [showAdv, setShowAdv] = useState(false);
+      const [strs, setStrs] = useState({}); // 字符串输入的本地草稿：key -> string
+
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/features")
+          .then((res) => { if (!res.ok) throw new Error("HTTP " + res.status); return res.json(); })
+          .then((j) => {
+            if (cancelled) return;
+            setState(j);
+            const e = (j && j.effective) || {};
+            const draft = {};
+            for (const key of FEATURE_STRINGS) draft[key] = String(e[key] ?? "");
+            setStrs(draft);
+          })
+          .catch(() => { if (!cancelled) setError(t("memory.features.loadFailed")); });
+        return () => { cancelled = true; };
+      }, [t]);
+
+      const eff = (state && state.effective) || {};
+
+      const put = async (patch) => {
+        setBusy(true);
+        try {
+          const res = await apiFetch("/api/dsh-mneme/features", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(patch)
+          });
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          setState(await res.json());
+          setSavedTick(true);
+          setTimeout(() => setSavedTick(false), 1800);
+        } catch {
+          setError(t("memory.features.loadFailed"));
+        } finally {
+          setBusy(false);
+        }
+      };
+
+      // 字符串项失焦/回车提交：trim 后与生效值相同则回填放弃，否则交给
+      // 后端校验（ollamaBaseUrl 的协议、embedProvider 的枚举在后端把关）。
+      const commitString = (key) => {
+        const raw = (strs[key] ?? "").trim();
+        if (raw === String(eff[key] ?? "")) {
+          setStrs((c) => ({ ...c, [key]: String(eff[key] ?? "") }));
+          return;
+        }
+        put({ [key]: raw });
+      };
+
+      const boolRow = (k) => h(FeatureRow, {
+        key: k,
+        name: t(`memory.features.${k}`),
+        hint: t(`memory.features.${k}.hint`),
+        on: !!eff[k],
+        disabled: busy,
+        onToggle: () => put({ [k]: !eff[k] })
+      });
+
+      const strRow = (key) => h("div", { className: "mneme-featnum", key },
+        h("span", { className: "mneme-featnumlabel" }, t(`memory.features.${key}`)),
+        h("input", {
+          className: "mneme-strinput",
+          value: strs[key] ?? "",
+          onChange: (e) => setStrs((c) => ({ ...c, [key]: e.target.value })),
+          onBlur: () => commitString(key),
+          onKeyDown: (e) => { if (e.key === "Enter") e.target.blur(); }
+        }));
+
+      // 语义检索路线：provider 下拉即时提交；local/ollama 选中时展开各自
+      // 的连接字段，openai 的连接信息由「向量搜索」卡片持有，只给指引。
+      const embedSub = h("div", { className: "mneme-featsub" },
+        h("div", { className: "mneme-featnum" },
+          h("span", { className: "mneme-featnumlabel" }, t("memory.features.embedProvider")),
+          h("select", {
+            className: "mneme-select",
+            value: eff.embedProvider || "openai",
+            disabled: busy,
+            onChange: (e) => put({ embedProvider: e.target.value })
+          },
+            EMBED_PROVIDERS.map((p) => h("option", { key: p, value: p }, t(`memory.features.embedProvider.${p}`))))
+        ),
+        h("div", { className: "mneme-featsubhint" },
+          t(`memory.features.embedProvider.${eff.embedProvider || "openai"}.hint`)),
+        eff.embedProvider === "local" && strRow("localEmbedModel"),
+        eff.embedProvider === "ollama" && strRow("ollamaBaseUrl"),
+        eff.embedProvider === "ollama" && strRow("ollamaModel")
+      );
+
+      // 巩固模型：autoDream 开着才展开，避免闲置配置占版面。
+      const dreamSub = eff.autoDream && h("div", { className: "mneme-featsub" },
+        strRow("dreamProvider"),
+        strRow("dreamModel"),
+        h("div", { className: "mneme-featsubhint" }, t("memory.features.dreamModelHint"))
+      );
+
+      if (error && !state) return h("section", { className: "mneme-set-card" },
+        h("div", { className: "mneme-set-title" }, t("memory.features.title")),
+        h("div", { className: "mneme-set-hint" }, error));
+
+      return h("section", { className: "mneme-set-card" },
+        h("div", { className: "mneme-set-title" },
+          t("memory.features.title"),
+          savedTick && h("span", { className: "mneme-saved", style: { marginLeft: 8, fontWeight: 400 } }, t("memory.features.restartHint"))
+        ),
+        h("div", { className: "mneme-set-desc" }, t("memory.features.desc")),
+        state === null && !error
+          ? h("div", { className: "mneme-set-hint" }, "…")
+          : h(react.Fragment, null,
+              FEATURE_GROUPS.map((g) => h(react.Fragment, { key: g.key },
+                h("div", { className: "mneme-featgroup" }, t(`memory.features.${g.key}`)),
+                g.items.map(boolRow),
+                g.key === "group.enhance" && embedSub,
+                g.key === "group.dream" && dreamSub
+              )),
+              h("div", { className: "mneme-featgroup" },
+                h("button", {
+                  type: "button",
+                  className: "mneme-footbtn",
+                  "aria-expanded": String(showAdv),
+                  onClick: () => setShowAdv(!showAdv)
+                },
+                  h(Icon, { name: showAdv ? "chevronDown" : "chevronRight", size: 12 }),
+                  t("memory.features.advancedToggle"))
+              ),
+              showAdv && FEATURE_ADVANCED_BOOLS.map(boolRow)
+            )
+      );
+    }
+
+    // 令牌遮蔽：保留首尾少量字符便于辨认，中间全部打点；完整值只经复制
+    // 通道离开面板。
+    function maskToken(value) {
+      const s = String(value ?? "");
+      if (s.length <= 8) return "•".repeat(Math.max(6, s.length));
+      return `${s.slice(0, 5)}${"•".repeat(10)}${s.slice(-4)}`;
+    }
+
     function SettingsContent({ t }) {
       const [profile, setProfile] = react.useState("");
       const [rules, setRules] = react.useState([]);
@@ -1141,6 +1676,8 @@ window.__ModuleLoader__.load({
       const [extapiSaved, setExtapiSaved] = react.useState(false);
       const [extapiCopied, setExtapiCopied] = react.useState(false);
       const [extapiError, setExtapiError] = react.useState("");
+      // 令牌默认遮蔽显示：完整值只经「复制」离开面板，不直接铺在页面上。
+      const [extapiTokenShown, setExtapiTokenShown] = react.useState(false);
 
       const load = react.useCallback(async () => {
         try {
@@ -1433,6 +1970,9 @@ window.__ModuleLoader__.load({
             )
           )
         ),
+        // 功能开关 — 0.7.13/0.7.14 后端能力的前端总闸（codingRetrospect、
+        // 智能调速器参数、实体抽取、巩固等）；重启 DSH 后生效。
+        h(FeaturesCard, { t }),
         // 运行模式 — light vs standard chip radios; each click PUTs and the
         // change only lands after a DSH restart (green saved hint says so).
         h("section", { className: "mneme-set-card" },
@@ -1505,7 +2045,16 @@ window.__ModuleLoader__.load({
                       t("memory.settings.vectorSave"))
                   ),
                   h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginTop: 10 } },
-                    h("div", { className: "mneme-set-token", style: { flex: 1, minWidth: 0 } }, extapi.token || "—"),
+                    h("div", {
+                      className: "mneme-set-token",
+                      style: { flex: 1, minWidth: 0 },
+                      title: extapi.token && !extapiTokenShown ? t("memory.settings.extapi.maskHint") : undefined
+                    }, !extapi.token ? "—" : (extapiTokenShown ? extapi.token : maskToken(extapi.token))),
+                    h("button", {
+                      className: "mneme-footbtn",
+                      onClick: () => setExtapiTokenShown(!extapiTokenShown),
+                      "aria-label": extapiTokenShown ? t("memory.settings.extapi.hide") : t("memory.settings.extapi.reveal")
+                    }, extapiTokenShown ? t("memory.settings.extapi.hide") : t("memory.settings.extapi.reveal")),
                     h("button", { className: "mneme-btn", onClick: copyExtapiToken },
                       t("memory.settings.extapi.copy")),
                     extapiCopied && h("span", { className: "mneme-saved" }, t("memory.settings.extapi.copied"))
@@ -1551,59 +2100,14 @@ window.__ModuleLoader__.load({
       );
     }
 
-    // --- Main-area memory library: the single home for every memory feature ---
-    // Registered under conversation.view beside Chat / Trajectory. The old
-    // right-hand drawer is gone: the sidebar foot entry activates this tab
-    // directly. The framework keeps the active-view setter private to the
-    // conversation package, and the DOM tab click is the one stable
-    // activation path available to plugins.
-    //
-    // One host constraint remains: the conversation header (and with it the
-    // whole tab ring) is hidden while a session is blank — the new-chat hero
-    // screen. There the tab simply does not exist, so activateExplorerTab
-    // resolves false and the sidebar entry falls back to the full-viewport
-    // overlay surface below.
-    // Candidate tabs whose label matches ours exactly. The conversation tab
-    // ring carries no registrant id in the DOM, so the label is all we have —
-    // but other plugins may register views (or settings dialogs may render
-    // panes) with the same text, and hidden panes still sit in the document.
-    // Restrict to rendered tabs (offsetParent filters display:none subtrees)
-    // and verify by rendering, not by label alone (see activateExplorerTab).
-    function findExplorerTabs(label) {
-      const matches = [];
-      for (const tab of document.querySelectorAll('[role="tab"]')) {
-        if ((tab.textContent || "").trim() !== label) continue;
-        if (tab.offsetParent === null && getComputedStyle(tab).position !== "fixed") continue;
-        matches.push(tab);
-      }
-      return matches;
-    }
-
-    // Click the memory library tab and wait (bounded, rAF-polled) until the
-    // host marks it selected AND our explorer actually rendered (`.mneme-x`).
-    // aria-selected alone cannot tell our tab from a same-labelled tab of
-    // another plugin — the sidebar entry must not activate theirs. On a
-    // failed candidate, move on to the next one; resolve false when the
-    // fallback overlay should take over.
-    function activateExplorerTab(label) {
-      return new Promise((resolve) => {
-        const candidates = findExplorerTabs(label);
-        if (candidates.length === 0) { resolve(false); return; }
-        let index = 0;
-        const tryNext = () => {
-          if (index >= candidates.length) { resolve(false); return; }
-          const tab = candidates[index++];
-          tab.click();
-          const deadline = Date.now() + 400;
-          (function check() {
-            const rendered = document.querySelector(".mneme-x") !== null;
-            if (tab.getAttribute("aria-selected") === "true" && rendered) { resolve(true); return; }
-            if (Date.now() >= deadline) { setTimeout(tryNext, 0); return; }
-            requestAnimationFrame(check);
-          })();
-        };
-        tryNext();
-      });
+    // --- 打开记忆库 ---
+    // v0.7.15 起记忆库不再注册 conversation.view tab：对话内嵌体验差
+    // （面板被悬浮输入框遮挡、挤压会话布局）。唯一入口是侧边栏记忆按钮，
+    // 直接打开居中 sheet——对话留在背板之后，不占全屏。保留这层间接函数
+    // 是给图/实体视图的「查看来源记忆」跳转一个稳定语义：打开 sheet，
+    // MemoryExplorer 内部状态（选中行、过滤）由各自的跳转回调处理。
+    function openLibrary() {
+      setOverlayOpen(true);
     }
 
     // --- Hero fallback overlay state (module-level pub/sub) ---
@@ -1624,11 +2128,9 @@ window.__ModuleLoader__.load({
       return [open, setOverlayOpen];
     }
 
-    // Full-viewport memory library for states without a tab ring (new-chat
-    // hero). Same MemoryExplorer component as the tab view — identical
-    // three-column layout, graph and settings — plus a slim top bar with a
-    // close affordance. Esc closes. Portalled to <body> so sidebar stacking
-    // contexts cannot clip it.
+    // 居中 sheet 记忆库：任何状态下（含新会话 hero、无 tab 环）都能从侧边栏
+    // 入口直接打开。背板点击 / Esc 关闭。portal 到 <body>，侧边栏的层叠
+    // 上下文裁不住它；运行时拒绝 react-dom 时就地渲染（position:fixed 仍然成立）。
     function MemoryOverlay({ t }) {
       const [open, setOpen] = useOverlayOpen();
       useEffect(() => {
@@ -1638,16 +2140,30 @@ window.__ModuleLoader__.load({
         return () => window.removeEventListener("keydown", onKey);
       }, [open]);
       if (!open) return null;
-      const tree = h("div", { className: "mneme-overlay", role: "region", "aria-label": t("memory.view.label") },
-        h("div", { className: "mneme-overlaybar" },
-          h("span", { className: "mneme-overlaytitle" }, t("memory.view.label")),
-          h("button", {
-            type: "button",
-            className: "mneme-footbtn",
-            onClick: () => setOpen(false)
-          }, t("memory.overlay.close"))
-        ),
-        h("div", { className: "mneme-overlaybody" }, h(MemoryExplorer, { t }))
+      // 背板与 sheet 是兄弟节点而不是嵌套：点击背板自身才关闭，sheet 内部
+      // 的任何点击都不会冒泡到背板，不需要额外拦截。
+      const tree = h(react.Fragment, null,
+        h("div", {
+          className: "mneme-backdrop",
+          onClick: () => setOpen(false),
+          "aria-hidden": "true"
+        }),
+        h("div", { className: "mneme-overlay", role: "region", "aria-label": t("memory.view.label") },
+          h("div", { className: "mneme-overlaybar" },
+            h("span", { className: "mneme-overlaytitle" },
+              h(IconArchiveOutline20, { size: 15 }),
+              t("memory.view.label")
+            ),
+            h("button", {
+              type: "button",
+              className: "mneme-footbtn",
+              "aria-label": t("memory.overlay.close"),
+              title: t("memory.overlay.close"),
+              onClick: () => setOpen(false)
+            }, "✕")
+          ),
+          h("div", { className: "mneme-overlaybody" }, h(MemoryExplorer, { t }))
+        )
       );
       if (reactDom && typeof document !== "undefined") return reactDom.createPortal(tree, document.body);
       return tree;
@@ -1789,17 +2305,396 @@ window.__ModuleLoader__.load({
       });
     }
 
+    // 巩固状态卡（×2）：最近一次 autoDream 运行 + 待确认冲突计数。数据来自
+    // /dream-status，一次取回两张卡共用；失败只影响这两张卡自身。
+    function DreamStatusCards({ t }) {
+      const [state, setState] = useState({ loading: true, error: false, lastRun: null, pending: 0 });
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/dream-status")
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((d) => {
+            if (cancelled) return;
+            setState({
+              loading: false,
+              error: false,
+              lastRun: (d && d.lastRun) || null,
+              pending: Number((d && d.pendingConflicts) ?? 0)
+            });
+          })
+          .catch(() => { if (!cancelled) setState({ loading: false, error: true, lastRun: null, pending: 0 }); });
+        return () => { cancelled = true; };
+      }, []);
+      const run = state.lastRun;
+      const num = run ? formatRelativeTime(run.created_at, t) : t("memory.status.dreamNever");
+      const cap = run
+        ? `${run.status || "—"}${run.model ? ` · ${run.model}` : ""}`
+        : t("memory.settings.mode.offList");
+      return h(react.Fragment, null,
+        h(StatusCard, { t, title: t("memory.status.dream"), loading: state.loading, error: state.error, num, cap }),
+        h(StatusCard, {
+          t,
+          title: t("memory.status.conflicts"),
+          loading: state.loading,
+          error: state.error,
+          num: state.pending.toLocaleString(),
+          cap: t("memory.status.conflictsHint")
+        })
+      );
+    }
+
+    // --- 状态页工作台：让用户切实看见插件在干活 ---
+    // 活动流合并 llm_audit 里 autoDream/autoSummarize 的后台调用（状态、
+    // token、沉淀条数）；沉淀记忆列表用 audit 行携带的 related_memory_ids
+    // 对照最近列表解析出标题；归档列表走 /list?archived=only，「恢复」经
+    // POST /update {archived:false} 送回主列表。
+    function parseRelatedIds(v) {
+      if (Array.isArray(v)) return v;
+      if (typeof v === "string") {
+        try { const a = JSON.parse(v); return Array.isArray(a) ? a : []; } catch { return []; }
+      }
+      return [];
+    }
+
+    function WorkbenchSection({ t }) {
+      const [feed, setFeed] = useState(null); // audit rows（已过滤巩固/总结）
+      const [deposited, setDeposited] = useState(null); // ids 解析出的记忆
+      const [archived, setArchived] = useState(null);
+      const [restoring, setRestoring] = useState("");
+
+      const load = useCallback(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/semantic/llm-audit?pageSize=12")
+          .then((r) => (r.ok ? r.json() : { items: [] }))
+          .then((d) => {
+            if (cancelled) return;
+            const rows = (d.items || []).filter((r) =>
+              r.trigger_source === "autoDream" || r.trigger_source === "autoSummarize");
+            setFeed(rows);
+            const ids = [];
+            for (const row of rows) {
+              for (const id of parseRelatedIds(row.related_memory_ids)) {
+                if (!ids.includes(id)) ids.push(id);
+              }
+            }
+            return apiFetch("/api/dsh-mneme/list?limit=300&order=chrono")
+              .then((r2) => (r2.ok ? r2.json() : { items: [] }))
+              .then((d2) => {
+                if (cancelled) return;
+                const byId = new Map((d2.items || []).map((m) => [m.id, m]));
+                setDeposited(ids.map((id) => byId.get(id)).filter(Boolean).slice(0, 8));
+              });
+          })
+          .catch(() => { if (!cancelled) setFeed([]); });
+        apiFetch("/api/dsh-mneme/list?archived=only&limit=50&order=chrono")
+          .then((r) => (r.ok ? r.json() : { items: [] }))
+          .then((d) => { if (!cancelled) setArchived(d.items || []); })
+          .catch(() => { if (!cancelled) setArchived([]); });
+        return () => { cancelled = true; };
+      }, []);
+      useEffect(() => { load(); }, [load]);
+
+      const restore = (id) => {
+        setRestoring(id);
+        apiFetch("/api/dsh-mneme/update", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id, archived: false })
+        })
+          .then((r) => { if (!r.ok) throw new Error("http"); })
+          .then(() => setArchived((cur) => (cur || []).filter((m) => m.id !== id)))
+          .catch(() => {})
+          .finally(() => setRestoring(""));
+      };
+
+      const statusLabel = (s) => s === "error"
+        ? t("memory.status.failed")
+        : s === "skipped" ? t("memory.status.skipped") : t("memory.status.success");
+      const triggerLabel = (s) => s === "autoDream"
+        ? t("memory.status.dreamConsolidate") : t("memory.status.summarize");
+
+      return h(react.Fragment, null,
+        h("div", { className: "mneme-wbhead" }, t("memory.status.workbench")),
+        feed === null
+          ? h("div", { className: "mneme-featsubhint" }, "…")
+          : feed.length === 0
+            ? h("div", { className: "mneme-featsubhint" }, t("memory.status.emptyFeed"))
+            : h("div", { className: "mneme-wblist" },
+                feed.map((row) => {
+                  const n = parseRelatedIds(row.related_memory_ids).length;
+                  return h("div", { className: "mneme-wbrow", key: row.id ?? row.timestamp },
+                    h("span", { className: row.status === "error" ? "mneme-wbdot mneme-wbdot--err" : "mneme-wbdot", "aria-hidden": "true" }),
+                    h("div", { className: "mneme-wbmain" },
+                      h("div", { className: "mneme-wbtitle" },
+                        `${triggerLabel(row.trigger_source)} · ${statusLabel(row.status)}`),
+                      h("div", { className: "mneme-wbsub" },
+                        formatRelativeTime(row.timestamp, t),
+                        n > 0 && ` · ${t("memory.status.deposited").replace("{n}", String(n))}`,
+                        row.total_tokens ? ` · ${t("memory.status.tokens").replace("{n}", Number(row.total_tokens).toLocaleString())}` : "",
+                        row.error_message ? ` · ${row.error_message}` : "")
+                    ));
+                })),
+        deposited !== null && deposited.length > 0 && h(react.Fragment, null,
+          h("div", { className: "mneme-wbhead" }, t("memory.status.consolidated")),
+          h("div", { className: "mneme-wblist" },
+            deposited.map((m) => h("div", { className: "mneme-wbmemo", key: m.id },
+              h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(m.type) }, "aria-hidden": "true" }),
+              h("div", { className: "mneme-wbmemo-main" },
+                h("div", { className: "mneme-wbtitle" }, m.title || (m.content || "").slice(0, 40)),
+                h("div", { className: "mneme-wbsub" },
+                  `${typeLabel(t, m.type)} · ${formatRelativeTime(m.updated_at || m.created_at, t)}`))
+              )))),
+        archived !== null && h(react.Fragment, null,
+          h("div", { className: "mneme-wbhead" }, t("memory.status.archivedMemories")),
+          archived.length === 0
+            ? h("div", { className: "mneme-featsubhint" }, t("memory.status.archivedEmpty"))
+            : h("div", { className: "mneme-wblist" },
+                archived.map((m) => h("div", { className: "mneme-wbmemo", key: m.id },
+                  h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(m.type) }, "aria-hidden": "true" }),
+                  h("div", { className: "mneme-wbmemo-main" },
+                    h("div", { className: "mneme-wbtitle" }, m.title || (m.content || "").slice(0, 40)),
+                    h("div", { className: "mneme-wbsub" },
+                      `${typeLabel(t, m.type)} · ${formatRelativeTime(m.updated_at || m.created_at, t)}`)),
+                  h("button", {
+                    type: "button",
+                    className: "mneme-btn",
+                    disabled: restoring === m.id,
+                    onClick: () => restore(m.id)
+                  }, t("memory.status.restore"))
+                ))))
+      );
+    }
+
     function StatusPanel({ t }) {
       return h("div", { className: "mneme-status" },
         h("div", { className: "mneme-statusgrid" },
           h(MemoriesStatusCard, { t }),
           h(EntitiesStatusCard, { t }),
           h(VectorStatusCard, { t }),
-          h(LlmStatusCard, { t })
+          h(LlmStatusCard, { t }),
+          h(DreamStatusCards, { t })
+        ),
+        h(WorkbenchSection, { t })
+      );
+    }
+
+
+    // --- 详情抽屉 ---
+    // 右侧滑出：全文、来源、质量分、关联实体与手动操作（编辑/归档/删除）。
+    // 编辑态本地暂存草稿，保存经 POST /update 落库；后端成功后重渲染镜像，
+    // 前端只做本地视图同步。两步删除确认在此完成（红钮武装 → 实心红提交）。
+    function MemoryDrawer({ t, memory, conflict, deleting, deleteError, onClose, onDelete, onSaved }) {
+      const [editing, setEditing] = useState(false);
+      const [title, setTitle] = useState(memory.title || "");
+      const [content, setContent] = useState(memory.content || "");
+      const [importance, setImportance] = useState(memory.importance || 3);
+      const [confirmDelete, setConfirmDelete] = useState(false);
+      const [busy, setBusy] = useState(false);
+      const [savedTick, setSavedTick] = useState(false);
+      const [saveError, setSaveError] = useState(false);
+      const [copied, setCopied] = useState(false);
+      const [entities, setEntities] = useState(null);
+
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch(`/api/dsh-mneme/memories/entities?memoryId=${encodeURIComponent(memory.id)}`)
+          .then((res) => (res.ok ? res.json() : { entities: [] }))
+          .then((d) => { if (!cancelled) setEntities(d.entities || []); })
+          .catch(() => { if (!cancelled) setEntities([]); });
+        return () => { cancelled = true; };
+      }, [memory.id]);
+
+      const postUpdate = (patch, opts) => {
+        setBusy(true);
+        setSaveError(false);
+        apiFetch("/api/dsh-mneme/update", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: memory.id, ...patch })
+        })
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((d) => {
+            onSaved(d.memory, opts);
+            setEditing(false);
+            setSavedTick(true);
+            setTimeout(() => setSavedTick(false), 2000);
+          })
+          .catch(() => setSaveError(true))
+          .finally(() => setBusy(false));
+      };
+
+      const save = () => {
+        const t2 = title.trim();
+        if (!t2) return;
+        postUpdate({ title: t2, content, importance }, {});
+      };
+
+      return h("aside", { className: "mneme-drawer", "aria-label": t("memory.explorer.detail") },
+        h("div", { className: "mneme-drawerbar" },
+          h("span", { className: "mneme-drawertype" },
+            h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(memory.type) }, "aria-hidden": "true" }),
+            typeLabel(t, memory.type)
+          ),
+          conflict && h("span", { className: "mneme-badge mneme-badge--conflict" }, "⚠ ", t("memory.explorer.conflictBadge")),
+          h("button", {
+            type: "button",
+            className: "mneme-footbtn",
+            style: { marginLeft: "auto" },
+            "aria-label": t("memory.explorer.detail.closeAria"),
+            title: t("memory.explorer.detail.closeAria"),
+            onClick: onClose
+          }, "✕")
+        ),
+        h("div", { className: "mneme-drawerbody" },
+          editing
+            ? h(react.Fragment, null,
+                h("div", { className: "mneme-xcolhead", style: { padding: "0 0 4px" } }, t("memory.explorer.detail.editTitle")),
+                h("input", { className: "mneme-drawertitle-input", value: title, onChange: (e) => setTitle(e.target.value) }))
+            : h("div", { className: "mneme-drawertitle" }, memory.title || t("memory.panel.empty")),
+          h("div", { className: "mneme-dmeta" },
+            h("span", { className: "mneme-dmetakey" }, t("memory.explorer.importance")),
+            editing
+              ? h("select", {
+                  className: "mneme-select",
+                  style: { height: 26, fontSize: 12, justifySelf: "start" },
+                  value: importance,
+                  onChange: (e) => setImportance(Number(e.target.value))
+                }, [1, 2, 3, 4, 5].map((n) => h("option", { key: n, value: n }, "★".repeat(n))))
+              : h("span", { className: "mneme-dmetaval" }, "★".repeat(Math.min(5, Math.max(0, memory.importance || 0)))),
+            memory.source && h(react.Fragment, null,
+              h("span", { className: "mneme-dmetakey" }, t("memory.explorer.source")),
+              h("span", { className: "mneme-dmetaval", title: memory.source }, memory.source)),
+            memory.quality_score != null && h(react.Fragment, null,
+              h("span", { className: "mneme-dmetakey" }, t("memory.explorer.detail.quality")),
+              h("span", { className: "mneme-dmetaval" }, String(memory.quality_score))),
+            h("span", { className: "mneme-dmetakey" }, t("memory.explorer.created")),
+            h("span", { className: "mneme-dmetaval", title: formatDate(memory.created_at) }, formatDateShort(memory.created_at)),
+            h("span", { className: "mneme-dmetakey" }, t("memory.explorer.updated")),
+            h("span", { className: "mneme-dmetaval", title: formatDate(memory.updated_at) },
+              `${formatRelativeTime(memory.updated_at, t)}（${formatDateShort(memory.updated_at)}）`),
+            Array.isArray(memory.tags) && memory.tags.length > 0 && h(react.Fragment, null,
+              h("span", { className: "mneme-dmetakey" }, t("memory.explorer.tags")),
+              h("span", { className: "mneme-dmetaval" }, memory.tags.join(" · ")))
+          ),
+          entities !== null && h(react.Fragment, null,
+            h("div", { className: "mneme-xcolhead", style: { padding: "16px 0 0" } }, t("memory.explorer.detail.entities")),
+            entities.length === 0
+              ? h("div", { className: "mneme-featsubhint", style: { marginTop: 4 } }, t("memory.explorer.detail.entitiesEmpty"))
+              : h("div", { className: "mneme-dentities" },
+                  entities.map((e, i) => h("span", { key: `${e.name}-${i}`, className: "mnementity-chip" },
+                    h("span", { className: "mneme-xdot", style: { color: typeColor(e.type) }, "aria-hidden": "true" }),
+                    e.name
+                  )))),
+          editing && h("div", { className: "mneme-xcolhead", style: { padding: "16px 0 4px" } }, t("memory.explorer.detail.editContent")),
+          editing
+            ? h("textarea", { className: "mneme-dcontent-input", value: content, onChange: (e) => setContent(e.target.value) })
+            : h("div", { className: "mneme-dcontent" }, memory.content)
+        ),
+        h("div", { className: "mneme-dactions" },
+          editing
+            ? h(react.Fragment, null,
+                h("button", { type: "button", className: "mneme-btn", disabled: busy, onClick: save }, t("memory.explorer.detail.save")),
+                h("button", {
+                  type: "button",
+                  className: "mneme-btn",
+                  disabled: busy,
+                  onClick: () => {
+                    setEditing(false);
+                    setTitle(memory.title || "");
+                    setContent(memory.content || "");
+                    setImportance(memory.importance || 3);
+                  }
+                }, t("memory.explorer.detail.cancel")),
+                savedTick && h("span", { className: "mneme-saved" }, t("memory.explorer.detail.saved")),
+                saveError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)" } }, t("memory.explorer.detail.archiveFailed"))
+              )
+            : h(react.Fragment, null,
+                h("button", { type: "button", className: "mneme-btn", onClick: () => setEditing(true) }, t("memory.explorer.detail.edit")),
+                h("button", { type: "button", className: "mneme-btn", disabled: busy, onClick: () => postUpdate({ archived: true }, { archived: true }) },
+                  t("memory.explorer.detail.archive")),
+                h("button", {
+                  type: "button",
+                  className: "mneme-btn",
+                  onClick: () => {
+                    navigator.clipboard?.writeText(memory.content || "").then(
+                      () => { setCopied(true); setTimeout(() => setCopied(false), 1500); },
+                      () => {}
+                    );
+                  }
+                }, copied ? t("memory.explorer.copied") : t("memory.explorer.copy")),
+                confirmDelete
+                  ? h(react.Fragment, null,
+                      h("button", { type: "button", className: "mneme-btn mneme-btndangerconfirm", disabled: deleting, onClick: () => onDelete(memory.id) },
+                        t("memory.explorer.confirmDelete")),
+                      h("button", { type: "button", className: "mneme-btn", onClick: () => setConfirmDelete(false) },
+                        t("memory.explorer.cancel"))
+                    )
+                  : h("button", { type: "button", className: "mneme-btn mneme-btndanger", onClick: () => setConfirmDelete(true) },
+                      t("memory.explorer.delete")),
+                deleteError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)" } },
+                  t("memory.explorer.deleteFailed"))
+              )
         )
       );
     }
 
+    // --- 导入弹层 ---
+    // 选类型 → 选文件 → 解析合并。文件在本地读成文本，POST /import 只传
+    // 文本与类型；成功后提示合并条数，并由父级刷新列表。
+    function ImportDialog({ t, onClose, onImported }) {
+      const [type, setType] = useState("preference");
+      const [file, setFile] = useState(null);
+      const [busy, setBusy] = useState(false);
+      const [msg, setMsg] = useState("");
+      const [err, setErr] = useState("");
+      const fileRef = useRef(null);
+      const submit = () => {
+        if (!file) { setErr(t("memory.explorer.importNoFile")); return; }
+        setBusy(true);
+        setErr("");
+        file.text()
+          .then((text) => apiFetch("/api/dsh-mneme/import", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ type, markdown: text })
+          }))
+          .then((res) => { if (!res.ok) throw new Error("http"); return res.json(); })
+          .then((d) => {
+            setMsg(t("memory.explorer.imported").replace("{n}", String((d && d.merged) ?? 0)));
+            setBusy(false);
+            setTimeout(() => { onImported(); onClose(); }, 900);
+          })
+          .catch(() => { setBusy(false); setErr(t("memory.explorer.importFailed")); });
+      };
+      return h("div", { className: "mneme-impdialog", role: "region", "aria-label": t("memory.explorer.importTitle") },
+        h("div", { className: "mneme-set-title" }, t("memory.explorer.importTitle")),
+        h("div", { className: "mneme-featsubhint", style: { marginTop: 4 } }, t("memory.explorer.importHint")),
+        h("div", { className: "mneme-improw" },
+          h("span", { className: "mneme-featnumlabel" }, t("memory.explorer.importType")),
+          h("select", { className: "mneme-select", value: type, onChange: (e) => setType(e.target.value) },
+            ["preference", "project", "decision", "summary", "history"].map((k) =>
+              h("option", { key: k, value: k }, typeLabel(t, k))))
+        ),
+        h("div", { className: "mneme-improw" },
+          h("button", { type: "button", className: "mneme-btn", onClick: () => fileRef.current?.click() },
+            file ? file.name : t("memory.explorer.importPick")),
+          h("input", {
+            ref: fileRef,
+            type: "file",
+            accept: ".md,.markdown,text/markdown",
+            style: { display: "none" },
+            onChange: (e) => { setFile((e.target.files && e.target.files[0]) || null); setErr(""); }
+          })
+        ),
+        err && h("div", { className: "mneme-featsubhint", style: { color: "var(--dsw-alias-state-error,#c33)", marginTop: 8 } }, err),
+        msg && h("div", { className: "mneme-saved", style: { marginTop: 8 } }, msg),
+        h("div", { className: "mneme-improw", style: { justifyContent: "flex-end" } },
+          h("button", { type: "button", className: "mneme-btn", disabled: busy, onClick: onClose }, t("memory.explorer.importCancel")),
+          h("button", { type: "button", className: "mneme-btn", disabled: busy, onClick: submit },
+            busy ? t("memory.explorer.importing") : t("memory.explorer.importConfirm"))
+        )
+      );
+    }
 
     function MemoryExplorer({ t }) {
       const [view, setView] = useState("memory"); // memory | entity | status | settings
@@ -1817,15 +2712,28 @@ window.__ModuleLoader__.load({
       const [selectedId, setSelectedId] = useState(null);
       const [expandedMonths, setExpandedMonths] = useState(null); // null = 仅最新一个月展开
       const [collapsed, setCollapsed] = useState({});
-      const [copied, setCopied] = useState(false);
       const [reloadKey, setReloadKey] = useState(0);
-      const [confirmDelete, setConfirmDelete] = useState(false); // two-step delete armed
       const [deleting, setDeleting] = useState(false);
       const [deleteError, setDeleteError] = useState(false);
-      const [deleteMsg, setDeleteMsg] = useState(false); // transient "deleted" notice
+      const [toastMsg, setToastMsg] = useState(""); // 瞬时操作提示（删除/归档），挂在外层不被抽屉卸载吞掉
       const [graphFocus, setGraphFocus] = useState("");
+      // 交互式面板新增：浏览模式（卡片/时间线，本地记住）、时间筛选、
+      // 冲突冻结指示、更多操作菜单与导入弹层。
+      const [viewMode, setViewMode] = useState(() => {
+        try { return window.localStorage.getItem("dsh-mneme-view") === "cards" ? "cards" : "timeline"; }
+        catch { return "timeline"; }
+      });
+      const [dateRange, setDateRange] = useState("all"); // all | 7d | 30d | 90d
+      const [pendingIds, setPendingIds] = useState(() => new Set());
+      const [menuOpen, setMenuOpen] = useState(false);
+      const [importOpen, setImportOpen] = useState(false);
       const itemRefs = useRef(new Map());
       const moreRef = useRef(null);
+
+      const switchViewMode = (mode) => {
+        setViewMode(mode);
+        try { window.localStorage.setItem("dsh-mneme-view", mode); } catch { /* 隐私模式等 */ }
+      };
 
       useEffect(() => {
         apiFetch("/api/dsh-mneme/vector-config")
@@ -1834,11 +2742,27 @@ window.__ModuleLoader__.load({
           .catch(() => {});
       }, []);
 
+      // 冲突冻结指示：dream-status 一次带出待确认冲突涉及的记忆 id，
+      // 卡片与详情抽屉据此画「冲突」徽章。
+      useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/dream-status")
+          .then((res) => (res.ok ? res.json() : { pendingMemoryIds: [] }))
+          .then((d) => { if (!cancelled) setPendingIds(new Set(d.pendingMemoryIds || [])); })
+          .catch(() => {});
+        return () => { cancelled = true; };
+      }, [reloadKey]);
+
       // One query string behind every browse-list fetch (initial page,
-      // loadMore, auto-refresh): the type filter and the importance floor
-      // always travel together, so counts and pagination stay consistent.
+      // loadMore, auto-refresh): the type filter, importance floor and time
+      // window always travel together, so counts and pagination stay
+      // consistent.
+      const dateFromIso = dateRange === "all" ? "" : new Date(
+        Date.now() - (dateRange === "7d" ? 7 : dateRange === "30d" ? 30 : 90) * 86400000
+      ).toISOString();
       const filterQS = (type === "all" ? "" : `&type=${encodeURIComponent(type)}`)
-        + (minImp ? `&minImportance=${minImp}` : "");
+        + (minImp ? `&minImportance=${minImp}` : "")
+        + (dateFromIso ? `&updatedFrom=${encodeURIComponent(dateFromIso)}` : "");
       const listUrl = (offset) => `/api/dsh-mneme/list?limit=${PAGE_SIZE}&offset=${offset}${filterQS}&order=chrono`;
 
       // Browse = paged, pure-chronological pages (order=chrono). The default
@@ -1935,10 +2859,10 @@ window.__ModuleLoader__.load({
         itemRefs.current.get(selectedId)?.scrollIntoView({ block: "nearest" });
       }, [selectedId]);
 
-      // The two-step delete arms per selection: switching or clearing the
-      // target disarms it, so a stale confirm can never delete a new pick.
+      // The two-step delete arms inside the drawer per selection: switching
+      // or clearing the target disarms it, so a stale confirm can never
+      // delete a new pick.
       useEffect(() => {
-        setConfirmDelete(false);
         setDeleteError(false);
       }, [selectedId]);
 
@@ -1993,22 +2917,12 @@ window.__ModuleLoader__.load({
 
       const selected = visible.find((m) => m.id === selectedId) || null;
 
-      const copyContent = () => {
-        if (!selected) return;
-        navigator.clipboard?.writeText(selected.content || "").then(
-          () => { setCopied(true); setTimeout(() => setCopied(false), 1500); },
-          () => {}
-        );
-      };
-
-      // Two-step delete (no window.confirm): the red button arms, a second
-      // click commits POST /api/dsh-mneme/delete. On success the row leaves
-      // every local view (browse pages + search results), the selection
-      // clears and the total shrinks; failures — 404 included — surface as
-      // a transient red note next to the actions.
-      const deleteSelected = () => {
-        if (!selected || deleting) return;
-        const id = selected.id;
+      // Delete / archive / edit commit through POST endpoints; on success the
+      // row leaves or updates in every local view (browse pages + search
+      // results). Failures — 404 included — surface as a transient red note
+      // in the drawer's action bar.
+      const deleteById = (id) => {
+        if (!id || deleting) return;
         setDeleting(true);
         setDeleteError(false);
         apiFetch("/api/dsh-mneme/delete", {
@@ -2022,15 +2936,52 @@ window.__ModuleLoader__.load({
             setRemoteItems((cur) => (cur ? cur.filter((m) => m.id !== id) : cur));
             setTotal((n) => Math.max(0, n - 1));
             setSelectedId(null);
-            setConfirmDelete(false);
-            setDeleteMsg(true);
-            setTimeout(() => setDeleteMsg(false), 2500);
+            setToastMsg(t("memory.explorer.deleted"));
+            setTimeout(() => setToastMsg(""), 2500);
           })
           .catch(() => {
             setDeleteError(true);
             setTimeout(() => setDeleteError(false), 4000);
           })
           .finally(() => setDeleting(false));
+      };
+
+      // 编辑保存 / 归档的本地落账：替换或移除对应行；镜像由后端重渲染。
+      // 归档从所有视图移除（列表默认只看未归档），并清空选中。
+      const applyMemoryUpdate = (updated, { archived = false } = {}) => {
+        if (archived) {
+          setItems((cur) => cur.filter((m) => m.id !== updated.id));
+          setRemoteItems((cur) => (cur ? cur.filter((m) => m.id !== updated.id) : cur));
+          setTotal((n) => Math.max(0, n - 1));
+          setSelectedId(null);
+          setToastMsg(t("memory.explorer.detail.archived"));
+          setTimeout(() => setToastMsg(""), 2500);
+          return;
+        }
+        const replace = (m) => (m.id === updated.id ? updated : m);
+        setItems((cur) => cur.map(replace));
+        setRemoteItems((cur) => (cur ? cur.map(replace) : cur));
+      };
+
+      // 导出：JSON 走响应对象重序列化（缩进美化），Markdown 原样落盘；
+      // 文件名带日期，浏览器下载不动主列表。
+      const exportData = (format) => {
+        apiFetch(`/api/dsh-mneme/export?format=${format}`)
+          .then(async (res) => {
+            if (!res.ok) throw new Error("http");
+            const blob = format === "json"
+              ? new Blob([JSON.stringify(await res.json(), null, 2)], { type: "application/json" })
+              : new Blob([await res.text()], { type: "text/markdown" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `dsh-mneme-export-${new Date().toISOString().slice(0, 10)}.${format === "json" ? "json" : "md"}`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+          })
+          .catch(() => {});
       };
 
       // Graph → memory jump: land on the browser tab with filters reset so
@@ -2074,7 +3025,45 @@ window.__ModuleLoader__.load({
                 s.label
               ))
           ),
+          view === "memory" && h("div", { className: "mneme-xtools" },
+            h("div", { className: "mneme-seg", role: "group", "aria-label": t("memory.explorer.viewAria") },
+              h("button", {
+                type: "button",
+                className: viewMode === "cards" ? "mneme-active" : "",
+                onClick: () => switchViewMode("cards")
+              }, t("memory.explorer.viewCards")),
+              h("button", {
+                type: "button",
+                className: viewMode === "timeline" ? "mneme-active" : "",
+                onClick: () => switchViewMode("timeline")
+              }, t("memory.explorer.viewTimeline"))
+            ),
+            h("div", { className: "mneme-menuwrap" },
+              h("button", {
+                type: "button",
+                className: "mneme-footbtn",
+                style: { fontSize: 15, padding: "3px 9px" },
+                "aria-label": t("memory.explorer.more"),
+                "aria-expanded": String(menuOpen),
+                title: t("memory.explorer.more"),
+                onClick: () => { setMenuOpen(!menuOpen); setImportOpen(false); }
+              }, "⋯"),
+              menuOpen && h("div", { className: "mneme-menu", role: "menu" },
+                h("button", { type: "button", role: "menuitem", onClick: () => { setMenuOpen(false); exportData("json"); } },
+                  t("memory.explorer.exportJson")),
+                h("button", { type: "button", role: "menuitem", onClick: () => { setMenuOpen(false); exportData("markdown"); } },
+                  t("memory.explorer.exportMarkdown")),
+                h("button", { type: "button", role: "menuitem", onClick: () => { setImportOpen(true); setMenuOpen(false); } },
+                  t("memory.explorer.importMd"))
+              ),
+              importOpen && h(ImportDialog, {
+                t,
+                onClose: () => setImportOpen(false),
+                onImported: () => setReloadKey((k) => k + 1)
+              })
+            )
           ),
+        ),
         view === "memory" && h("div", { className: "mneme-xmain" },
           h("div", { className: "mneme-xside" },
             h("div", { className: "mneme-xcolhead" }, t("memory.explorer.searchTitle")),
@@ -2104,6 +3093,17 @@ window.__ModuleLoader__.load({
                 onChange: (e) => setSearchTopK(Number(e.target.value)),
                 title: t("memory.explorer.topK")
               }, [5, 10, 20, 50].map((n) => h("option", { key: n, value: n }, t("memory.explorer.topKOption").replace("{n}", String(n)))))
+            ),
+            h("div", { className: "mneme-xrow" },
+              h("select", {
+                className: "mneme-select mneme-xselect",
+                value: dateRange,
+                onChange: (e) => setDateRange(e.target.value),
+                title: t("memory.explorer.dateLabel"),
+                "aria-label": t("memory.explorer.dateLabel")
+              },
+                ["all", "7d", "30d", "90d"].map((k) =>
+                  h("option", { key: k, value: k }, t(`memory.explorer.date.${k}`))))
             ),
             h("div", { className: "mneme-xrow" },
               h("span", { className: "mneme-xcount" }, t("memory.explorer.count").replace("{n}", String(visible.length))),
@@ -2137,7 +3137,42 @@ window.__ModuleLoader__.load({
                 h("span", { className: "mneme-xcount2" }, String(counts[key]))
               ))
           ),
-          h("div", { className: "mneme-xbrowse" },
+          viewMode === "cards"
+            ? h("div", { className: "mneme-cards" },
+                loading
+                  ? h("div", { className: "mneme-xempty", style: { gridColumn: "1 / -1" } }, "…")
+                  : visible.length === 0
+                    ? h("div", { className: "mneme-xempty", style: { gridColumn: "1 / -1" } },
+                        h(Icon, { name: "inbox", size: 20, className: "mneme-xemptyico" }),
+                        t("memory.explorer.empty"))
+                    : sorted.map((m) => h("button", {
+                        key: m.id,
+                        type: "button",
+                        className: m.id === selectedId ? "mneme-card mneme-active" : "mneme-card",
+                        onClick: () => setSelectedId(m.id)
+                      },
+                        h("div", { className: "mneme-cardhead" },
+                          h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(m.type) }, title: typeLabel(t, m.type), "aria-hidden": "true" }),
+                          h("span", null, typeLabel(t, m.type)),
+                          h("span", { style: { marginLeft: "auto", fontVariantNumeric: "tabular-nums" } }, formatRelativeTime(m.updated_at || m.created_at, t))
+                        ),
+                        pendingIds.has(m.id) && h("span", { className: "mneme-badge mneme-badge--conflict", style: { alignSelf: "flex-start" } }, "⚠ ", t("memory.explorer.conflictBadge")),
+                        h("div", { className: "mneme-cardtitle" }, m.title || (m.content || "").slice(0, 60)),
+                        h("div", { className: "mneme-cardexcerpt" }, m.content || ""),
+                        h("div", { className: "mneme-cardfoot" },
+                          h("span", null, "★".repeat(Math.min(5, Math.max(0, m.importance || 0)))),
+                          m.source && h("span", { className: "mneme-cardsrc", title: m.source }, m.source)
+                        )
+                      )),
+                h("div", { ref: moreRef, className: "mneme-xmore", style: { gridColumn: "1 / -1" } },
+                  canLoadMore
+                    ? h("button", { className: "mneme-footbtn", disabled: loadingMore, onClick: loadMore },
+                        loadingMore ? "…" : `${t("memory.explorer.loadMore")}（${items.length}/${total}）`)
+                    : (!loading && visible.length > 0 && !q && !remoteItems
+                        ? h("span", { className: "mneme-xcount" }, `${items.length} / ${total}`)
+                        : null))
+              )
+            : h("div", { className: "mneme-xbrowse" },
             h("div", { className: "mneme-xtree" },
               h("div", { className: "mneme-xcolhead" }, t("memory.explorer.timeline")),
               loading
@@ -2202,94 +3237,106 @@ window.__ModuleLoader__.load({
                       : null)
               )
             ),
-            h("div", { className: "mneme-xdetail" },
-              selected
-                ? h(react.Fragment, { key: selected.id },
-                    h("div", { className: "mneme-xdinner" },
-                      h("div", { className: "mneme-xdtitle" }, selected.title),
-                      h("div", { className: "mneme-xdmeta" },
-                        h("span", { style: { display: "inline-flex", alignItems: "center", gap: "6px" } },
-                          h("span", { className: "mneme-xdot", style: { color: memoryTypeColor(selected.type) }, "aria-hidden": "true" }),
-                          `${typeLabel(t, selected.type)} · ${t("memory.explorer.importance")} ★${selected.importance}`
-                        ),
-                        selected.source && h("span", { title: selected.source },
-                          `${t("memory.explorer.source")}: `,
-                          h("span", { className: "mneme-xdsrc" }, selected.source)),
-                        h("span", { title: formatDate(selected.created_at) }, `${t("memory.explorer.created")}: ${formatDateShort(selected.created_at)}`),
-                        h("span", { title: formatDate(selected.updated_at) }, `${t("memory.explorer.updated")}: ${formatRelativeTime(selected.updated_at, t)}`)
-                      ),
-                      Array.isArray(selected.tags) && selected.tags.length > 0 && h("div", { className: "mneme-xdmeta" },
-                        h("span", null, `${t("memory.explorer.tags")}: ${selected.tags.join(" · ")}`)
-                      ),
-                      h("div", { className: "mneme-xdcontent" }, selected.content),
-                      h("div", { className: "mneme-xdactions" },
-                        h("button", { className: "mneme-footbtn", onClick: copyContent },
-                          h(Icon, { name: copied ? "check" : "copy", size: 12 }),
-                          copied ? t("memory.explorer.copied") : t("memory.explorer.copy")),
-                        // two-step delete: red outline arms, solid red commits
-                        confirmDelete
-                          ? h(react.Fragment, null,
-                              h("button", {
-                                className: "mneme-btn mneme-btndangerconfirm",
-                                disabled: deleting,
-                                onClick: deleteSelected
-                              }, t("memory.explorer.confirmDelete")),
-                              h("button", {
-                                className: "mneme-btn",
-                                onClick: () => setConfirmDelete(false)
-                              }, t("memory.explorer.cancel"))
-                            )
-                          : h("button", {
-                              className: "mneme-btn mneme-btndanger",
-                              onClick: () => setConfirmDelete(true)
-                            }, t("memory.explorer.delete")),
-                        deleteError && h("span", { style: { fontSize: 12, color: "var(--dsw-alias-state-error,#c33)" } },
-                          t("memory.explorer.deleteFailed"))
-                      )
-                    )
-                  )
-                : h("div", { className: "mneme-xempty" },
-                    deleteMsg && h("div", { className: "mneme-saved", style: { marginBottom: 6 } }, t("memory.explorer.deleted")),
-                    t("memory.explorer.emptyDetail"))
-            )
-          )
+            ),
+      // 详情抽屉：卡片/时间线共用，选中即从右侧滑出（替代旧底部面板）。
+      // 两步删除确认在抽屉内完成；编辑/归档经 /update 落库并同步本地视图。
+      selected && h(MemoryDrawer, {
+        key: selected.id,
+        t,
+        memory: selected,
+        conflict: pendingIds.has(selected.id),
+        deleting,
+        deleteError,
+        onClose: () => setSelectedId(null),
+        onDelete: deleteById,
+        onSaved: applyMemoryUpdate
+      })
         ),
         view === "entity" && h(EntityPanel, { t, focusEntity: graphFocus, onJumpMemory: jumpToMemory }),
         view === "status" && h(StatusPanel, { t }),
         view === "settings" && h("div", { className: "mneme-set" },
           h("div", { className: "mneme-set-inner" }, h(SettingsContent, { t }))
-        )
+        ),
+        toastMsg && h("div", { className: "mneme-toast", role: "status" }, toastMsg)
       );
     }
 
-    // --- Sidebar foot entry: the wide row / rail icon that activates the
-    // main-area memory library tab. When the tab ring is absent (new-chat
-    // hero screen hides the conversation header entirely) the same click
-    // opens the full-viewport overlay instead — the library stays reachable
-    // from every conversation state.
-    function SidebarTrigger({ wide, t }) {
-      const [, setOpen] = useOverlayOpen();
+    // --- Sidebar entry: 工作区上方的记忆按钮 ---
+    // 注册仍在 sidebar.footer.action（list 插槽）——它既是 React 树的挂载
+    // 锚点，也是 portal 失效时的原位回退。真实按钮 portal 插到 regionArea
+    // （工作区列表容器）之前，即「新会话」按钮下方、工作区上方。
+    // 几何对齐方案：读取宿主「新会话」按钮的实时 className 原样套用，再用
+    // 我们的修饰类覆盖配色（次级观感）。这样展开态与收起态（rail）都直接
+    // 继承宿主自己的盒模型与间距——宿主改版/缩进动画零位移，无需硬编码。
+    // 宿主结构异常时约 2 秒后放弃 portal，footer 回退按钮保持可用。
+    function SidebarFallbackTrigger({ wide, t }) {
       return h("button", {
         type: "button",
         className: wide ? "mneme-trigger" : "mneme-trigger mneme-rail",
         "aria-label": t("memory.sidebar.aria"),
-        title: t("memory.sidebar.aria"),
-        onClick: () => {
-          activateExplorerTab(t("memory.view.label")).then((ok) => { if (!ok) setOpen(true); });
-        }
+        title: t("memory.panel.open"),
+        onClick: openLibrary
       },
         h(IconArchiveOutline20, { size: wide ? 16 : 18 }),
         wide && h("span", { className: "mneme-trigger-label" }, t("memory.panel.open"))
       );
     }
 
+    function SidebarTopEntry({ wide, t, fallback }) {
+      const [host, setHost] = useState(null);
+      const [nativeCls, setNativeCls] = useState("");
+      useEffect(() => {
+        if (!reactDom || typeof document === "undefined") return undefined;
+        let tries = 0, timer = null, created = null;
+        const attempt = () => {
+          const region = document.querySelector('[class*="regionArea"]');
+          if (region && region.parentElement) {
+            // 「新会话」按钮与 regionArea 同级且紧邻其前，借它的类名获得
+            // 与原生侧边栏项完全一致的盒模型（含收起态 rail 几何）。
+            const ns = region.parentElement.querySelector('[class*="newSession"]')
+              || region.previousElementSibling;
+            created = document.createElement("div");
+            created.dataset.pluginEntry = "@modusensus/dsh-mneme";
+            region.parentElement.insertBefore(created, region);
+            setHost(created);
+            setNativeCls(ns?.className || "");
+            return;
+          }
+          if (++tries > 40) return; // 放弃 portal，footer 回退保持可用
+          timer = setTimeout(attempt, 50);
+        };
+        attempt();
+        return () => {
+          clearTimeout(timer);
+          if (created && created.parentElement) created.parentElement.removeChild(created);
+        };
+      }, []);
+      if (!host) return fallback;
+      // wrapper 用 display:contents 隐身：我们的按钮成为侧边栏弹性布局的
+      // 直接子元素，与「新会话」按钮同级同距；展开/收起只切换图标与文案。
+      return reactDom.createPortal(
+        h("div", { className: "mneme-topentry", style: { display: "contents" } },
+          h("button", {
+            type: "button",
+            className: `${nativeCls} mneme-topentry-native`.trim(),
+            "aria-label": t("memory.sidebar.aria"),
+            title: t("memory.panel.open"),
+            onClick: openLibrary
+          },
+            h(IconArchiveOutline20, { size: wide ? 15 : 18 }),
+            wide && h("span", { className: "mneme-topentry-label" }, t("memory.panel.open"))
+          )
+        ), host);
+    }
+
     function apply(ctx) {
       ctx.effect(() => ctx.locale.register(NS, dictionaries), "dsh-mneme: dictionaries");
 
-      // Register the memory entry beside Settings at the sidebar foot. The
-      // entry renders a wide row (icon + label) when the sidebar is expanded
-      // and a rail icon when collapsed; clicking activates the memory
-      // library conversation view.
+      // 记忆库唯一入口：sidebar.footer.action 注册作为锚点与回退；真实按钮
+      // 由 SidebarTopEntry portal 到侧边栏工作区上方。overlay 从这个常驻
+      // 插槽挂载（portal 到 body），会话切换不影响它的开关状态。
+      // v0.7.15 起不再注册 conversation.view tab——对话内嵌的面板被悬浮
+      // 输入框遮挡、挤压会话布局，sheet 页是更舒服的承载方式。
       ctx.slots.inject("sidebar.footer.action", () => {
         const t = ctx.locale.bind(NS);
         return ctx.slots.register({
@@ -2298,26 +3345,13 @@ window.__ModuleLoader__.load({
           order: 0,
           label: () => t("memory.panel.open")
         }, (props) => h(react.Fragment, null,
-          h(SidebarTrigger, { ...props, t }),
-          // The overlay mounts from the always-rendered sidebar slot so it
-          // survives conversation switches; the portal moves it to <body>.
+          h(SidebarTopEntry, {
+            wide: !!(props && props.wide),
+            t,
+            fallback: h(SidebarFallbackTrigger, { wide: !!(props && props.wide), t })
+          }),
           h(MemoryOverlay, { t })
         ));
-      });
-
-      // Register the memory library as a conversation view tab, beside
-      // Chat / Trajectory. The view ignores its session props: the library
-      // reads the memory store over HTTP. It hosts every memory feature —
-      // browse, graph and settings — in the main content area.
-      ctx.slots.inject("conversation.view", () => {
-        const t = ctx.locale.bind(NS);
-        return ctx.slots.register({
-          name: "conversation.view",
-          id: "dsh-mneme-memory",
-          order: 30,
-          locale: NS,
-          label: () => t("memory.view.label")
-        }, () => h(MemoryExplorer, { t }));
       });
     }
 

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -66,7 +66,30 @@ export const apply = (ctx, config) => {
   // semantic feature off and keeps the core loop (autoInject, autoSummarize,
   // hot memory, quality filter).
   const lightMode = rawCfg.lightMode === true || settings.getPanelMode() === "light";
-  const cfg = applyLightModePreset({ ...rawCfg, lightMode });
+  // 功能开关合并顺序即优先级：用户显式开关（feature_flags kv，面板写入）>
+  // 轻量预设（applyLightModePreset 批量置关的重型能力）> bundle 配置。预设必须
+  // 先应用、用户开关后展开，否则 LIGHT_MODE_OFF 会把用户显式打开的开关再次
+  // 压掉。合并结果只作用于本次启动：面板改开关后与 panel_mode 一样在下次
+  // 启动生效。
+  // 嵌套对象开关按首个点号拆开（kv 里平铺存的 "memoryQualityFilter.enabled" →
+  // cfg.memoryQualityFilter.enabled），点号键不原样留在 cfg 顶层属性里。
+  const flags = settings.getFeatureFlags();
+  const flatFlags = {};
+  const nestedFlags = {};
+  for (const [key, value] of Object.entries(flags)) {
+    const dot = key.indexOf(".");
+    if (dot > 0) {
+      const objKey = key.slice(0, dot);
+      const subKey = key.slice(dot + 1);
+      nestedFlags[objKey] = { ...(nestedFlags[objKey] ?? {}), [subKey]: value };
+    } else {
+      flatFlags[key] = value;
+    }
+  }
+  const cfg = { ...applyLightModePreset({ ...rawCfg, lightMode }), ...flatFlags };
+  for (const [objKey, sub] of Object.entries(nestedFlags)) {
+    cfg[objKey] = { ...(cfg[objKey] ?? {}), ...sub };
+  }
 
   const mirror = createMirror(memoryDir);
   const service = createService({ store, mirror, config: cfg, logger: ctx.logger });
@@ -340,7 +363,7 @@ export const apply = (ctx, config) => {
       add: () => { throw new Error("commands unavailable"); },
       remove: () => false,
       list: () => []
-    }, embedder, { vectorIndex, reranker }, cfg.apiToken);
+    }, embedder, { vectorIndex, reranker }, cfg.apiToken, cfg);
     disposers.push(api.dispose);
   }
 

--- a/dsh-mneme/lib/mirror.js
+++ b/dsh-mneme/lib/mirror.js
@@ -47,6 +47,92 @@ function renderMemory(m) {
   return lines.join("\n");
 }
 
+/**
+ * Render one type's memories into exactly the mirror-file text (header +
+ * per-memory blocks, updated_at DESC like sync). sync() writes this to disk;
+ * the /export endpoint returns the same text, so an exported markdown is
+ * byte-compatible with a mirror file and can be fed straight back through
+ * parseHumanEdits → mergeHumanEdits. Unknown type → undefined.
+ */
+export function renderMirrorText(type, memories) {
+  const name = TYPE_FILE[type];
+  if (!name) return undefined;
+  const items = (memories ?? [])
+    .slice()
+    .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+  const header = `# ${name} — dsh-mneme 镜像\n\n<!-- 手工编辑此文件会被合并回记忆库（人工优先）。 -->\n\n`;
+  const body = items.map(renderMemory).join("\n");
+  return header + body;
+}
+
+/**
+ * Parse mirror text back into {id, title, content} entries for human edits.
+ * Pure text-in/edits-out core: readHumanEdits feeds it mirror file contents
+ * and the /import endpoint feeds it user-pasted markdown, so both paths share
+ * one parsing implementation (行为一致是硬约束——import 必须能吃回 export 与
+ * 磁盘镜像)。Entries are anchored on "- **ID**: `...`" lines that are followed
+ * by the "- **类型**:" metadata line (structural entry head): each entry's
+ * block spans from its ID line up to the next ID line (or end of text). The
+ * block head (the ID line plus the generated metadata run) and the trailing
+ * structural "---" separator are stripped; everything in between is the entry
+ * body, so user content containing "---", metadata-like lines, or even a
+ * machine-format "- **ID**: `x`" line is preserved. The title is the "## "
+ * heading preceding the ID line.
+ */
+export function parseHumanEdits(text) {
+  // CRLF 归一化（readHumanEdits 原有的读取侧处理移入纯函数，Windows 手工编辑
+  // 的文件与导入文本都能正确解析）。
+  const normalized = String(text ?? "").replace(/\r\n/g, "\n");
+  const edits = [];
+  // Anchor on the ID line only when it is a structural entry head: the
+  // machine-rendered ID line is always followed by the "- **类型**:" line.
+  // A body line like "- **ID**: `x`" is not, so it never splits the block
+  // or produces a ghost entry.
+  const anchors = [...normalized.matchAll(/^- \*\*ID\*\*: `([^`]+)`\n- \*\*类型\*\*:/gm)];
+  let prevEnd = 0;
+  for (let i = 0; i < anchors.length; i++) {
+    const anchor = anchors[i];
+    const blockStart = anchor.index;
+    const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : normalized.length;
+
+    // Title: last "## " heading before this ID line (file header region /
+    // previous block tail). Body headings of earlier entries come before
+    // the structural "---" + "## " of this entry, so the last match wins.
+    const titleMatches = [...normalized.slice(prevEnd, blockStart).matchAll(/^## (.+)$/gm)];
+    const titleMatch = titleMatches[titleMatches.length - 1];
+
+    // Body: the ID line and the generated metadata run are structural head;
+    // everything after them up to the trailing "---" separator is the body.
+    let body = normalized
+      .slice(blockStart, blockEnd)
+      .replace(/^- \*\*ID\*\*: `[^`]+`\n?/, "")
+      .replace(/^(- \*\*(类型|重要性|标签|更新时间|来源)\*\*:.*\n?)+/, "")
+      .replace(/^<!-- mirror-digest: [a-f0-9]+ -->\n?/m, "");
+    const separators = [...body.matchAll(/^---\s*$/gm)];
+    const lastSep = separators[separators.length - 1];
+    if (lastSep) body = body.slice(0, lastSep.index);
+    body = body.trim();
+
+    // The machine-written "更新时间" line records the store's updated_at at
+    // render time — the version token for detecting a concurrent store write
+    // during a three-way merge of human edits (see service.syncMirror).
+    const block = normalized.slice(blockStart, blockEnd);
+    const updatedMatch = block.match(/- \*\*更新时间\*\*: ([^\n]+)/);
+    const digestMatch = block.match(/<!-- mirror-digest: ([a-f0-9]+) -->/);
+    edits.push({
+      id: anchor[1],
+      title: titleMatch ? unescape(titleMatch[1]).trim() : undefined,
+      content: body,
+      updated_at: updatedMatch ? updatedMatch[1].trim() : undefined,
+      digest: digestMatch ? digestMatch[1] : undefined
+    });
+
+    const lineEnd = normalized.indexOf("\n", blockStart);
+    prevEnd = lineEnd === -1 ? normalized.length : lineEnd + 1;
+  }
+  return edits;
+}
+
 export function createMirror(dir) {
   mkdirSync(dir, { recursive: true });
 
@@ -56,15 +142,9 @@ export function createMirror(dir) {
   }
 
   /**
-   * Parse a mirror file back into {id, title, content} entries for human edits.
-   * Entries are anchored on "- **ID**: `...`" lines that are followed by the
-   * "- **类型**:" metadata line (structural entry head): each entry's block
-   * spans from its ID line up to the next ID line (or end of file). The block
-   * head (the ID line plus the generated metadata run) and the trailing
-   * structural "---" separator are stripped; everything in between is the entry
-   * body, so user content containing "---", metadata-like lines, or even a
-   * machine-format "- **ID**: `x`" line is preserved. The title is the "## "
-   * heading preceding the ID line.
+   * Read the mirror files and parse them back into human edits. The pure
+   * parsing logic lives in the exported parseHumanEdits (shared with /import);
+   * this wrapper only owns the "read file → text" side.
    */
   function readHumanEdits(type = undefined) {
     const types = type ? [type] : Object.keys(TYPE_FILE);
@@ -72,53 +152,7 @@ export function createMirror(dir) {
     for (const t of types) {
       const file = filePath(t);
       if (!file || !existsSync(file)) continue;
-      const text = readFileSync(file, "utf8").replace(/\r\n/g, "\n");
-      // Anchor on the ID line only when it is a structural entry head: the
-      // machine-rendered ID line is always followed by the "- **类型**:" line.
-      // A body line like "- **ID**: `x`" is not, so it never splits the block
-      // or produces a ghost entry.
-      const anchors = [...text.matchAll(/^- \*\*ID\*\*: `([^`]+)`\n- \*\*类型\*\*:/gm)];
-      let prevEnd = 0;
-      for (let i = 0; i < anchors.length; i++) {
-        const anchor = anchors[i];
-        const blockStart = anchor.index;
-        const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : text.length;
-
-        // Title: last "## " heading before this ID line (file header region /
-        // previous block tail). Body headings of earlier entries come before
-        // the structural "---" + "## " of this entry, so the last match wins.
-        const titleMatches = [...text.slice(prevEnd, blockStart).matchAll(/^## (.+)$/gm)];
-        const titleMatch = titleMatches[titleMatches.length - 1];
-
-        // Body: the ID line and the generated metadata run are structural head;
-        // everything after them up to the trailing "---" separator is the body.
-        let body = text
-          .slice(blockStart, blockEnd)
-          .replace(/^- \*\*ID\*\*: `[^`]+`\n?/, "")
-          .replace(/^(- \*\*(类型|重要性|标签|更新时间|来源)\*\*:.*\n?)+/, "")
-          .replace(/^<!-- mirror-digest: [a-f0-9]+ -->\n?/m, "");
-        const separators = [...body.matchAll(/^---\s*$/gm)];
-        const lastSep = separators[separators.length - 1];
-        if (lastSep) body = body.slice(0, lastSep.index);
-        body = body.trim();
-
-        // The machine-written "更新时间" line records the store's updated_at at
-        // render time — the version token for detecting a concurrent store write
-        // during a three-way merge of human edits (see service.syncMirror).
-        const block = text.slice(blockStart, blockEnd);
-        const updatedMatch = block.match(/- \*\*更新时间\*\*: ([^\n]+)/);
-        const digestMatch = block.match(/<!-- mirror-digest: ([a-f0-9]+) -->/);
-        edits.push({
-          id: anchor[1],
-          title: titleMatch ? unescape(titleMatch[1]).trim() : undefined,
-          content: body,
-          updated_at: updatedMatch ? updatedMatch[1].trim() : undefined,
-          digest: digestMatch ? digestMatch[1] : undefined
-        });
-
-        const lineEnd = text.indexOf("\n", blockStart);
-        prevEnd = lineEnd === -1 ? text.length : lineEnd + 1;
-      }
+      edits.push(...parseHumanEdits(readFileSync(file, "utf8")));
     }
     return edits;
   }
@@ -145,9 +179,9 @@ export function createMirror(dir) {
           // memories do not "resurrect" via readHumanEdits
           rmSync(file, { force: true });
         } else {
-          const header = `# ${TYPE_FILE[type]} — dsh-mneme 镜像\n\n<!-- 手工编辑此文件会被合并回记忆库（人工优先）。 -->\n\n`;
-          const body = items.map(renderMemory).join("\n");
-          writeFileSync(file, header + body, "utf8");
+          // 渲染走 renderMirrorText（与 /export 共用同一条渲染路径），磁盘镜像
+          // 与导出文本永远同构。
+          writeFileSync(file, renderMirrorText(type, items), "utf8");
         }
         results[type] = { ok: true };
       } catch (error) {

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -1511,6 +1511,8 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     findEntityByName: (n) => store.findEntityByName(n),
     findEntityById: (id) => store.findEntityById(id),
     getAttrsByMemory: (id) => store.getAttrsByMemory(id),
+    // 记忆详情侧栏：一条记忆关联到的实体（entity_attrs.memory_id 反查，纯读）。
+    entitiesForMemory: (id) => store.entitiesForMemory(id),
     getCurrentAttrs: (id) => store.getCurrentAttrs(id),
     migrateAttrsToMemory: (fromId, toId, now) => store.migrateAttrsToMemory(fromId, toId, now)
   };

--- a/dsh-mneme/lib/settings.js
+++ b/dsh-mneme/lib/settings.js
@@ -31,6 +31,155 @@ function parseList(raw) {
   }
 }
 
+// --- feature flags（功能开关）白名单 -----------------------------------------
+// 面板可逐项开关的后端能力。设计约束：
+// 1. 键名与类型必须和 config.js schema 同名同型，这份白名单是唯一校验源
+//    （api.js 复用它计算 effective），schema 增删能力键时要同步改这里。
+// 2. 持久化（kv "feature_flags"）只落白名单键；读到未知键、类型损坏或越界的
+//    值一律丢弃而不是报错——kv 会残留旧版本写入的键，读路径必须向前兼容。
+// 3. 写入是逐键校验的合并写：未知键/类型/范围不符抛 TypeError（消息含键名，
+//    供 API 透传给前端定位），校验不通过不落库，坏值永远进不了 kv。
+const FEATURE_FLAG_BOOLEANS = [
+  "autoInject",
+  "autoSummarize",
+  "hotMemoryEnabled",
+  "entityExtractionEnabled",
+  "codingRetrospect",
+  "autoDream",
+  "sleepModeEnabled",
+  "hybridInject",
+  "selectiveInjectEnabled",
+  "searchSemanticDedup",
+  "rerankEnabled",
+  "adaptiveThresholdEnabled",
+  "reflectionUpdateEnabled",
+  "reflectionFailureTracking",
+  "bm25SearchEnabled",
+  "conflictFreezeEnabled",
+  "trustEpistemicWeighting",
+  // 嵌套对象开关：config.js 里是 memoryQualityFilter / llmAudit 对象的 enabled
+  // 子字段。kv 按点号键平铺存（"memoryQualityFilter.enabled": false），index.js
+  // 合并时展开回嵌套对象，api.js 的 effective 从对象子字段取值。
+  "memoryQualityFilter.enabled",
+  "llmAudit.enabled"
+];
+// 整数开关的闭区间，与 config.js 里 z.natural().min().max() 对齐。
+const FEATURE_FLAG_INT_RANGES = {
+  distillRateLimitIntervalMs: [0, 60000],
+  distillRateLimitRetries: [0, 10],
+  distillRateLimitBaseDelayMs: [100, 60000],
+  distillMaxChars: [1000, 200000],
+  codingBoostFactor: [1, 5]
+};
+// 自由字符串开关（与 config.js 的 z.string() 同名同型）：trim 后 ≤200 字符，
+// 空串合法（= 跟随主对话模型/默认路径，面板显示 placeholder）。
+const FEATURE_FLAG_STRINGS = [
+  "dreamProvider",
+  "dreamModel",
+  "localEmbedModel",
+  "ollamaModel"
+];
+// URL 字符串开关：trim 后必须为空或合法 http/https URL（new URL() 校验协议，
+// 拒绝其余协议——这是 SSRF 防线的一部分）。
+const FEATURE_FLAG_URLS = ["ollamaBaseUrl"];
+// 枚举开关（与 config.js 的 z.union(z.const(...)) 对齐）：仅允许列出的值。
+const FEATURE_FLAG_ENUMS = {
+  embedProvider: ["openai", "local", "ollama"]
+};
+const FEATURE_FLAG_STRING_MAX = 200;
+
+// 供 api.js 复用同一份白名单（effective 只在白名单键上计算）。
+export const FEATURE_FLAG_SPEC = {
+  booleans: FEATURE_FLAG_BOOLEANS,
+  ints: FEATURE_FLAG_INT_RANGES,
+  strings: FEATURE_FLAG_STRINGS,
+  urls: FEATURE_FLAG_URLS,
+  enums: FEATURE_FLAG_ENUMS
+};
+
+/** ollamaBaseUrl 的协议白名单：只接受 http/https（SSRF 防线的一部分）。 */
+function isHttpUrl(value) {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** 校验单个开关值；不合法抛 TypeError（消息含键名）。 */
+function validateFlag(key, value) {
+  if (FEATURE_FLAG_BOOLEANS.includes(key)) {
+    if (typeof value !== "boolean") {
+      throw new TypeError(`feature flag "${key}" must be a boolean`);
+    }
+    return value;
+  }
+  const range = FEATURE_FLAG_INT_RANGES[key];
+  if (range) {
+    const [min, max] = range;
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new TypeError(`feature flag "${key}" must be an integer in [${min}, ${max}]`);
+    }
+    return value;
+  }
+  if (FEATURE_FLAG_STRINGS.includes(key)) {
+    if (typeof value !== "string") {
+      throw new TypeError(`feature flag "${key}" must be a string`);
+    }
+    const trimmed = value.trim();
+    if (trimmed.length > FEATURE_FLAG_STRING_MAX) {
+      throw new TypeError(`feature flag "${key}" must be at most ${FEATURE_FLAG_STRING_MAX} characters`);
+    }
+    return trimmed; // 空串合法 = 跟随默认
+  }
+  if (FEATURE_FLAG_URLS.includes(key)) {
+    if (typeof value !== "string") {
+      throw new TypeError(`feature flag "${key}" must be a string`);
+    }
+    const trimmed = value.trim();
+    if (trimmed && !isHttpUrl(trimmed)) {
+      throw new TypeError(`feature flag "${key}" must be empty or a valid http(s) URL`);
+    }
+    return trimmed; // 空串合法 = 跟随默认
+  }
+  const allowed = FEATURE_FLAG_ENUMS[key];
+  if (allowed) {
+    if (typeof value !== "string" || !allowed.includes(value)) {
+      throw new TypeError(`feature flag "${key}" must be one of: ${allowed.join(", ")}`);
+    }
+    return value;
+  }
+  throw new TypeError(`unknown feature flag "${key}"`);
+}
+
+/** 清洗已存的 feature_flags 对象：只保留白名单键，类型/范围损坏的键丢弃。 */
+function sanitizeFlags(raw) {
+  const out = {};
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return out;
+  for (const key of FEATURE_FLAG_BOOLEANS) {
+    if (typeof raw[key] === "boolean") out[key] = raw[key];
+  }
+  for (const [key, [min, max]] of Object.entries(FEATURE_FLAG_INT_RANGES)) {
+    if (Number.isInteger(raw[key]) && raw[key] >= min && raw[key] <= max) out[key] = raw[key];
+  }
+  for (const key of FEATURE_FLAG_STRINGS) {
+    if (typeof raw[key] === "string" && raw[key].trim().length <= FEATURE_FLAG_STRING_MAX) {
+      out[key] = raw[key].trim();
+    }
+  }
+  for (const key of FEATURE_FLAG_URLS) {
+    if (typeof raw[key] === "string") {
+      const trimmed = raw[key].trim();
+      if (!trimmed || isHttpUrl(trimmed)) out[key] = trimmed;
+    }
+  }
+  for (const [key, allowed] of Object.entries(FEATURE_FLAG_ENUMS)) {
+    if (allowed.includes(raw[key])) out[key] = raw[key];
+  }
+  return out;
+}
+
 export function createSettings(db) {
   db.exec(SCHEMA);
 
@@ -177,6 +326,31 @@ export function createSettings(db) {
     },
     setPanelMode(mode) {
       setSetting("panel_mode", mode === "light" ? "light" : "standard");
+    },
+
+    /**
+     * Feature flags（kv "feature_flags"）：面板对后端能力的显式覆盖。读取只
+     * 返回白名单内的合法键（默认 {}），写入是逐键校验后的合并持久化。
+     */
+    getFeatureFlags() {
+      const raw = getSetting("feature_flags");
+      if (!raw) return {};
+      try {
+        return sanitizeFlags(JSON.parse(raw));
+      } catch {
+        return {};
+      }
+    },
+    setFeatureFlags(patch) {
+      if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
+        throw new TypeError("feature flags patch must be a plain object");
+      }
+      const merged = this.getFeatureFlags();
+      for (const [key, value] of Object.entries(patch)) {
+        merged[key] = validateFlag(key, value);
+      }
+      setSetting("feature_flags", JSON.stringify(merged));
+      return merged;
     }
   };
 }

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -303,6 +303,25 @@ function escapeLike(q) {
   return q.replace(/[\\%_]/g, (c) => `\\${c}`);
 }
 
+// 日期过滤参数归一化（list/count 共用，保证分页 total 与行同过滤）：接受 ISO
+// 日期（"2026-09-01"）或完整时间戳，返回闭区间的 UTC ISO 边界。date-only 的
+// updatedFrom 按当天 00:00:00.000Z 起、updatedTo 按当天 23:59:59.999Z 收；非
+// 法值一律返回 undefined → 不进 WHERE（忽略而非报错：面板传坏参数时宁可放宽
+// 过滤也不要白屏）。updated_at 列是 toISOString 产生的 UTC "Z" 字符串，字典
+// 序与时间序一致，SQL 里可直接比较。
+function updatedAtBounds(updatedFrom, updatedTo) {
+  const norm = (raw, endOfDay) => {
+    if (typeof raw !== "string" || !raw.trim()) return undefined;
+    const s = raw.trim();
+    const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(s);
+    const ms = Date.parse(dateOnly ? `${s}T00:00:00.000Z` : s);
+    if (Number.isNaN(ms)) return undefined;
+    if (dateOnly && endOfDay) return `${s}T23:59:59.999Z`;
+    return new Date(ms).toISOString();
+  };
+  return { from: norm(updatedFrom, false), to: norm(updatedTo, true) };
+}
+
 function parseTags(raw) {
   try {
     const arr = JSON.parse(raw);
@@ -618,7 +637,7 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false } = {}) {
+  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, onlyArchived = false, updatedFrom = null, updatedTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
@@ -634,10 +653,24 @@ export function createStore(path) {
       clauses.push("source = ?");
       params.push(source);
     }
+    // updated_at 闭区间：与 list() 共用 updatedAtBounds 归一化，非法值被忽略
+    // （不进 WHERE），total 才能和行保持同过滤。
+    const bounds = updatedAtBounds(updatedFrom, updatedTo);
+    if (bounds.from) {
+      clauses.push("updated_at >= ?");
+      params.push(bounds.from);
+    }
+    if (bounds.to) {
+      clauses.push("updated_at <= ?");
+      params.push(bounds.to);
+    }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
     }
-    if (!includeArchived) {
+    // 与 list() 同过滤：total 才能和归档列表的行保持一致。
+    if (onlyArchived) {
+      clauses.push("archived = 1");
+    } else if (!includeArchived) {
       clauses.push("archived = 0");
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
@@ -891,7 +924,7 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, minImportance = null, source = null } = {}) {
+  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, onlyArchived = false, minImportance = null, source = null, updatedFrom = null, updatedTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
@@ -908,10 +941,25 @@ export function createStore(path) {
       clauses.push("source = ?");
       params.push(source);
     }
+    // Optional updated_at closed range (date-only "to" is normalized to the
+    // end of that day). Same helper as count() so total matches the rows.
+    const bounds = updatedAtBounds(updatedFrom, updatedTo);
+    if (bounds.from) {
+      clauses.push("updated_at >= ?");
+      params.push(bounds.from);
+    }
+    if (bounds.to) {
+      clauses.push("updated_at <= ?");
+      params.push(bounds.to);
+    }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
     }
-    if (!includeArchived) {
+    // onlyArchived：只看归档（状态页的归档列表用）；与 includeArchived（含
+    // 归档混看）互斥，同时给时归档视图优先。
+    if (onlyArchived) {
+      clauses.push("archived = 1");
+    } else if (!includeArchived) {
       clauses.push("archived = 0");
     }
     const { limit: lim, offset: off } = sanitizePage(limit, offset, 50);
@@ -1599,6 +1647,30 @@ export function createStore(path) {
   }
 
   /**
+   * 一条记忆关联到的实体（记忆详情侧栏用）：entity_attrs.memory_id 反查实体，
+   * 一条 JOIN 完成。同一记忆对同一实体的多次提及（多条 attr 行）按 name 去重，
+   * 每个实体只出现一次，按提及次数降序。只取 name/type——attr 详情走
+   * entity-attrs 端点。无关联（或记忆不存在）返回空数组。
+   */
+  function entitiesForMemory(memoryId) {
+    const rows = db.prepare(
+      `SELECT e.id, e.name, e.type, e.mention_count, e.last_seen
+       FROM entity_attrs ea JOIN entities e ON e.id = ea.entity_id
+       WHERE ea.memory_id = ?
+       GROUP BY e.id
+       ORDER BY e.mention_count DESC, e.last_seen DESC, e.name ASC`
+    ).all(memoryId ?? "");
+    const seen = new Set();
+    const out = [];
+    for (const row of rows) {
+      if (seen.has(row.name)) continue;
+      seen.add(row.name);
+      out.push({ name: row.name, type: row.type ?? null });
+    }
+    return out;
+  }
+
+  /**
    * Memories carrying a currently-valid attr matching key=value (deduped).
    * When value is empty/undefined, the attr_value filter is dropped and every
    * currently-valid memory for that attr_key is returned — the "attr:key"
@@ -1941,6 +2013,7 @@ export function createStore(path) {
     getCurrentAttrs,
     getAttrHistory,
     getAttrsByMemory,
+    entitiesForMemory,
     findMemoriesByAttr,
     saveRelation,
     migrateAttrsToMemory,

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -1,10 +1,34 @@
 import { URL } from "node:url";
+import { readFileSync } from "node:fs";
 import { timingSafeEqual, randomBytes } from "node:crypto";
+import { FEATURE_FLAG_SPEC } from "./settings.js";
+import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 
-function sendJson(res, status, payload) {
-  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+// headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
+function sendJson(res, status, payload, headers = {}) {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8", ...headers });
   res.end(JSON.stringify(payload));
 }
+
+// 附件下载响应（导出端点）：Content-Type 与文件名（含日期后缀）由调用方给定。
+function sendAttachment(res, status, contentType, filename, body) {
+  res.writeHead(status, {
+    "Content-Type": contentType,
+    "Content-Disposition": `attachment; filename="${filename}"`
+  });
+  res.end(body);
+}
+
+// 导出 JSON 的 version 字段：读插件根的 package.json（src/ 与 lib/ 都在根下
+// 一层，相对 import.meta.url 解析一致）。读取失败（打包/受限环境）降级为
+// "unknown"，导出本身仍然可用。
+const PACKAGE_VERSION = (() => {
+  try {
+    return JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+})();
 
 // Defaults for the standalone external API — keep in step with the schema
 // defaults in config.js (externalApiPort / externalApiHost).
@@ -70,8 +94,42 @@ function parseBody(text) {
   }
 }
 
-export function createApi(ctx, service, settings, commands, embedder, semantic = null, apiToken = "") {
+export function createApi(ctx, service, settings, commands, embedder, semantic = null, apiToken = "", config = null) {
   const disposers = [];
+
+  // feature flags 快照（GET/PUT 共用）：overrides 是持久化的用户显式覆盖；
+  // effective 是启动配置在白名单键上被 overrides 覆盖后的最终值。config 缺席
+  // （旧调用方直连、未传 cfg）时只报被覆盖的键，不把不存在的默认值编造给前端。
+  const flagKeys = [
+    ...FEATURE_FLAG_SPEC.booleans,
+    ...Object.keys(FEATURE_FLAG_SPEC.ints),
+    ...FEATURE_FLAG_SPEC.strings,
+    ...FEATURE_FLAG_SPEC.urls,
+    ...Object.keys(FEATURE_FLAG_SPEC.enums)
+  ];
+  // 嵌套键在 kv 里按点号平铺（"memoryQualityFilter.enabled"），运行时 cfg 里
+  // 是嵌套对象，effective 从对象子字段取值；其余键照旧从 cfg 顶层取。
+  const NESTED_FLAG_PATHS = {
+    "memoryQualityFilter.enabled": ["memoryQualityFilter", "enabled"],
+    "llmAudit.enabled": ["llmAudit", "enabled"]
+  };
+  function configFlagValue(key) {
+    const path = NESTED_FLAG_PATHS[key];
+    if (path) return config?.[path[0]]?.[path[1]];
+    return config?.[key];
+  }
+  function featureSnapshot() {
+    const overrides = settings.getFeatureFlags();
+    const effective = {};
+    for (const key of flagKeys) {
+      if (overrides[key] !== undefined) effective[key] = overrides[key];
+      else {
+        const value = configFlagValue(key);
+        if (value !== undefined) effective[key] = value;
+      }
+    }
+    return { overrides, effective };
+  }
 
   // Ensure the service has an embedder when the API layer was handed one
   // (tests wire the embedder through the API instead of index.js). Without
@@ -112,10 +170,26 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           ? Number(minRaw)
           : undefined;
         const source = url.searchParams.get("source") || undefined;
-        const items = service.toApiList(service.list({ type, limit, offset, order, minImportance, source }));
+        // updatedFrom/updatedTo：updated_at 闭区间过滤（ISO 日期或完整时间戳）。
+        // 边界归一化在 store 的 updatedAtBounds（list/count 共用同一纯函数）
+        // 完成，非法值在那里被忽略——这里原样透传即可。
+        const updatedFrom = url.searchParams.get("updatedFrom") ?? undefined;
+        const updatedTo = url.searchParams.get("updatedTo") ?? undefined;
+        // archived=only：只看归档（状态页的归档列表用）。归档行不进默认列表，
+        // 所以这是独立的视图开关，而不是 includeArchived 的混看模式。
+        const onlyArchived = url.searchParams.get("archived") === "only";
+        const rows = service.list({ type, limit, offset, order, minImportance, source, updatedFrom, updatedTo, onlyArchived });
+        // 面板行在 wire DTO 之上补 archived/quality_score——模型工具的输出
+        // schema 严格复用 toApiList，扩展只发生在 HTTP 层。
+        const items = service.toApiList(rows).map((m, i) => ({
+          ...m,
+          archived: rows[i].archived === true || rows[i].archived === 1,
+          quality_score: rows[i].quality_score ?? null
+        }));
         // Total honors the same filters as the rows, or the pager's
-        // has-more math breaks whenever minImportance/source is active.
-        sendJson(res, 200, { items, total: service.count(type, { minImportance, source }) });
+        // has-more math breaks whenever minImportance/source/updated-at
+        // bounds are active.
+        sendJson(res, 200, { items, total: service.count(type, { minImportance, source, updatedFrom, updatedTo, onlyArchived }) });
       } catch {
         sendJson(res, 500, { error: "internal" });
       }
@@ -213,6 +287,90 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           }
           service.remove(id);
           sendJson(res, 200, { ok: true });
+        });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 编辑/归档一条记忆（面板写路径，与 /delete 对称命名）-------------------
+  // POST body {id, title?, content?, importance?, tags?, archived?}。字段校验
+  // 只做类型/范围检查：字段出现（!== undefined）就必须合法，宁 400 不静默纠正
+  // ——静默丢字段会让面板误以为保存成功。写入走 service 的正规更新路径：
+  // updated_at 由 store 的单调时钟推进；content 被改写时旧版本按 human_override
+  // 入档（与镜像人工编辑回灌 mergeHumanEdits 的语义对齐，FIFO 上限 20）；
+  // archived 走 setArchived。两条路径都会触发镜像重渲染（afterSync）。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/update",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") {
+          sendJson(res, 404, { error: "not-found" });
+          return;
+        }
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then((text) => {
+          const body = parseBody(text);
+          const id = typeof body.id === "string" ? body.id.trim() : "";
+          if (!id) {
+            sendJson(res, 400, { error: "missing-id" });
+            return;
+          }
+          const patch = {};
+          if (body.title !== undefined) {
+            if (typeof body.title !== "string" || !body.title.trim()) {
+              sendJson(res, 400, { error: "invalid-title" });
+              return;
+            }
+            patch.title = body.title.trim();
+          }
+          if (body.content !== undefined) {
+            if (typeof body.content !== "string" || !body.content.trim()) {
+              sendJson(res, 400, { error: "invalid-content" });
+              return;
+            }
+            patch.content = body.content.trim();
+          }
+          if (body.importance !== undefined) {
+            if (!Number.isInteger(body.importance) || body.importance < 1 || body.importance > 5) {
+              sendJson(res, 400, { error: "invalid-importance" });
+              return;
+            }
+            patch.importance = body.importance;
+          }
+          if (body.tags !== undefined) {
+            if (!Array.isArray(body.tags) || !body.tags.every((t) => typeof t === "string")) {
+              sendJson(res, 400, { error: "invalid-tags" });
+              return;
+            }
+            patch.tags = body.tags;
+          }
+          if (body.archived !== undefined && typeof body.archived !== "boolean") {
+            sendJson(res, 400, { error: "invalid-archived" });
+            return;
+          }
+          if (Object.keys(patch).length === 0 && body.archived === undefined) {
+            sendJson(res, 400, { error: "no-fields" });
+            return;
+          }
+          const existing = service.getById(id);
+          if (!existing) {
+            sendJson(res, 404, { error: "not-found" });
+            return;
+          }
+          // 内容被改写时旧版本先入档（human_override），人工修正不静默销毁旧值。
+          if (patch.content !== undefined && patch.content !== existing.content) {
+            const history = Array.isArray(existing.content_history) ? existing.content_history : [];
+            patch.content_history = [
+              { content: existing.content ?? "", source: "human_override", updated_at: new Date().toISOString() },
+              ...history
+            ].slice(0, 20);
+          }
+          if (Object.keys(patch).length) service.update(id, patch);
+          if (body.archived !== undefined) service.setArchived(id, body.archived);
+          sendJson(res, 200, { memory: service.getById(id) });
         });
       } catch {
         sendJson(res, 500, { error: "internal" });
@@ -501,6 +659,144 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // --- 一条记忆的关联实体（记忆详情侧栏）-------------------------------------
+  // 只读：entity_attrs.memory_id 反查实体（store 一条 JOIN 完成，按提及去重）。
+  // 与目录 /entities 不同，这里以记忆为锚点，回答"这条记忆提到了谁"。记忆不
+  // 存在或无关联一律返回空数组——详情侧栏不需要区分这两种情况。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/memories/entities",
+    handler(req, res) {
+      try {
+        const url = new URL(req.url, "http://localhost");
+        const memoryId = (url.searchParams.get("memoryId") ?? "").trim();
+        if (!memoryId) {
+          sendJson(res, 400, { error: "missing-memory-id" });
+          return;
+        }
+        sendJson(res, 200, { entities: service.entitiesForMemory?.(memoryId) ?? [] });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 导出（面板备份/迁移）---------------------------------------------------
+  // 只读。json：全字段行（含 archived/forgotten，布尔化），updated_at DESC；
+  // markdown：按类型分节，块格式与磁盘镜像完全同构（renderMirrorText 与
+  // mirror.sync 共用同一条渲染路径），因此导出文本可以被 /import 原样吃回。
+  // 全量一次性取回（store.all 按 updated_at DESC）——导出是一次性备份动作，
+  // 不需要流式。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/export",
+    handler(req, res) {
+      try {
+        const url = new URL(req.url, "http://localhost");
+        const format = url.searchParams.get("format") ?? "json";
+        if (format !== "json" && format !== "markdown") {
+          sendJson(res, 400, { error: "invalid-format" });
+          return;
+        }
+        const rows = service.all?.() ?? [];
+        const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+        if (format === "json") {
+          sendJson(res, 200, {
+            exported_at: new Date().toISOString(),
+            version: PACKAGE_VERSION,
+            count: rows.length,
+            memories: rows
+          }, { "Content-Disposition": `attachment; filename="dsh-mneme-export-${stamp}.json"` });
+          return;
+        }
+        const byType = {};
+        for (const row of rows) {
+          if (TYPE_FILE[row.type]) (byType[row.type] ??= []).push(row);
+        }
+        const sections = [];
+        for (const type of Object.keys(TYPE_FILE)) {
+          if (byType[type]?.length) sections.push(renderMirrorText(type, byType[type]));
+        }
+        sendAttachment(res, 200, "text/markdown; charset=utf-8", `dsh-mneme-export-${stamp}.md`, sections.join("\n"));
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 导入（Markdown 镜像回填）----------------------------------------------
+  // 写路径（requireAuth）。body {type, markdown}：type 是镜像 TYPE_FILE 键
+  // （preference/project/decision/history/summary），markdown 是与镜像文件同构
+  // 的文本。解析复用 readHumanEdits 的纯函数核心 parseHumanEdits（同一实现，
+  // 行为一致是硬约束），合并走 mergeHumanEdits（只吃 title/content；digest 命
+  // 中或无差异的条目在 service 侧自动跳过）。解析出 0 条不算错误。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/import",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") {
+          sendJson(res, 404, { error: "not-found" });
+          return;
+        }
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then((text) => {
+          const body = parseBody(text);
+          if (typeof body.type !== "string" || !Object.hasOwn(TYPE_FILE, body.type)) {
+            sendJson(res, 400, { error: "invalid-type" });
+            return;
+          }
+          if (typeof body.markdown !== "string" || !body.markdown.trim()) {
+            sendJson(res, 400, { error: "invalid-markdown" });
+            return;
+          }
+          const edits = parseHumanEdits(body.markdown);
+          service.mergeHumanEdits(body.type, edits);
+          sendJson(res, 200, { merged: edits.length, type: body.type });
+        });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- 巩固状态（dream 面板）--------------------------------------------------
+  // 只读：最近巩固运行（最多 5 条，created_at DESC）+ 未解决冲突队列。
+  // pendingMemoryIds 从未解决冲突行提取涉及的记忆 id，去重后上限 200，避免积
+  // 压很大时响应失控。listDreamRuns/listConflictPending 走 service 现成的审计
+  // 只读通道（bookkeeping 语义，不触发写钩子）。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/dream-status",
+    handler(req, res) {
+      try {
+        const runs = (service.listDreamRuns?.({ limit: 5 }) ?? []).map((r) => ({
+          created_at: r.created_at,
+          status: r.status,
+          provider: r.provider ?? null,
+          model: r.model ?? null,
+          error: r.error ?? null
+        }));
+        const pendingConflicts = service.countConflictPending?.() ?? 0;
+        const ids = new Set();
+        for (const row of service.listConflictPending?.({ limit: 200, includeResolved: false }) ?? []) {
+          if (ids.size >= 200) break;
+          if (row.memory_a) ids.add(row.memory_a);
+          if (ids.size >= 200) break;
+          if (row.memory_b) ids.add(row.memory_b);
+        }
+        sendJson(res, 200, {
+          lastRun: runs[0] ?? null,
+          runs,
+          pendingConflicts,
+          pendingMemoryIds: [...ids].slice(0, 200)
+        });
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
   // --- health: mirror sync state (F-NEW-03 / v0.3.6) ---
   // Auth-gated; only returns a sanitized error code (never raw last_error which
   // may leak paths/token-like strings/internal hosts). On state read failure it
@@ -624,6 +920,41 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // --- feature flags（功能开关：面板逐项开关后端能力）-------------------------
+  // 读路由保持开放（与 mode/list 一致），前端无需 token 即可渲染开关状态；PUT
+  // 与其他设置写一致走 requireAuth。空/非对象 patch 直接 400：它不携带任何
+  // 意图，静默成功只会掩盖前端 bug。校验失败（未知键/类型/越界）的 400 把键
+  // 名放进 error，前端能直接定位写坏的开关。生效节奏与 panel_mode 相同：
+  // 持久化后下次启动合并进 cfg，本次启动的运行时行为不变。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/features",
+    handler(req, res) {
+      try {
+        if (req.method === "PUT" || req.method === "POST") {
+          if (!requireAuth(req, res, apiToken)) return;
+          return readBody(req).then((text) => {
+            const body = parseBody(text);
+            if (typeof body !== "object" || body === null || Array.isArray(body) || Object.keys(body).length === 0) {
+              sendJson(res, 400, { error: "invalid-patch" });
+              return;
+            }
+            try {
+              settings.setFeatureFlags(body);
+            } catch (error) {
+              sendJson(res, 400, { error: error.message });
+              return;
+            }
+            sendJson(res, 200, featureSnapshot());
+          });
+        }
+        sendJson(res, 200, featureSnapshot());
+      } catch {
+        sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
   // --- custom commands ---
   register({
     kind: "exact",
@@ -662,7 +993,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   });
 
   return {
-    routes: 17,
+    routes: 23,
     dispose: () => {
       for (const dispose of disposers) dispose();
     }

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -66,7 +66,30 @@ export const apply = (ctx, config) => {
   // semantic feature off and keeps the core loop (autoInject, autoSummarize,
   // hot memory, quality filter).
   const lightMode = rawCfg.lightMode === true || settings.getPanelMode() === "light";
-  const cfg = applyLightModePreset({ ...rawCfg, lightMode });
+  // 功能开关合并顺序即优先级：用户显式开关（feature_flags kv，面板写入）>
+  // 轻量预设（applyLightModePreset 批量置关的重型能力）> bundle 配置。预设必须
+  // 先应用、用户开关后展开，否则 LIGHT_MODE_OFF 会把用户显式打开的开关再次
+  // 压掉。合并结果只作用于本次启动：面板改开关后与 panel_mode 一样在下次
+  // 启动生效。
+  // 嵌套对象开关按首个点号拆开（kv 里平铺存的 "memoryQualityFilter.enabled" →
+  // cfg.memoryQualityFilter.enabled），点号键不原样留在 cfg 顶层属性里。
+  const flags = settings.getFeatureFlags();
+  const flatFlags = {};
+  const nestedFlags = {};
+  for (const [key, value] of Object.entries(flags)) {
+    const dot = key.indexOf(".");
+    if (dot > 0) {
+      const objKey = key.slice(0, dot);
+      const subKey = key.slice(dot + 1);
+      nestedFlags[objKey] = { ...(nestedFlags[objKey] ?? {}), [subKey]: value };
+    } else {
+      flatFlags[key] = value;
+    }
+  }
+  const cfg = { ...applyLightModePreset({ ...rawCfg, lightMode }), ...flatFlags };
+  for (const [objKey, sub] of Object.entries(nestedFlags)) {
+    cfg[objKey] = { ...(cfg[objKey] ?? {}), ...sub };
+  }
 
   const mirror = createMirror(memoryDir);
   const service = createService({ store, mirror, config: cfg, logger: ctx.logger });
@@ -340,7 +363,7 @@ export const apply = (ctx, config) => {
       add: () => { throw new Error("commands unavailable"); },
       remove: () => false,
       list: () => []
-    }, embedder, { vectorIndex, reranker }, cfg.apiToken);
+    }, embedder, { vectorIndex, reranker }, cfg.apiToken, cfg);
     disposers.push(api.dispose);
   }
 

--- a/dsh-mneme/src/mirror.js
+++ b/dsh-mneme/src/mirror.js
@@ -47,6 +47,92 @@ function renderMemory(m) {
   return lines.join("\n");
 }
 
+/**
+ * Render one type's memories into exactly the mirror-file text (header +
+ * per-memory blocks, updated_at DESC like sync). sync() writes this to disk;
+ * the /export endpoint returns the same text, so an exported markdown is
+ * byte-compatible with a mirror file and can be fed straight back through
+ * parseHumanEdits → mergeHumanEdits. Unknown type → undefined.
+ */
+export function renderMirrorText(type, memories) {
+  const name = TYPE_FILE[type];
+  if (!name) return undefined;
+  const items = (memories ?? [])
+    .slice()
+    .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+  const header = `# ${name} — dsh-mneme 镜像\n\n<!-- 手工编辑此文件会被合并回记忆库（人工优先）。 -->\n\n`;
+  const body = items.map(renderMemory).join("\n");
+  return header + body;
+}
+
+/**
+ * Parse mirror text back into {id, title, content} entries for human edits.
+ * Pure text-in/edits-out core: readHumanEdits feeds it mirror file contents
+ * and the /import endpoint feeds it user-pasted markdown, so both paths share
+ * one parsing implementation (行为一致是硬约束——import 必须能吃回 export 与
+ * 磁盘镜像)。Entries are anchored on "- **ID**: `...`" lines that are followed
+ * by the "- **类型**:" metadata line (structural entry head): each entry's
+ * block spans from its ID line up to the next ID line (or end of text). The
+ * block head (the ID line plus the generated metadata run) and the trailing
+ * structural "---" separator are stripped; everything in between is the entry
+ * body, so user content containing "---", metadata-like lines, or even a
+ * machine-format "- **ID**: `x`" line is preserved. The title is the "## "
+ * heading preceding the ID line.
+ */
+export function parseHumanEdits(text) {
+  // CRLF 归一化（readHumanEdits 原有的读取侧处理移入纯函数，Windows 手工编辑
+  // 的文件与导入文本都能正确解析）。
+  const normalized = String(text ?? "").replace(/\r\n/g, "\n");
+  const edits = [];
+  // Anchor on the ID line only when it is a structural entry head: the
+  // machine-rendered ID line is always followed by the "- **类型**:" line.
+  // A body line like "- **ID**: `x`" is not, so it never splits the block
+  // or produces a ghost entry.
+  const anchors = [...normalized.matchAll(/^- \*\*ID\*\*: `([^`]+)`\n- \*\*类型\*\*:/gm)];
+  let prevEnd = 0;
+  for (let i = 0; i < anchors.length; i++) {
+    const anchor = anchors[i];
+    const blockStart = anchor.index;
+    const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : normalized.length;
+
+    // Title: last "## " heading before this ID line (file header region /
+    // previous block tail). Body headings of earlier entries come before
+    // the structural "---" + "## " of this entry, so the last match wins.
+    const titleMatches = [...normalized.slice(prevEnd, blockStart).matchAll(/^## (.+)$/gm)];
+    const titleMatch = titleMatches[titleMatches.length - 1];
+
+    // Body: the ID line and the generated metadata run are structural head;
+    // everything after them up to the trailing "---" separator is the body.
+    let body = normalized
+      .slice(blockStart, blockEnd)
+      .replace(/^- \*\*ID\*\*: `[^`]+`\n?/, "")
+      .replace(/^(- \*\*(类型|重要性|标签|更新时间|来源)\*\*:.*\n?)+/, "")
+      .replace(/^<!-- mirror-digest: [a-f0-9]+ -->\n?/m, "");
+    const separators = [...body.matchAll(/^---\s*$/gm)];
+    const lastSep = separators[separators.length - 1];
+    if (lastSep) body = body.slice(0, lastSep.index);
+    body = body.trim();
+
+    // The machine-written "更新时间" line records the store's updated_at at
+    // render time — the version token for detecting a concurrent store write
+    // during a three-way merge of human edits (see service.syncMirror).
+    const block = normalized.slice(blockStart, blockEnd);
+    const updatedMatch = block.match(/- \*\*更新时间\*\*: ([^\n]+)/);
+    const digestMatch = block.match(/<!-- mirror-digest: ([a-f0-9]+) -->/);
+    edits.push({
+      id: anchor[1],
+      title: titleMatch ? unescape(titleMatch[1]).trim() : undefined,
+      content: body,
+      updated_at: updatedMatch ? updatedMatch[1].trim() : undefined,
+      digest: digestMatch ? digestMatch[1] : undefined
+    });
+
+    const lineEnd = normalized.indexOf("\n", blockStart);
+    prevEnd = lineEnd === -1 ? normalized.length : lineEnd + 1;
+  }
+  return edits;
+}
+
 export function createMirror(dir) {
   mkdirSync(dir, { recursive: true });
 
@@ -56,15 +142,9 @@ export function createMirror(dir) {
   }
 
   /**
-   * Parse a mirror file back into {id, title, content} entries for human edits.
-   * Entries are anchored on "- **ID**: `...`" lines that are followed by the
-   * "- **类型**:" metadata line (structural entry head): each entry's block
-   * spans from its ID line up to the next ID line (or end of file). The block
-   * head (the ID line plus the generated metadata run) and the trailing
-   * structural "---" separator are stripped; everything in between is the entry
-   * body, so user content containing "---", metadata-like lines, or even a
-   * machine-format "- **ID**: `x`" line is preserved. The title is the "## "
-   * heading preceding the ID line.
+   * Read the mirror files and parse them back into human edits. The pure
+   * parsing logic lives in the exported parseHumanEdits (shared with /import);
+   * this wrapper only owns the "read file → text" side.
    */
   function readHumanEdits(type = undefined) {
     const types = type ? [type] : Object.keys(TYPE_FILE);
@@ -72,53 +152,7 @@ export function createMirror(dir) {
     for (const t of types) {
       const file = filePath(t);
       if (!file || !existsSync(file)) continue;
-      const text = readFileSync(file, "utf8").replace(/\r\n/g, "\n");
-      // Anchor on the ID line only when it is a structural entry head: the
-      // machine-rendered ID line is always followed by the "- **类型**:" line.
-      // A body line like "- **ID**: `x`" is not, so it never splits the block
-      // or produces a ghost entry.
-      const anchors = [...text.matchAll(/^- \*\*ID\*\*: `([^`]+)`\n- \*\*类型\*\*:/gm)];
-      let prevEnd = 0;
-      for (let i = 0; i < anchors.length; i++) {
-        const anchor = anchors[i];
-        const blockStart = anchor.index;
-        const blockEnd = i + 1 < anchors.length ? anchors[i + 1].index : text.length;
-
-        // Title: last "## " heading before this ID line (file header region /
-        // previous block tail). Body headings of earlier entries come before
-        // the structural "---" + "## " of this entry, so the last match wins.
-        const titleMatches = [...text.slice(prevEnd, blockStart).matchAll(/^## (.+)$/gm)];
-        const titleMatch = titleMatches[titleMatches.length - 1];
-
-        // Body: the ID line and the generated metadata run are structural head;
-        // everything after them up to the trailing "---" separator is the body.
-        let body = text
-          .slice(blockStart, blockEnd)
-          .replace(/^- \*\*ID\*\*: `[^`]+`\n?/, "")
-          .replace(/^(- \*\*(类型|重要性|标签|更新时间|来源)\*\*:.*\n?)+/, "")
-          .replace(/^<!-- mirror-digest: [a-f0-9]+ -->\n?/m, "");
-        const separators = [...body.matchAll(/^---\s*$/gm)];
-        const lastSep = separators[separators.length - 1];
-        if (lastSep) body = body.slice(0, lastSep.index);
-        body = body.trim();
-
-        // The machine-written "更新时间" line records the store's updated_at at
-        // render time — the version token for detecting a concurrent store write
-        // during a three-way merge of human edits (see service.syncMirror).
-        const block = text.slice(blockStart, blockEnd);
-        const updatedMatch = block.match(/- \*\*更新时间\*\*: ([^\n]+)/);
-        const digestMatch = block.match(/<!-- mirror-digest: ([a-f0-9]+) -->/);
-        edits.push({
-          id: anchor[1],
-          title: titleMatch ? unescape(titleMatch[1]).trim() : undefined,
-          content: body,
-          updated_at: updatedMatch ? updatedMatch[1].trim() : undefined,
-          digest: digestMatch ? digestMatch[1] : undefined
-        });
-
-        const lineEnd = text.indexOf("\n", blockStart);
-        prevEnd = lineEnd === -1 ? text.length : lineEnd + 1;
-      }
+      edits.push(...parseHumanEdits(readFileSync(file, "utf8")));
     }
     return edits;
   }
@@ -145,9 +179,9 @@ export function createMirror(dir) {
           // memories do not "resurrect" via readHumanEdits
           rmSync(file, { force: true });
         } else {
-          const header = `# ${TYPE_FILE[type]} — dsh-mneme 镜像\n\n<!-- 手工编辑此文件会被合并回记忆库（人工优先）。 -->\n\n`;
-          const body = items.map(renderMemory).join("\n");
-          writeFileSync(file, header + body, "utf8");
+          // 渲染走 renderMirrorText（与 /export 共用同一条渲染路径），磁盘镜像
+          // 与导出文本永远同构。
+          writeFileSync(file, renderMirrorText(type, items), "utf8");
         }
         results[type] = { ok: true };
       } catch (error) {

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -1511,6 +1511,8 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     findEntityByName: (n) => store.findEntityByName(n),
     findEntityById: (id) => store.findEntityById(id),
     getAttrsByMemory: (id) => store.getAttrsByMemory(id),
+    // 记忆详情侧栏：一条记忆关联到的实体（entity_attrs.memory_id 反查，纯读）。
+    entitiesForMemory: (id) => store.entitiesForMemory(id),
     getCurrentAttrs: (id) => store.getCurrentAttrs(id),
     migrateAttrsToMemory: (fromId, toId, now) => store.migrateAttrsToMemory(fromId, toId, now)
   };

--- a/dsh-mneme/src/settings.js
+++ b/dsh-mneme/src/settings.js
@@ -31,6 +31,155 @@ function parseList(raw) {
   }
 }
 
+// --- feature flags（功能开关）白名单 -----------------------------------------
+// 面板可逐项开关的后端能力。设计约束：
+// 1. 键名与类型必须和 config.js schema 同名同型，这份白名单是唯一校验源
+//    （api.js 复用它计算 effective），schema 增删能力键时要同步改这里。
+// 2. 持久化（kv "feature_flags"）只落白名单键；读到未知键、类型损坏或越界的
+//    值一律丢弃而不是报错——kv 会残留旧版本写入的键，读路径必须向前兼容。
+// 3. 写入是逐键校验的合并写：未知键/类型/范围不符抛 TypeError（消息含键名，
+//    供 API 透传给前端定位），校验不通过不落库，坏值永远进不了 kv。
+const FEATURE_FLAG_BOOLEANS = [
+  "autoInject",
+  "autoSummarize",
+  "hotMemoryEnabled",
+  "entityExtractionEnabled",
+  "codingRetrospect",
+  "autoDream",
+  "sleepModeEnabled",
+  "hybridInject",
+  "selectiveInjectEnabled",
+  "searchSemanticDedup",
+  "rerankEnabled",
+  "adaptiveThresholdEnabled",
+  "reflectionUpdateEnabled",
+  "reflectionFailureTracking",
+  "bm25SearchEnabled",
+  "conflictFreezeEnabled",
+  "trustEpistemicWeighting",
+  // 嵌套对象开关：config.js 里是 memoryQualityFilter / llmAudit 对象的 enabled
+  // 子字段。kv 按点号键平铺存（"memoryQualityFilter.enabled": false），index.js
+  // 合并时展开回嵌套对象，api.js 的 effective 从对象子字段取值。
+  "memoryQualityFilter.enabled",
+  "llmAudit.enabled"
+];
+// 整数开关的闭区间，与 config.js 里 z.natural().min().max() 对齐。
+const FEATURE_FLAG_INT_RANGES = {
+  distillRateLimitIntervalMs: [0, 60000],
+  distillRateLimitRetries: [0, 10],
+  distillRateLimitBaseDelayMs: [100, 60000],
+  distillMaxChars: [1000, 200000],
+  codingBoostFactor: [1, 5]
+};
+// 自由字符串开关（与 config.js 的 z.string() 同名同型）：trim 后 ≤200 字符，
+// 空串合法（= 跟随主对话模型/默认路径，面板显示 placeholder）。
+const FEATURE_FLAG_STRINGS = [
+  "dreamProvider",
+  "dreamModel",
+  "localEmbedModel",
+  "ollamaModel"
+];
+// URL 字符串开关：trim 后必须为空或合法 http/https URL（new URL() 校验协议，
+// 拒绝其余协议——这是 SSRF 防线的一部分）。
+const FEATURE_FLAG_URLS = ["ollamaBaseUrl"];
+// 枚举开关（与 config.js 的 z.union(z.const(...)) 对齐）：仅允许列出的值。
+const FEATURE_FLAG_ENUMS = {
+  embedProvider: ["openai", "local", "ollama"]
+};
+const FEATURE_FLAG_STRING_MAX = 200;
+
+// 供 api.js 复用同一份白名单（effective 只在白名单键上计算）。
+export const FEATURE_FLAG_SPEC = {
+  booleans: FEATURE_FLAG_BOOLEANS,
+  ints: FEATURE_FLAG_INT_RANGES,
+  strings: FEATURE_FLAG_STRINGS,
+  urls: FEATURE_FLAG_URLS,
+  enums: FEATURE_FLAG_ENUMS
+};
+
+/** ollamaBaseUrl 的协议白名单：只接受 http/https（SSRF 防线的一部分）。 */
+function isHttpUrl(value) {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** 校验单个开关值；不合法抛 TypeError（消息含键名）。 */
+function validateFlag(key, value) {
+  if (FEATURE_FLAG_BOOLEANS.includes(key)) {
+    if (typeof value !== "boolean") {
+      throw new TypeError(`feature flag "${key}" must be a boolean`);
+    }
+    return value;
+  }
+  const range = FEATURE_FLAG_INT_RANGES[key];
+  if (range) {
+    const [min, max] = range;
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new TypeError(`feature flag "${key}" must be an integer in [${min}, ${max}]`);
+    }
+    return value;
+  }
+  if (FEATURE_FLAG_STRINGS.includes(key)) {
+    if (typeof value !== "string") {
+      throw new TypeError(`feature flag "${key}" must be a string`);
+    }
+    const trimmed = value.trim();
+    if (trimmed.length > FEATURE_FLAG_STRING_MAX) {
+      throw new TypeError(`feature flag "${key}" must be at most ${FEATURE_FLAG_STRING_MAX} characters`);
+    }
+    return trimmed; // 空串合法 = 跟随默认
+  }
+  if (FEATURE_FLAG_URLS.includes(key)) {
+    if (typeof value !== "string") {
+      throw new TypeError(`feature flag "${key}" must be a string`);
+    }
+    const trimmed = value.trim();
+    if (trimmed && !isHttpUrl(trimmed)) {
+      throw new TypeError(`feature flag "${key}" must be empty or a valid http(s) URL`);
+    }
+    return trimmed; // 空串合法 = 跟随默认
+  }
+  const allowed = FEATURE_FLAG_ENUMS[key];
+  if (allowed) {
+    if (typeof value !== "string" || !allowed.includes(value)) {
+      throw new TypeError(`feature flag "${key}" must be one of: ${allowed.join(", ")}`);
+    }
+    return value;
+  }
+  throw new TypeError(`unknown feature flag "${key}"`);
+}
+
+/** 清洗已存的 feature_flags 对象：只保留白名单键，类型/范围损坏的键丢弃。 */
+function sanitizeFlags(raw) {
+  const out = {};
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return out;
+  for (const key of FEATURE_FLAG_BOOLEANS) {
+    if (typeof raw[key] === "boolean") out[key] = raw[key];
+  }
+  for (const [key, [min, max]] of Object.entries(FEATURE_FLAG_INT_RANGES)) {
+    if (Number.isInteger(raw[key]) && raw[key] >= min && raw[key] <= max) out[key] = raw[key];
+  }
+  for (const key of FEATURE_FLAG_STRINGS) {
+    if (typeof raw[key] === "string" && raw[key].trim().length <= FEATURE_FLAG_STRING_MAX) {
+      out[key] = raw[key].trim();
+    }
+  }
+  for (const key of FEATURE_FLAG_URLS) {
+    if (typeof raw[key] === "string") {
+      const trimmed = raw[key].trim();
+      if (!trimmed || isHttpUrl(trimmed)) out[key] = trimmed;
+    }
+  }
+  for (const [key, allowed] of Object.entries(FEATURE_FLAG_ENUMS)) {
+    if (allowed.includes(raw[key])) out[key] = raw[key];
+  }
+  return out;
+}
+
 export function createSettings(db) {
   db.exec(SCHEMA);
 
@@ -177,6 +326,31 @@ export function createSettings(db) {
     },
     setPanelMode(mode) {
       setSetting("panel_mode", mode === "light" ? "light" : "standard");
+    },
+
+    /**
+     * Feature flags（kv "feature_flags"）：面板对后端能力的显式覆盖。读取只
+     * 返回白名单内的合法键（默认 {}），写入是逐键校验后的合并持久化。
+     */
+    getFeatureFlags() {
+      const raw = getSetting("feature_flags");
+      if (!raw) return {};
+      try {
+        return sanitizeFlags(JSON.parse(raw));
+      } catch {
+        return {};
+      }
+    },
+    setFeatureFlags(patch) {
+      if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
+        throw new TypeError("feature flags patch must be a plain object");
+      }
+      const merged = this.getFeatureFlags();
+      for (const [key, value] of Object.entries(patch)) {
+        merged[key] = validateFlag(key, value);
+      }
+      setSetting("feature_flags", JSON.stringify(merged));
+      return merged;
     }
   };
 }

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -303,6 +303,25 @@ function escapeLike(q) {
   return q.replace(/[\\%_]/g, (c) => `\\${c}`);
 }
 
+// 日期过滤参数归一化（list/count 共用，保证分页 total 与行同过滤）：接受 ISO
+// 日期（"2026-09-01"）或完整时间戳，返回闭区间的 UTC ISO 边界。date-only 的
+// updatedFrom 按当天 00:00:00.000Z 起、updatedTo 按当天 23:59:59.999Z 收；非
+// 法值一律返回 undefined → 不进 WHERE（忽略而非报错：面板传坏参数时宁可放宽
+// 过滤也不要白屏）。updated_at 列是 toISOString 产生的 UTC "Z" 字符串，字典
+// 序与时间序一致，SQL 里可直接比较。
+function updatedAtBounds(updatedFrom, updatedTo) {
+  const norm = (raw, endOfDay) => {
+    if (typeof raw !== "string" || !raw.trim()) return undefined;
+    const s = raw.trim();
+    const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(s);
+    const ms = Date.parse(dateOnly ? `${s}T00:00:00.000Z` : s);
+    if (Number.isNaN(ms)) return undefined;
+    if (dateOnly && endOfDay) return `${s}T23:59:59.999Z`;
+    return new Date(ms).toISOString();
+  };
+  return { from: norm(updatedFrom, false), to: norm(updatedTo, true) };
+}
+
 function parseTags(raw) {
   try {
     const arr = JSON.parse(raw);
@@ -618,7 +637,7 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false } = {}) {
+  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, onlyArchived = false, updatedFrom = null, updatedTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
@@ -634,10 +653,24 @@ export function createStore(path) {
       clauses.push("source = ?");
       params.push(source);
     }
+    // updated_at 闭区间：与 list() 共用 updatedAtBounds 归一化，非法值被忽略
+    // （不进 WHERE），total 才能和行保持同过滤。
+    const bounds = updatedAtBounds(updatedFrom, updatedTo);
+    if (bounds.from) {
+      clauses.push("updated_at >= ?");
+      params.push(bounds.from);
+    }
+    if (bounds.to) {
+      clauses.push("updated_at <= ?");
+      params.push(bounds.to);
+    }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
     }
-    if (!includeArchived) {
+    // 与 list() 同过滤：total 才能和归档列表的行保持一致。
+    if (onlyArchived) {
+      clauses.push("archived = 1");
+    } else if (!includeArchived) {
       clauses.push("archived = 0");
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
@@ -891,7 +924,7 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, minImportance = null, source = null } = {}) {
+  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, onlyArchived = false, minImportance = null, source = null, updatedFrom = null, updatedTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
@@ -908,10 +941,25 @@ export function createStore(path) {
       clauses.push("source = ?");
       params.push(source);
     }
+    // Optional updated_at closed range (date-only "to" is normalized to the
+    // end of that day). Same helper as count() so total matches the rows.
+    const bounds = updatedAtBounds(updatedFrom, updatedTo);
+    if (bounds.from) {
+      clauses.push("updated_at >= ?");
+      params.push(bounds.from);
+    }
+    if (bounds.to) {
+      clauses.push("updated_at <= ?");
+      params.push(bounds.to);
+    }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
     }
-    if (!includeArchived) {
+    // onlyArchived：只看归档（状态页的归档列表用）；与 includeArchived（含
+    // 归档混看）互斥，同时给时归档视图优先。
+    if (onlyArchived) {
+      clauses.push("archived = 1");
+    } else if (!includeArchived) {
       clauses.push("archived = 0");
     }
     const { limit: lim, offset: off } = sanitizePage(limit, offset, 50);
@@ -1599,6 +1647,30 @@ export function createStore(path) {
   }
 
   /**
+   * 一条记忆关联到的实体（记忆详情侧栏用）：entity_attrs.memory_id 反查实体，
+   * 一条 JOIN 完成。同一记忆对同一实体的多次提及（多条 attr 行）按 name 去重，
+   * 每个实体只出现一次，按提及次数降序。只取 name/type——attr 详情走
+   * entity-attrs 端点。无关联（或记忆不存在）返回空数组。
+   */
+  function entitiesForMemory(memoryId) {
+    const rows = db.prepare(
+      `SELECT e.id, e.name, e.type, e.mention_count, e.last_seen
+       FROM entity_attrs ea JOIN entities e ON e.id = ea.entity_id
+       WHERE ea.memory_id = ?
+       GROUP BY e.id
+       ORDER BY e.mention_count DESC, e.last_seen DESC, e.name ASC`
+    ).all(memoryId ?? "");
+    const seen = new Set();
+    const out = [];
+    for (const row of rows) {
+      if (seen.has(row.name)) continue;
+      seen.add(row.name);
+      out.push({ name: row.name, type: row.type ?? null });
+    }
+    return out;
+  }
+
+  /**
    * Memories carrying a currently-valid attr matching key=value (deduped).
    * When value is empty/undefined, the attr_value filter is dropped and every
    * currently-valid memory for that attr_key is returned — the "attr:key"
@@ -1941,6 +2013,7 @@ export function createStore(path) {
     getCurrentAttrs,
     getAttrHistory,
     getAttrsByMemory,
+    entitiesForMemory,
     findMemoriesByAttr,
     saveRelation,
     migrateAttrsToMemory,

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -6,6 +6,11 @@ import { createService } from "../src/service.js";
 import { createApi } from "../src/api.js";
 import { createSettings } from "../src/settings.js";
 import { createVectorIndex } from "../src/vector-index.js";
+import { Config } from "../src/config.js";
+import { parseHumanEdits } from "../src/mirror.js";
+
+// 解析后的 schema 默认值，作为 /features effective 的 bundle 配置侧样本。
+const FLAGS_CFG = Config({});
 
 class FakeRes extends EventEmitter {
   constructor() { super(); this.statusCode = 200; this.body = ""; }
@@ -27,7 +32,7 @@ function req(path, method = "GET", body = null) {
   return r;
 }
 
-function setup(embedder, apiToken = "") {
+function setup(embedder, apiToken = "", config = null) {
   const store = createStore(":memory:");
   const service = createService({ store, mirror: null, config: {} });
   const settings = createSettings(store.db);
@@ -45,7 +50,7 @@ function setup(embedder, apiToken = "") {
       }
     }
   };
-  const api = createApi(ctx, service, settings, commands, embedder, undefined, apiToken);
+  const api = createApi(ctx, service, settings, commands, embedder, undefined, apiToken, config);
   return { store, service, routes, api, settings, apiToken };
 }
 
@@ -510,4 +515,482 @@ test("Bug10: vector-reindex with an embed-only OpenAI-compatible embedder return
   assert.equal(vectorIndex.modelHash(), "text-embedding-3#abc", "model_hash written to vector_meta");
   assert.equal(vectorIndex.dimension(), 3, "dimension written to vector_meta");
   assert.equal(vectorIndex.getEmbedding(service.all()[0].id).length, 3, "embedding persisted");
+});
+
+// --- feature flags（/features：overrides + effective）------------------------
+
+test("GET /api/dsh-mneme/features returns empty overrides and effective config defaults", async () => {
+  const { routes } = setup(undefined, "", FLAGS_CFG);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/features");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features"), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.deepEqual(data.overrides, {});
+  // effective 覆盖全部 30 个白名单键，未覆盖时取 bundle 配置的解析默认值；
+  // dreamProvider/dreamModel 无 schema 默认值（Config({}) 解析为 undefined），
+  // 不编造给前端 → 30 - 2 = 28
+  assert.equal(Object.keys(data.effective).length, 28);
+  assert.equal(data.effective.autoInject, true);
+  assert.equal(data.effective.codingRetrospect, false);
+  assert.equal(data.effective.distillMaxChars, 24000);
+  assert.equal(data.effective.codingBoostFactor, 2);
+  // 新增布尔键（含嵌套点号键）从 bundle 配置的对象子字段/顶层取默认值
+  assert.equal(data.effective.bm25SearchEnabled, true);
+  assert.equal(data.effective.conflictFreezeEnabled, false);
+  assert.equal(data.effective.trustEpistemicWeighting, false);
+  assert.equal(data.effective.reflectionFailureTracking, true);
+  assert.equal(data.effective["memoryQualityFilter.enabled"], true);
+  assert.equal(data.effective["llmAudit.enabled"], true);
+  // 新增字符串 / URL / 枚举键
+  assert.equal(data.effective.localEmbedModel, "Xenova/bge-small-zh-v1.5");
+  assert.equal(data.effective.ollamaBaseUrl, "http://localhost:11434");
+  assert.equal(data.effective.ollamaModel, "nomic-embed-text");
+  assert.equal(data.effective.embedProvider, "openai");
+});
+
+test("PUT /api/dsh-mneme/features round-trips, overrides effective and persists", async () => {
+  const { routes, settings } = setup(undefined, "", FLAGS_CFG);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/features");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { autoDream: false, distillMaxChars: 48000 }), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.deepEqual(data.overrides, { autoDream: false, distillMaxChars: 48000 });
+  assert.equal(data.effective.autoDream, false, "override wins over config default");
+  assert.equal(data.effective.distillMaxChars, 48000);
+  assert.equal(data.effective.autoInject, true, "keys not in the patch still report config");
+  assert.deepEqual(settings.getFeatureFlags(), { autoDream: false, distillMaxChars: 48000 });
+});
+
+test("PUT /api/dsh-mneme/features round-trips nested, string, url and enum keys", async () => {
+  const { routes, settings } = setup(undefined, "", FLAGS_CFG);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/features");
+  const patch = {
+    "memoryQualityFilter.enabled": false,
+    "llmAudit.enabled": false,
+    embedProvider: "local",
+    ollamaBaseUrl: "http://127.0.0.1:11434",
+    dreamProvider: "  siliconflow  ",
+    dreamModel: ""
+  };
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", patch), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.deepEqual(data.overrides, {
+    "memoryQualityFilter.enabled": false,
+    "llmAudit.enabled": false,
+    embedProvider: "local",
+    ollamaBaseUrl: "http://127.0.0.1:11434",
+    dreamProvider: "siliconflow",
+    dreamModel: ""
+  }, "nested keys persist flat, free strings are trimmed");
+  // 嵌套键的覆盖值压过 bundle 配置的对象子字段
+  assert.equal(data.effective["memoryQualityFilter.enabled"], false);
+  assert.equal(data.effective["llmAudit.enabled"], false);
+  assert.equal(data.effective.embedProvider, "local");
+  assert.equal(data.effective.ollamaBaseUrl, "http://127.0.0.1:11434");
+  assert.equal(data.effective.dreamProvider, "siliconflow");
+  assert.equal(data.effective.dreamModel, "", "empty string is a legal override");
+  assert.deepEqual(settings.getFeatureFlags(), data.overrides, "overrides persisted");
+
+  // 非法枚举 / 非 http 协议的 URL → 400 且不落库
+  const badEnum = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { embedProvider: "bogus" }), badEnum);
+  assert.equal(badEnum.statusCode, 400);
+  assert.match(JSON.parse(badEnum.body).error, /embedProvider/);
+
+  const badUrl = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { ollamaBaseUrl: "ftp://localhost:11434" }), badUrl);
+  assert.equal(badUrl.statusCode, 400);
+  assert.match(JSON.parse(badUrl.body).error, /ollamaBaseUrl/);
+
+  assert.deepEqual(settings.getFeatureFlags(), data.overrides, "rejected writes persist nothing");
+});
+
+test("PUT /api/dsh-mneme/features rejects unknown keys, bad types and bad ranges with 400", async () => {
+  const { routes, settings } = setup(undefined, "", FLAGS_CFG);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/features");
+
+  const unknown = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { noSuchFlag: true }), unknown);
+  assert.equal(unknown.statusCode, 400);
+  assert.match(JSON.parse(unknown.body).error, /noSuchFlag/);
+
+  const badType = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { autoInject: "yes" }), badType);
+  assert.equal(badType.statusCode, 400);
+  assert.match(JSON.parse(badType.body).error, /autoInject/);
+
+  const badRange = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { codingBoostFactor: 9 }), badRange);
+  assert.equal(badRange.statusCode, 400);
+  assert.match(JSON.parse(badRange.body).error, /codingBoostFactor/);
+
+  // 空 patch 不携带任何意图，直接 400
+  const empty = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", {}), empty);
+  assert.equal(empty.statusCode, 400);
+
+  assert.deepEqual(settings.getFeatureFlags(), {}, "failed writes persist nothing");
+});
+
+test("PUT /api/dsh-mneme/features is token-gated; GET stays open", async () => {
+  const { routes } = setup(undefined, "secret-token", FLAGS_CFG);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/features");
+
+  const get = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features"), get);
+  assert.equal(get.statusCode, 200, "read stays open without token");
+
+  const put = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/features", "PUT", { autoDream: false }), put);
+  assert.equal(put.statusCode, 401);
+
+  const ok = req("/api/dsh-mneme/features", "PUT", { autoDream: false });
+  ok.headers = { authorization: "Bearer secret-token" };
+  const okRes = new FakeRes();
+  await route.handler(ok, okRes);
+  assert.equal(okRes.statusCode, 200);
+});
+
+// --- 交互式记忆库面板：日期过滤 / update / memories/entities / export / import / dream-status ---
+
+test("GET /api/dsh-mneme/list supports updatedFrom/updatedTo and count matches", async () => {
+  const { routes, service, store } = setup();
+  service.saveWithDedupe({ type: "preference", title: "旧", content: "1" });
+  service.saveWithDedupe({ type: "preference", title: "中", content: "2" });
+  service.saveWithDedupe({ type: "preference", title: "新", content: "3" });
+  const setAt = (title, at) => store.db.prepare("UPDATE memories SET updated_at = ? WHERE title = ?").run(at, title);
+  setAt("旧", "2026-08-01T00:00:00.000Z");
+  setAt("中", "2026-09-01T12:00:00.000Z");
+  setAt("新", "2026-09-15T23:00:00.000Z");
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/list");
+
+  const from = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?updatedFrom=2026-09-01"), from);
+  const fromData = JSON.parse(from.body);
+  assert.equal(fromData.items.length, 2);
+  assert.equal(fromData.total, 2, "count filter matches list filter");
+  assert.deepEqual(fromData.items.map((m) => m.title).sort(), ["中", "新"]);
+
+  // date-only updatedTo 闭区间含当天全天（中 09-01T12:00 命中）
+  const range = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?updatedFrom=2026-08-01&updatedTo=2026-09-01"), range);
+  const rangeData = JSON.parse(range.body);
+  assert.equal(rangeData.items.length, 2);
+  assert.equal(rangeData.total, 2);
+
+  const to = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?updatedTo=2026-08-31"), to);
+  const toData = JSON.parse(to.body);
+  assert.equal(toData.items.length, 1);
+  assert.equal(toData.items[0].title, "旧");
+
+  // 非法日期值 → 忽略（不报错、不过滤）
+  const bad = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?updatedFrom=not-a-date&updatedTo=%E4%B9%B1"), bad);
+  const badData = JSON.parse(bad.body);
+  assert.equal(badData.items.length, 3);
+  assert.equal(badData.total, 3);
+
+  // 完整时间戳同样生效
+  const ts = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?updatedFrom=2026-09-02T00:00:00.000Z"), ts);
+  const tsData = JSON.parse(ts.body);
+  assert.equal(tsData.items.length, 1);
+  assert.equal(tsData.items[0].title, "新");
+});
+
+test("POST /api/dsh-mneme/update edits title/importance and archives", async () => {
+  const { routes, service } = setup();
+  const created = service.saveWithDedupe({ type: "preference", title: "原始", content: "原始内容" });
+  const id = created.memory.id;
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/update");
+
+  const edit = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, title: "改名", importance: 5 }), edit);
+  assert.equal(edit.statusCode, 200);
+  const row = JSON.parse(edit.body).memory;
+  assert.equal(row.title, "改名");
+  assert.equal(row.importance, 5);
+  assert.equal(row.archived, false, "archived booleanized in the response row");
+  assert.notEqual(row.updated_at, created.memory.updated_at, "updated_at advances");
+
+  const archive = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, archived: true }), archive);
+  assert.equal(archive.statusCode, 200);
+  assert.equal(JSON.parse(archive.body).memory.archived, true);
+  assert.equal(service.getById(id).archived, true);
+});
+
+test("POST /api/dsh-mneme/update archives replaced content into content_history", async () => {
+  const { routes, service } = setup();
+  const created = service.saveWithDedupe({ type: "preference", title: "历史", content: "第一版" });
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/update");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id: created.memory.id, content: "第二版" }), res);
+  assert.equal(res.statusCode, 200);
+  const row = service.getById(created.memory.id);
+  assert.equal(row.content, "第二版");
+  assert.equal(row.content_history[0].content, "第一版");
+  assert.equal(row.content_history[0].source, "human_override");
+});
+
+test("POST /api/dsh-mneme/update returns 400/404 for bad requests", async () => {
+  const { routes, service } = setup();
+  const created = service.saveWithDedupe({ type: "preference", title: "存在", content: "x" });
+  const id = created.memory.id;
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/update");
+
+  const missing = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { title: "无 id" }), missing);
+  assert.equal(missing.statusCode, 400);
+
+  const noFields = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id }), noFields);
+  assert.equal(noFields.statusCode, 400);
+
+  const emptyTitle = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, title: "   " }), emptyTitle);
+  assert.equal(emptyTitle.statusCode, 400);
+
+  const emptyContent = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, content: "" }), emptyContent);
+  assert.equal(emptyContent.statusCode, 400);
+
+  const badImportance = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, importance: 9 }), badImportance);
+  assert.equal(badImportance.statusCode, 400);
+
+  const badTags = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, tags: "x" }), badTags);
+  assert.equal(badTags.statusCode, 400);
+
+  const badArchived = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id, archived: "yes" }), badArchived);
+  assert.equal(badArchived.statusCode, 400);
+
+  const gone = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id: "no-such-id", title: "x" }), gone);
+  assert.equal(gone.statusCode, 404);
+  assert.deepEqual(JSON.parse(gone.body), { error: "not-found" });
+
+  assert.equal(service.getById(id).title, "存在", "failed writes persist nothing");
+});
+
+test("POST /api/dsh-mneme/update is token-gated", async () => {
+  const { routes } = setup(undefined, "secret-token");
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/update");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/update", "POST", { id: "x", title: "y" }), res);
+  assert.equal(res.statusCode, 401);
+});
+
+test("GET /api/dsh-mneme/memories/entities returns entities linked to a memory", async () => {
+  const { routes, service } = setup();
+  const a = service.saveWithDedupe({ type: "project", title: "A", content: "提到甲" });
+  const b = service.saveWithDedupe({ type: "project", title: "B", content: "无关" });
+  const entity = service.createEntity({ name: "甲", type: "person" });
+  // 同一记忆两次提及同一实体（两条 attr）→ 去重后只出现一次
+  service.saveAttr({ entity_id: entity.id, attr_key: "角色", attr_value: "负责人", memory_id: a.memory.id });
+  service.saveAttr({ entity_id: entity.id, attr_key: "团队", attr_value: "前端", memory_id: a.memory.id });
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/memories/entities");
+
+  const res = new FakeRes();
+  await route.handler(req(`/api/dsh-mneme/memories/entities?memoryId=${a.memory.id}`), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.equal(data.entities.length, 1, "deduped by mention");
+  assert.equal(data.entities[0].name, "甲");
+  assert.equal(data.entities[0].type, "person");
+
+  const none = new FakeRes();
+  await route.handler(req(`/api/dsh-mneme/memories/entities?memoryId=${b.memory.id}`), none);
+  assert.deepEqual(JSON.parse(none.body), { entities: [] });
+
+  const missing = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/memories/entities"), missing);
+  assert.equal(missing.statusCode, 400);
+});
+
+test("GET /api/dsh-mneme/export json carries full rows and version", async () => {
+  const { routes, service } = setup();
+  service.saveWithDedupe({ type: "preference", title: "甲", content: "内容甲" });
+  const hidden = service.saveWithDedupe({ type: "preference", title: "乙", content: "内容乙" });
+  service.setForget(hidden.memory.id, true);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/export");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/export"), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.equal(data.count, 2, "export includes forgotten rows");
+  assert.equal(data.memories.length, 2);
+  assert.equal(typeof data.version, "string", "version comes from package.json");
+  assert.ok(data.exported_at);
+  assert.equal(data.memories.every((m) => typeof m.archived === "boolean" && typeof m.forgotten === "boolean"), true);
+  const times = data.memories.map((m) => m.updated_at);
+  assert.deepEqual(times, [...times].sort().reverse(), "updated_at DESC");
+  assert.match(res.headers["Content-Disposition"], /attachment; filename="dsh-mneme-export-\d{8}\.json"/);
+});
+
+test("GET /api/dsh-mneme/export markdown feeds straight back through import", async () => {
+  const { routes, service } = setup();
+  const a = service.saveWithDedupe({ type: "preference", title: "语言", content: "中文优先" });
+  const b = service.saveWithDedupe({ type: "preference", title: "风格", content: "简洁" });
+  const exportRoute = routes.find((r) => r.path === "/api/dsh-mneme/export");
+  const importRoute = routes.find((r) => r.path === "/api/dsh-mneme/import");
+
+  const res = new FakeRes();
+  await exportRoute.handler(req("/api/dsh-mneme/export?format=markdown"), res);
+  assert.equal(res.statusCode, 200);
+  assert.match(res.headers["Content-Type"], /text\/markdown/);
+  assert.match(res.headers["Content-Disposition"], /attachment; filename="dsh-mneme-export-\d{8}\.md"/);
+  const md = res.body;
+  assert.ok(md.includes("- **ID**: `" + a.memory.id + "`"), "anchor line present (readHumanEdits-compatible)");
+
+  // 黄金用例：导出文本原样导入 → 解析出全部条目，且字段无漂移
+  const back = new FakeRes();
+  await importRoute.handler(req("/api/dsh-mneme/import", "POST", { type: "preference", markdown: md }), back);
+  assert.equal(back.statusCode, 200);
+  const data = JSON.parse(back.body);
+  assert.equal(data.type, "preference");
+  assert.ok(data.merged >= 2, "both memories parsed back");
+  assert.equal(service.getById(a.memory.id).title, "语言");
+  assert.equal(service.getById(a.memory.id).content, "中文优先");
+  assert.equal(service.getById(b.memory.id).title, "风格");
+  assert.equal(service.getById(b.memory.id).content, "简洁");
+});
+
+test("POST /api/dsh-mneme/import validates type/markdown and tolerates zero edits", async () => {
+  const { routes } = setup();
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/import");
+
+  const badType = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/import", "POST", { type: "preferences", markdown: "x" }), badType);
+  assert.equal(badType.statusCode, 400, "TYPE_FILE keys are singular, plural is rejected");
+
+  const badMd = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/import", "POST", { type: "preference", markdown: "" }), badMd);
+  assert.equal(badMd.statusCode, 400);
+
+  const zero = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/import", "POST", { type: "preference", markdown: "# 空镜像" }), zero);
+  assert.equal(zero.statusCode, 200);
+  assert.deepEqual(JSON.parse(zero.body), { merged: 0, type: "preference" });
+});
+
+test("POST /api/dsh-mneme/import is token-gated", async () => {
+  const { routes } = setup(undefined, "secret-token");
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/import");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/import", "POST", { type: "preference", markdown: "x" }), res);
+  assert.equal(res.statusCode, 401);
+});
+
+test("GET /api/dsh-mneme/dream-status returns runs and pending conflict ids", async () => {
+  const { routes, service } = setup();
+  service.saveDreamRun({ created_at: "2026-01-01T00:00:00.000Z", status: "ok", provider: "ollama", model: "qwen", snapshot_hash: "h1", input_count: 2, receipt: "r1" });
+  service.saveDreamRun({ created_at: "2026-01-02T00:00:00.000Z", status: "failed", error: "boom", snapshot_hash: "h2", input_count: 0, receipt: "r2" });
+  const pending = service.saveConflictPending({ memory_a: "aaaa", memory_b: "bbbb", reason: "矛盾" });
+
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/dream-status");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/dream-status"), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.equal(data.runs.length, 2);
+  assert.equal(data.runs[0].created_at, "2026-01-02T00:00:00.000Z", "created_at DESC");
+  assert.deepEqual(data.lastRun, data.runs[0]);
+  assert.deepEqual(Object.keys(data.lastRun).sort(), ["created_at", "error", "model", "provider", "status"]);
+  assert.equal(data.runs[0].error, "boom");
+  assert.equal(data.runs[1].provider, "ollama");
+  assert.equal(data.pendingConflicts, 1);
+  assert.deepEqual(data.pendingMemoryIds.sort(), ["aaaa", "bbbb"]);
+
+  // 解决后队列清空
+  service.resolveConflictPending(pending.id, { winner: "aaaa" });
+  const after = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/dream-status"), after);
+  const afterData = JSON.parse(after.body);
+  assert.equal(afterData.pendingConflicts, 0);
+  assert.deepEqual(afterData.pendingMemoryIds, []);
+});
+
+test("parseHumanEdits is the pure core of readHumanEdits (CRLF tolerant)", () => {
+  const digest = "0".repeat(64);
+  const text = [
+    "# x\r\n",
+    "\r\n",
+    "## 标题\r\n",
+    "\r\n",
+    "- **ID**: `m1`\n",
+    "- **类型**: preference\n",
+    "- **重要性**: 3\n",
+    "- **标签**: \n",
+    "- **更新时间**: 2026-01-01T00:00:00.000Z\n",
+    "\n",
+    `<!-- mirror-digest: ${digest} -->\n`,
+    "正文一段\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 另一条\n",
+    "\r\n",
+    "- **ID**: `m2`\n",
+    "- **类型**: preference\n",
+    "- **重要性**: 4\n",
+    "- **标签**: \n",
+    "- **更新时间**: 2026-01-02T00:00:00.000Z\n",
+    "\n",
+    "内容二\n",
+    "\n",
+    "---\n"
+  ].join("");
+  const edits = parseHumanEdits(text);
+  assert.equal(edits.length, 2);
+  assert.equal(edits[0].id, "m1");
+  assert.equal(edits[0].title, "标题");
+  assert.equal(edits[0].content, "正文一段");
+  assert.equal(edits[1].id, "m2");
+  assert.equal(edits[1].content, "内容二");
+});
+
+test("GET /api/dsh-mneme/list?archived=only lists just archived rows; default list hides them", async () => {
+  const { routes, service } = setup();
+  service.saveWithDedupe({ type: "preference", title: "在用", content: "keep" });
+  service.saveWithDedupe({ type: "project", title: "已归档", content: "gone" });
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/list");
+  const upd = routes.find((r) => r.path === "/api/dsh-mneme/update");
+
+  const def0 = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list"), def0);
+  const target = JSON.parse(def0.body).items.find((m) => m.title === "已归档");
+
+  const arch = new FakeRes();
+  await upd.handler(req("/api/dsh-mneme/update", "POST", { id: target.id, archived: true }), arch);
+  assert.equal(arch.statusCode, 200);
+
+  const def = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list"), def);
+  assert.equal(JSON.parse(def.body).total, 1, "default list hides archived rows");
+
+  const only = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?archived=only"), only);
+  const onlyData = JSON.parse(only.body);
+  assert.equal(onlyData.total, 1, "archived-only count matches rows");
+  assert.deepEqual(onlyData.items.map((m) => m.title), ["已归档"]);
+  assert.equal(onlyData.items[0].archived, true);
+
+  // 恢复（unarchive）后归档视图清空、默认列表重新可见
+  const restore = new FakeRes();
+  await upd.handler(req("/api/dsh-mneme/update", "POST", { id: target.id, archived: false }), restore);
+  assert.equal(restore.statusCode, 200);
+  const empty = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list?archived=only"), empty);
+  assert.equal(JSON.parse(empty.body).total, 0);
+  const back = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/list"), back);
+  assert.equal(JSON.parse(back.body).total, 2);
 });

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -41,71 +41,71 @@ test("memory entry registers into the sidebar foot slot", () => {
   );
 });
 
-// The drawer era is over as the PRIMARY surface: the sidebar entry must
-// activate the main-area memory library tab first. The one sanctioned
-// exception is the hero screen — the host hides the whole tab ring while a
-// session is blank, so activation legitimately fails there and the same
-// click falls back to a full-viewport overlay (same MemoryExplorer, not the
-// old 420px side drawer). A dialog role stays banned either way.
-test("tab-first activation with hero-screen overlay fallback", () => {
+// The tab era is over: the in-conversation memory tab fought the floating
+// composer and squeezed the session layout, so the library no longer
+// registers as a conversation view. The sidebar entry opens the centered
+// sheet directly — from any state, including the new-chat hero screen. A
+// dialog role stays banned either way.
+test("sidebar entry opens the sheet; conversation-view tab stays retired", () => {
   assert.equal(
     clientSource.includes("role: \"dialog\""),
     false,
     "no dialog surface should remain"
   );
   assert.ok(
-    clientSource.includes("activateExplorerTab(t(\"memory.view.label\"))"),
-    "the sidebar trigger must activate the memory library tab by its label"
+    /function openLibrary\(\) \{\s*setOverlayOpen\(true\);\s*\}/.test(clientSource),
+    "the entry must open the overlay directly (no tab activation)"
   );
-  assert.ok(
-    clientSource.includes("activateExplorerTab(t(\"memory.view.label\")).then((ok) => { if (!ok) setOpen(true); })"),
-    "a failed tab activation must open the fallback overlay"
+  assert.equal(
+    clientSource.includes('ctx.slots.inject("conversation.view"'),
+    false,
+    "the conversation.view tab must stay retired"
   );
-  assert.ok(
-    /if \(candidates\.length === 0\) \{ resolve\(false\); return; \}/.test(clientSource),
-    "activation must resolve false when the tab ring is absent (hero screen)"
-  );
-  assert.ok(
-    /aria-selected.*true/.test(clientSource),
-    "activation is only confirmed once the host marks the tab selected"
-  );
-  // Same-labelled tabs from other plugins must never be activated by mistake:
-  // the click is only trusted once OUR explorer view actually rendered, and
-  // hidden tab panes are excluded before any click happens.
-  assert.ok(
-    /querySelector\("\.mneme-x"\) !== null/.test(clientSource),
-    "activation must verify the memory explorer rendered, not just the tab state"
-  );
-  assert.ok(
-    /offsetParent === null/.test(clientSource),
-    "hidden tab panes (settings dialogs etc.) must be excluded from activation"
+  assert.equal(
+    clientSource.includes("activateExplorerTab"),
+    false,
+    "the tab-click activation machinery must be gone"
   );
 });
 
-// The fallback overlay reuses the full MemoryExplorer (three columns, graph,
-// settings) at viewport size — not the old side drawer — and closes on Esc
-// or the close button.
-test("hero fallback overlay is a full-viewport MemoryExplorer with a close affordance", () => {
+// The sheet is deliberately NOT fullscreen: a dimmed backdrop plus a rounded
+// panel capped at 1180×880 keeps the conversation visible behind it. It
+// reuses the full MemoryExplorer and closes on Esc, the close button, or a
+// backdrop click.
+test("memory library opens as a centered sheet with backdrop", () => {
   assert.ok(
-    clientSource.includes('.mneme-overlay{position:fixed;inset:0'),
-    "the overlay must cover the full viewport"
+    clientSource.includes(".mneme-backdrop{position:fixed;inset:0"),
+    "a dimmed backdrop must sit behind the sheet"
+  );
+  assert.ok(
+    /\.mneme-overlay\{position:fixed;z-index:1000;left:50%;top:50%;transform:translate\(-50%,-50%\)/.test(clientSource),
+    "the sheet must be centered, not viewport-filling"
+  );
+  assert.ok(
+    clientSource.includes("width:min(1240px,calc(100vw - 88px))"),
+    "the sheet must not occupy the full width and keeps friendly margins"
   );
   assert.ok(
     clientSource.includes('h(MemoryExplorer, { t })'),
-    "the overlay renders the same MemoryExplorer component as the tab"
+    "the sheet renders the same MemoryExplorer component"
   );
   assert.ok(
     clientSource.includes('e.key === "Escape"'),
-    "Esc must close the overlay"
+    "Esc must close the sheet"
+  );
+  assert.ok(
+    clientSource.includes('className: "mneme-backdrop"'),
+    "the backdrop is a clickable close surface"
   );
   assert.ok(
     clientSource.includes('"memory.overlay.close"'),
-    "the overlay ships a localized close label in both dictionaries"
+    "the close affordance keeps its localized label"
   );
 });
 
-// The sidebar hands each footer action only its column state: a wide row
-// (icon + label) when expanded, a bare rail icon when collapsed.
+// The sidebar hands each entry only its column state: a wide row (icon +
+// label) when expanded, a bare rail icon when collapsed — for both the
+// portalled top button and the footer fallback.
 test("trigger renders a wide row or a rail icon from the wide flag", () => {
   assert.ok(
     /wide \? "mneme-trigger" : "mneme-trigger mneme-rail"/.test(clientSource),
@@ -115,23 +115,48 @@ test("trigger renders a wide row or a rail icon from the wide flag", () => {
     /wide && h\("span", \{ className: "mneme-trigger-label" \}/.test(clientSource),
     "the label span must render only when wide"
   );
+  assert.ok(
+    /size: wide \? 15 : 18/.test(clientSource),
+    "the portalled icon must follow the native rail sizing convention"
+  );
 });
 
-// The full-width memory browser lives in the conversation view ring beside
-// Chat / Trajectory, so the client must inject into `conversation.view` with
-// a stable entry id (the active view is persisted by that id).
-test("explorer registers into the conversation view ring", () => {
+// The entry lives ABOVE the workspaces region: the real button is portalled
+// just before the host's regionArea container (below New Session, above the
+// workspace list), while the sidebar.footer.action registration remains as
+// the React anchor and the in-place fallback when the host markup changes.
+test("sidebar entry portals above the workspaces region with footer fallback", () => {
   assert.ok(
-    clientSource.includes('ctx.slots.inject("conversation.view"'),
-    "client must inject into conversation.view"
+    clientSource.includes('ctx.slots.inject("sidebar.footer.action"'),
+    "the footer slot registration must stay as anchor + fallback"
   );
   assert.ok(
-    clientSource.includes('id: "dsh-mneme-memory"'),
-    "the view entry needs a stable, unique id"
+    clientSource.includes("SidebarTopEntry"),
+    "the portalled top entry must exist"
+  );
+  assert.ok(
+    clientSource.includes(`'[class*="regionArea"]'`),
+    "the portal must anchor at the host's regionArea container"
+  );
+  assert.ok(
+    clientSource.includes("insertBefore(created, region)"),
+    "the entry must sit immediately above the workspaces region"
+  );
+  assert.ok(
+    clientSource.includes("if (!host) return fallback;"),
+    "the portal entry persists across collapse (no footer jump); footer fallback only covers portal failure"
+  );
+  assert.ok(
+    clientSource.includes('className: `${nativeCls} mneme-topentry-native`'.replace("${nativeCls} mneme-topentry-native", "${nativeCls} mneme-topentry-native")),
+    "the entry must reuse the host New-Session button class for native geometry alignment"
+  );
+  assert.ok(
+    /querySelector\('\[class\*="newSession"\]'\)/.test(clientSource),
+    "the native class must be read from the live New-Session button, not hardcoded"
   );
   assert.ok(
     clientSource.includes('"memory.view.label"'),
-    "the tab label must come from the memory.view.label dictionary key"
+    "the sheet aria-label must come from the memory.view.label dictionary key"
   );
 });
 
@@ -199,16 +224,21 @@ test("entity: search grammar offers a graph jump", () => {
   );
 });
 
-// The explorer is a three-pane layout: types with counts, a month→day time
-// tree, and a detail pane rendering the untruncated content.
+// The explorer is a card-grid / timeline browse with a right-hand detail
+// drawer: types with counts, a month→day time tree (timeline mode), and the
+// drawer rendering the untruncated content.
 test("explorer lays out types, timeline, and full-text detail", () => {
   assert.ok(
     clientSource.includes('className: "mneme-xmain"'),
     "the three-column grid must be present"
   );
   assert.ok(
-    clientSource.includes('className: "mneme-xdcontent"'),
-    "the detail pane must render the full content"
+    clientSource.includes('className: "mneme-dcontent"'),
+    "the detail drawer must render the full content"
+  );
+  assert.ok(
+    clientSource.includes('className: "mneme-cards"'),
+    "the card-grid view must exist alongside the timeline"
   );
   assert.ok(
     /toLocaleDateString\(undefined, \{ year: "numeric", month: "long" \}\)/.test(clientSource),

--- a/dsh-mneme/test/settings.test.js
+++ b/dsh-mneme/test/settings.test.js
@@ -123,3 +123,139 @@ test("external api settings persist token and merge partial writes", () => {
   assert.deepEqual(settings.getExternalApi(), { enabled: true, port: 9000, host: "0.0.0.0", token: "tok-2" });
   store.close();
 });
+
+// --- feature flags ---
+
+test("feature flags default to an empty object", () => {
+  const { store, settings } = setup();
+  assert.deepEqual(settings.getFeatureFlags(), {});
+  store.close();
+});
+
+test("setFeatureFlags rejects unknown keys and persists nothing", () => {
+  const { store, settings } = setup();
+  settings.setFeatureFlags({ autoDream: false });
+  assert.throws(() => settings.setFeatureFlags({ noSuchFlag: true }), TypeError);
+  assert.throws(() => settings.setFeatureFlags({ noSuchFlag: true }), /noSuchFlag/);
+  // 被拒的 patch 不落库，已存的合法值原样保留
+  assert.deepEqual(settings.getFeatureFlags(), { autoDream: false });
+  store.close();
+});
+
+test("setFeatureFlags enforces boolean types and integer ranges", () => {
+  const { store, settings } = setup();
+  assert.throws(() => settings.setFeatureFlags({ autoInject: "yes" }), /autoInject/);
+  assert.throws(() => settings.setFeatureFlags({ distillMaxChars: 500 }), /distillMaxChars/);
+  assert.throws(() => settings.setFeatureFlags({ distillRateLimitRetries: 1.5 }), /distillRateLimitRetries/);
+  assert.throws(() => settings.setFeatureFlags({ codingBoostFactor: 9 }), /codingBoostFactor/);
+  assert.deepEqual(settings.getFeatureFlags(), {}, "failed writes persist nothing");
+  store.close();
+});
+
+test("setFeatureFlags merges partial patches and persists across instances", () => {
+  const { store, settings } = setup();
+  settings.setFeatureFlags({ autoDream: false, distillMaxChars: 48000 });
+  settings.setFeatureFlags({ rerankEnabled: true });
+  // 同一 kv 上的新实例读回合并结果，证明已真正持久化
+  const settings2 = createSettings(store.db);
+  assert.deepEqual(settings2.getFeatureFlags(), { autoDream: false, distillMaxChars: 48000, rerankEnabled: true });
+  store.close();
+});
+
+test("getFeatureFlags drops unknown and corrupted keys from the kv", () => {
+  const { store, settings } = setup();
+  settings.setFeatureFlags({ autoInject: false });
+  // 模拟旧版本/手改残留：绕过校验直接写脏 kv
+  store.db.prepare("UPDATE user_settings SET value = ? WHERE key = ?").run(
+    JSON.stringify({ autoInject: false, legacyFlag: true, autoDream: "yes", distillMaxChars: 999999 }),
+    "feature_flags"
+  );
+  assert.deepEqual(settings.getFeatureFlags(), { autoInject: false });
+  // 整个 kv 损坏（非 JSON）→ 读回空对象而不是抛错
+  store.db.prepare("UPDATE user_settings SET value = ? WHERE key = ?").run("not-json", "feature_flags");
+  assert.deepEqual(settings.getFeatureFlags(), {});
+  store.close();
+});
+
+test("feature flags accept the new boolean, string, url and enum keys", () => {
+  const { store, settings } = setup();
+  settings.setFeatureFlags({
+    "memoryQualityFilter.enabled": false,
+    "llmAudit.enabled": false,
+    bm25SearchEnabled: false,
+    conflictFreezeEnabled: true,
+    trustEpistemicWeighting: true,
+    reflectionFailureTracking: false,
+    dreamProvider: "  siliconflow  ",
+    dreamModel: "deepseek-chat",
+    localEmbedModel: "Xenova/bge-small-zh-v1.5",
+    ollamaModel: "nomic-embed-text",
+    ollamaBaseUrl: "http://127.0.0.1:11434/",
+    embedProvider: "ollama"
+  });
+  const flags = settings.getFeatureFlags();
+  assert.equal(flags["memoryQualityFilter.enabled"], false, "nested keys stored flat");
+  assert.equal(flags["llmAudit.enabled"], false);
+  assert.equal(flags.bm25SearchEnabled, false);
+  assert.equal(flags.conflictFreezeEnabled, true);
+  assert.equal(flags.trustEpistemicWeighting, true);
+  assert.equal(flags.reflectionFailureTracking, false);
+  assert.equal(flags.dreamProvider, "siliconflow", "string values are trimmed");
+  assert.equal(flags.dreamModel, "deepseek-chat");
+  assert.equal(flags.ollamaBaseUrl, "http://127.0.0.1:11434/");
+  assert.equal(flags.embedProvider, "ollama");
+  // 同一 kv 上的新实例读回合并结果：点号键按平铺键持久化
+  const settings2 = createSettings(store.db);
+  assert.equal(settings2.getFeatureFlags()["memoryQualityFilter.enabled"], false);
+  assert.equal(settings2.getFeatureFlags().embedProvider, "ollama");
+  store.close();
+});
+
+test("nested feature flag keys are validated as booleans and rejected otherwise", () => {
+  const { store, settings } = setup();
+  assert.throws(() => settings.setFeatureFlags({ "memoryQualityFilter.enabled": "yes" }), /memoryQualityFilter\.enabled/);
+  assert.throws(() => settings.setFeatureFlags({ "llmAudit.enabled": 1 }), /llmAudit\.enabled/);
+  assert.deepEqual(settings.getFeatureFlags(), {}, "failed writes persist nothing");
+  store.close();
+});
+
+test("string feature flags: empty is legal, over-length and enum violations rejected", () => {
+  const { store, settings } = setup();
+  // 空字符串合法 = 跟随主对话模型（面板显示 placeholder）
+  settings.setFeatureFlags({ dreamProvider: "", dreamModel: "   " });
+  assert.equal(settings.getFeatureFlags().dreamProvider, "");
+  assert.equal(settings.getFeatureFlags().dreamModel, "", "whitespace-only trims to empty");
+  assert.throws(() => settings.setFeatureFlags({ dreamModel: "x".repeat(201) }), /dreamModel/);
+  assert.throws(() => settings.setFeatureFlags({ localEmbedModel: 42 }), /localEmbedModel/);
+  assert.throws(() => settings.setFeatureFlags({ embedProvider: "bogus" }), /embedProvider/);
+  assert.throws(() => settings.setFeatureFlags({ embedProvider: "OpenAI" }), /embedProvider/, "enum is case-sensitive");
+  assert.deepEqual(settings.getFeatureFlags(), { dreamProvider: "", dreamModel: "" }, "failed writes persist nothing");
+  store.close();
+});
+
+test("ollamaBaseUrl accepts empty and http(s) URLs, rejects other protocols", () => {
+  const { store, settings } = setup();
+  settings.setFeatureFlags({ ollamaBaseUrl: "" });
+  assert.equal(settings.getFeatureFlags().ollamaBaseUrl, "", "empty = follow default");
+  settings.setFeatureFlags({ ollamaBaseUrl: "  https://embed.example.com/v1  " });
+  assert.equal(settings.getFeatureFlags().ollamaBaseUrl, "https://embed.example.com/v1");
+  assert.throws(() => settings.setFeatureFlags({ ollamaBaseUrl: "ftp://localhost:11434" }), /ollamaBaseUrl/);
+  assert.throws(() => settings.setFeatureFlags({ ollamaBaseUrl: "file:///etc/passwd" }), /ollamaBaseUrl/);
+  assert.throws(() => settings.setFeatureFlags({ ollamaBaseUrl: "javascript:alert(1)" }), /ollamaBaseUrl/);
+  assert.throws(() => settings.setFeatureFlags({ ollamaBaseUrl: "localhost:11434" }), /ollamaBaseUrl/, "protocol is required");
+  assert.throws(() => settings.setFeatureFlags({ ollamaBaseUrl: "not a url" }), /ollamaBaseUrl/);
+  assert.equal(settings.getFeatureFlags().ollamaBaseUrl, "https://embed.example.com/v1", "rejected writes persist nothing");
+  store.close();
+});
+
+test("getFeatureFlags drops corrupted string, url and enum keys from the kv", () => {
+  const { store, settings } = setup();
+  settings.setFeatureFlags({ dreamModel: "m", ollamaBaseUrl: "http://localhost:11434", embedProvider: "local" });
+  // 模拟旧版本/手改残留：字符串键混入非字符串、URL 键混入非法协议、枚举越界
+  store.db.prepare("UPDATE user_settings SET value = ? WHERE key = ?").run(
+    JSON.stringify({ dreamModel: 42, ollamaBaseUrl: "ftp://bad", embedProvider: "bogus", autoInject: false }),
+    "feature_flags"
+  );
+  assert.deepEqual(settings.getFeatureFlags(), { autoInject: false });
+  store.close();
+});


### PR DESCRIPTION
## feat: 记忆库面板重设计 + 功能开关 + 交互端点

桌面端（DSH Desktop Beta）适配驱动的整批面板升级：面板从「挤在对话里的 tab」升级为独立交互页面，同时把 0.7.13/0.7.14 攒下的后端能力第一次接上前端开关。

### 侧边栏入口（对齐 DSH 原生）
- 入口从 footer 上移到**工作区上方**（新会话按钮下方）：portal 插入 regionArea 之前，sidebar.footer.action 注册保留为锚点与失效回退
- **几何对齐方案**：运行时读取宿主「新会话」按钮的实时 className 原样套用（零硬编码），wrapper `display:contents` 使按钮成为侧边栏弹性布局直接子元素——展开态与收起态（rail）都与原生图标像素级对齐，缩进动画零位移
- 撤 `conversation.view` tab：对话内嵌的面板被悬浮输入框遮挡、挤压会话布局

### 记忆库 sheet（非全屏）
- 居中 sheet（上限 1240×920，边框友好距离），背板压暗 + 圆角卡片；Esc / 点背板 / 右上 ✕ 关闭；portal 到 body 不受宿主层叠上下文裁剪
- **卡片网格 / 时间线双视图**（偏好 localStorage 记住），无限滚动两视图通用
- **筛选**：关键词/语义搜索 + 类型 + 重要性 + **时间范围**（近 7/30/90 天，`/list updatedFrom` 服务端过滤，total 同过滤）

### 详情抽屉与手动操作
- 右侧滑出抽屉：全文、来源、质量分、标签、**关联实体**（`GET /memories/entities?memoryId=`）
- **编辑**（`POST /update`，content_history 语义不变、镜像自动重渲染）、**归档**、**复制全文**、两步删除；操作提示升级为 sheet 级 toast

### 功能开关（0.7.13/0.7.14 能力首次上 UI）
- `GET/PUT /api/dsh-mneme/features`：30 键白名单（布尔/整数/字符串/URL/枚举，含 `memoryQualityFilter.enabled`、`llmAudit.enabled` 嵌套键，`ollamaBaseUrl` 协议白名单）
- 设置页分组：核心 / 记忆增强 / 巩固与睡眠 / 高级折叠（注入策略）；**巩固模型**与 **embedding 提供方**（openai/local/ollama）可配
- 启动合并优先级：用户开关 > 轻量预设 > bundle 配置
- 429 调速器参数、distillMaxChars、codingBoostFactor 按对齐结论**留在配置文件不上 UI**

### 状态页工作台（让用户看见插件在干活）
- 新增「最近巩固」「待确认冲突」卡（`GET /dream-status`）
- **工作动态流**：llm_audit 里 autoDream/autoSummarize 的每次后台调用（状态 / token / 沉淀条数）
- **沉淀的记忆**：audit 行 related_memory_ids 对照 /list 解析标题
- **已归档的记忆**：`/list?archived=only` + 一键恢复（`POST /update {archived:false}`）

### 安全与工程
- 外部 API Token 面板**默认遮蔽**（显示/隐藏切换，复制仍给完整值）
- 归档/质量分字段只在 HTTP 层补充 wire DTO——模型工具（memory_list/search）的严格输出 schema 复用 `toApiList`，不受影响
- `parseHumanEdits` 重构为纯函数（行为不变），导出 Markdown 与磁盘镜像字节同构，可被 /import 直接吃回（黄金闭环测试兜住）
- 新记忆类型 `rejected_solution` / `pitfall` / `constraint` 的标签与配色

### 测试
- 645 全绿（+28：features 30 键校验/嵌套键/枚举/URL 协议白名单、update 往返与 404/400、entities 映射、export→import 黄金闭环、dream-status、archived=only 与默认列表互斥、面板结构断言重写）
- src/lib 一致性：`check-sync.js` 25 文件通过

### 说明
- 版本号与 CHANGELOG 留给 release 提交（沿用 #73/#74 → release 合并的节奏）
- 桌面端（v2.0.5-beta.1 + claude-style-skin）实机走查通过：入口对齐、sheet、卡片、抽屉、开关、工作台

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added memory editing, archiving, export, import, and consolidation-status capabilities.
  - Added feature-flag controls with validation and configurable settings.
  - Added entity lookup for individual memories.
  - Added archived-only and date-range filtering, plus archive status and quality scores in listings.
  - Exported memory files can be downloaded as JSON or Markdown.
  - Sidebar access now opens the memory sheet directly in a centered overlay.
- **Bug Fixes**
  - Improved consistency between exported text and synchronized mirror files.
- **Tests**
  - Expanded coverage for new memory, settings, filtering, import/export, and interface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->