### PR TITLE
fix: DSH Desktop 插件树加载崩溃（v0.7.23 回归）

### DIFF
--- a/dsh-mneme/CHANGELOG.md
+++ b/dsh-mneme/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.24] - 2026-09-09
+
+## 🐛 修复
+
+- **DSH Desktop 插件树加载崩溃（v0.7.23 回归）：`cannot get property "webServer" without inject`**：v0.7.23 把 webServer 从 inject 声明中去掉想支持 headless，但 cordis 4 的 ctx 是 Proxy——**直接访问未在 inject 声明的属性会抛错而非返回 undefined**，`if (ctx.webServer)` 守卫因此失效；且去掉 inject 后 cordis 不再等待宿主 webServer 服务就绪，Windows 桌面端重启即插件树加载失败。修复两处：
+  - **恢复 webServer 到 inject 声明**：cordis 等宿主服务激活后再 apply，路由注册不落时序（回退到 v0.7.22 已知正确行为）。
+  - **apply/register 守卫改 `ctx.reflect.get`**（cordis 免 inject 读取，未提供返回 undefined 不抛错）：即使未来把 webServer 移出 inject 支持 headless，apply 也安全跳过 API 注册而不崩。
+  - **真实 cordis + dsh-host-webserver 插件本地实测**：API 路由真实注册（GET /api/dsh-mneme/list → 200 JSON）、未知路径 404 JSON、headless 无 webServer 时静默不激活。
+- **回归测试（真实 cordis Context 两种宿主形态）**：有 webServer 时插件 boot 且注册 exact 路由 / 无 webServer 时不抛错——直接覆盖本次崩溃根因，防止再犯。
+
+## 🏗️ 工程
+
+- 714 测试全绿（+2 回归测试）。
+
 ## [0.7.23] - 2026-09-09
 
 ## 🐛 修复
@@ -12,7 +26,7 @@
 
 - **skipInvalid 恢复路径全量测试补全**（12 条：逐原因跳过 + 全局闸门交互 + runDream e2e）。
 - **合法空数组 e2e**：consolidation 返回 `[]` → run ok / applied 0 / summary 照跑 / audit+receipt 记 ok。
-- **webServer 可选化**：inject 声明去掉必填 webServer（headless/无 UI 宿主兼容），API 注册改运行时守卫。
+- ~~**webServer 可选化**：inject 声明去掉必填 webServer（headless/无 UI 宿主兼容），API 注册改运行时守卫。~~ ⚠️ **失败已回退**：cordis 4 直接访问未注入属性抛错（`if (ctx.webServer)` 守卫失效）+ 去掉 inject 后 cordis 不再等待宿主 webServer 服务 → **桌面端插件树加载崩溃**，见 [0.7.24] 修复。
 - **712 测试全绿**。
 
 ## [0.7.22] - 2026-09-09

--- a/dsh-mneme/README.en.md
+++ b/dsh-mneme/README.en.md
@@ -7,7 +7,7 @@ English | [简体中文](README.md)
 [![npm version](https://img.shields.io/npm/v/@modusensus/dsh-mneme?color=blue&label=npm)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Awesome](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
-[![tests](https://img.shields.io/badge/tests-712%20passed-success)](https://github.com/modusensus/dsh-mneme)
+[![tests](https://img.shields.io/badge/tests-714%20passed-success)](https://github.com/modusensus/dsh-mneme)
 
 > A cross-session memory plugin for DeepSeek Harness: it lets the Agent remember you, remember your projects, and organize memories automatically. **Mneme** (Μνήμη) — named after Mnemosyne, the Greek goddess of memory who presides over memory and dreams, just as autoDream consolidates memories in the background.
 
@@ -166,6 +166,7 @@ Every **background LLM call** (autoDream consolidation + summary, autoSummarize 
 
 | Version | Highlights |
 |------|------|
+| **v0.7.24** | Fixed DSH Desktop plugin-tree load crash (v0.7.23 regression): cordis 4's ctx is a Proxy — accessing a property not declared in `inject` throws `cannot get property "webServer" without inject` (not `undefined`), and removing webServer from inject meant cordis no longer waited for the host service, so Desktop crashed on restart; fix: restored webServer to inject (cordis applies the plugin only after the host service is ready) + apply/register guard switched to `ctx.reflect.get` (inject-free read, returns `undefined` when absent, never throws); verified with a real cordis + dsh-host-webserver plugin (API routes 200, unknown path 404, headless silently inactive); 714 tests green |
 | **v0.7.23** | Root-caused "memory consolidation keeps failing": a legal empty decision array `[]` from consolidation is no longer treated as a failure (CONSOLIDATION_PROMPT explicitly allows "no output when nothing needs changing", so a model with a healthy, non-redundant memory legitimately returns `[]` — yet `validateDecisions` hard-rejected it as `decision list must be a non-empty array`, failing the whole run and flooding the audit with failures; **model-agnostic** — ChatGPT/Claude hit the same trap; fix: empty array short-circuits to `ok:true` no-op instead of tripping the implicit-keep coverage check). Plus: empty-body fix part 2 (`dreamMaxTokens` default 8192→32768 so thinking models don't burn the whole budget on reasoning) + skipInvalid splice residue bug (length equality ≠ content equality, skipped decisions leaked into apply/audit); 712 tests green |
 | **v0.7.22** | Restored the v0.6.9 skipInvalid tolerant-validation path (issue #89 regression, lost in the v0.7.11 rewrite): `dreamSkipInvalid` (default true) skips individual invalid decisions, applies the valid subset, and marks the run degraded; `allowCrossTypeMerge` (default false) explicitly relaxes cross-type merging — weak models (e.g. qwen3.8-flash) with jittery schema compliance no longer fail the whole batch and burn LLM calls. Strict mode and the sleep path behave unchanged; global caps/coverage floors still reject the whole run (running over cap = broken model, not minor schema drift). New `dreamMinIntervalMinutes` (0–10080, default 0 = unlimited) minimum autoDream trigger interval — failed/degraded runs also consume the interval (throttling exists to stop back-to-back failing calls); feature_flags whitelist now 34 keys; 696 tests green |
 | **v0.7.21** | Fixed autoDream/sleep effort fallback being dead code on the stream path (the catch-based retry from v0.7.16 never fired): dsh-llm rc.1 turns adapter-stage failures (incl. `UNSUPPORTED_REASONING_EFFORT`) into a terminal error finish chunk instead of a throw; `streamText` now captures the finish-chunk failure cause (`describeStreamFailure` normalizes `{code,message}`) + `withEffortFallback` gains a `getStreamError` accessor (retries without effort when rejected) + `runAuditedLlm` supports `spec.streamError` (audit `error_message` carries the real cause; `run.error` stays a stable `"llm failed"`); 688 tests green |
@@ -441,7 +442,7 @@ src/
 lib/
 ├── client.js         # Web 面板（手写 ModuleLoader bundle）
 └── *.js              # src 的同步分发产物
-test/                 # 712 node:test tests (audit + three-axis stress invariants)
+test/                 # 714 node:test tests (audit + three-axis stress invariants)
 scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压测 · sync-lib.js 同步
 ```
 
@@ -450,7 +451,7 @@ scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压
 ```bash
 cd dsh-mneme
 npm install        # 安装 peer 依赖（以 devDependencies 形式，用于本地测试）
-npm test           # 运行 712 个测试
+npm test           # 运行 714 个测试
 npm run stress     # 三轴线压测：长会话检索 / 冲突仲裁 / 多 Agent 并发（离线 mock LLM）
 npm run sync       # 把 src/ 同步到 lib/（发布时由 prepack 钩子自动执行）
 ```

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@modusensus/dsh-mneme?color=blue&label=npm)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Awesome](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
-[![tests](https://img.shields.io/badge/tests-712%20passed-success)](https://github.com/modusensus/dsh-mneme)
+[![tests](https://img.shields.io/badge/tests-714%20passed-success)](https://github.com/modusensus/dsh-mneme)
 [![CI](https://img.shields.io/github/actions/workflow/status/modusensus/dsh-mneme/ci.yml)](https://github.com/modusensus/dsh-mneme/actions)
 [![node](https://img.shields.io/badge/node-24%2B-blue)](https://nodejs.org)
 [![npm downloads](https://img.shields.io/npm/dm/@modusensus/dsh-mneme?color=blue&label=downloads)](https://www.npmjs.com/package/@modusensus/dsh-mneme)
@@ -207,6 +207,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 | 版本 | 亮点 |
 |------|------|
+| **v0.7.24** | 修复 DSH Desktop 插件树加载崩溃（v0.7.23 回归）：cordis 4 的 ctx 是 Proxy，访问未在 inject 声明的 `webServer` 会抛 `cannot get property without inject`（而非返回 undefined），且去掉 inject 后 cordis 不再等待宿主服务 → 桌面端重启即崩；修复：恢复 webServer 到 inject（cordis 等宿主就绪再 apply）+ apply/register 守卫改 `ctx.reflect.get`（免 inject 读取、未提供返回 undefined 不抛错）；真实 cordis + dsh-host-webserver 插件实测；714 测试全绿 |
 | **v0.7.23** | 记忆沉淀「反复失败」根治：consolidation 合法空数组 `[]` 不再误判 failed（CONSOLIDATION_PROMPT 允许「无问题无需输出」，模型无冗余时合法返回 `[]`——此前 `validateDecisions` 硬判 non-empty → 整单 failed、审计反复失败，且与模型无关，ChatGPT/Claude 同样踩中；修复：空数组显式短路 `ok:true` no-op）+ 空体修复第二段（`dreamMaxTokens` 默认 8192→32768，思考模型推理烧光预算的根治余量，设置面板可调）+ skipInvalid splice 残留 bug（长度相等≠内容一致，被跳决策残留）；712 测试全绿 |
 | **v0.7.22** | 恢复 v0.6.9 的 skipInvalid 宽容校验路径（issue #89 回归，v0.7.11 重写丢失）：`dreamSkipInvalid`（默认 true）单条非法决策跳过 + 合法子集应用 + run 记 degraded，`allowCrossTypeMerge`（默认 false）显式放宽跨类型合并——弱模型（如 qwen3.8-flash）决策合规抖动不再整单拒绝白烧 LLM 调用；严格模式/sleep 路径行为不变，全局上限/覆盖率下限仍整单拒绝（刷爆上限=模型坏了，非轻微 schema 漂移）；新增 `dreamMinIntervalMinutes`（0-10080，默认 0=不限）autoDream 最小触发间隔，失败/degraded run 也占用间隔（节流防失败调用连发）；feature_flags 白名单 34 键；696 测试全绿 |
 | **v0.7.21** | 修复 autoDream/sleep 的 effort 回退在流式路径失效（v0.7.16 的 catch 式回退是死代码）：dsh-llm rc.1 把 adapter 阶段异常（含 `UNSUPPORTED_REASONING_EFFORT`）转成终态 error finish chunk 不再抛出；`streamText` 现捕获 finish-chunk 失败原因（新增 `describeStreamFailure` 归一化 `{code,message}`）+ `withEffortFallback` 增加 `getStreamError` 访问器（effort 被拒时去掉重试一次）+ `runAuditedLlm` 支持 `spec.streamError`（audit 行 `error_message` 携带真实原因，`run.error` 稳定 `"llm failed"` 不变）；688 测试全绿 |
@@ -293,6 +294,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 | **v0.7.18** | ✅ 完成 | 生态第一步 + 查询收敛 | better-sidebar 软集成（inject 声明 + optional peer `dsh-better-sidebar` + registerTab 复用四视图，未装安全跳过；窄容器 `@container` 适配）+ `/list?deposited=only` 沉淀视图（receipt_chain ∪ source=dream）+ 记忆库沉淀/已归档筛选 chip + 状态页仪表盘化（统计 + 查看全部跳转预置筛选）+ 抽屉归档记忆「恢复」；667 测试全绿 |
 | **v0.7.20** | ✅ 完成 | heat 回归 + 阶段二前端 + better-sidebar 修复 | heat 热度模型完整找回（issue #87，v0.7.10 移植：幂律衰减 + TYPE_DECAY + sleep 热联合双保护 + 实体热投影）+ 验收清单落地（heatEnabled 默认关 / feature_flags 31 键 / lightMode 联动 / sleep 降级审计暴露 / updated_at⊥last_accessed_at 契约）+ 阶段二前端（/list heat 投影、HeatBadge 三档、order=heat 页内排序）+ better-sidebar 修复（issue #88：内层动态子插件）；685 测试全绿 |
 | **v0.7.21** | ✅ 完成 | effort 回退流式修复 | autoDream/sleep 的 catch 式 effort 回退在流式路径是死代码（dsh-llm rc.1 把 adapter 异常转成终态 error finish chunk 不再抛出）→ `streamText` 捕获 finish-chunk 失败原因（`describeStreamFailure` 归一化）+ `withEffortFallback` 增加 `getStreamError` 访问器（effort 被拒去重试）+ `runAuditedLlm` 支持 `spec.streamError`（audit 记真实原因）；688 测试全绿 |
+| **v0.7.24** | ✅ 完成 | 桌面端崩溃紧急修复 | v0.7.23 把 webServer 移出 inject 致 cordis Proxy 抛 `cannot get property "webServer" without inject`（未注入属性直接访问抛错而非 undefined），桌面端重启插件树加载失败；修复：恢复 webServer 到 inject（cordis 等宿主就绪再 apply）+ apply/register 守卫改 `ctx.reflect.get`（免 inject 读取、未提供返回 undefined 不抛错，未来 headless 移出 inject 也安全）；真实 cordis + dsh-host-webserver 实测 API 路由 200 / 未知路径 404 / headless 静默不激活；714 测试全绿 |
 | **v0.7.23** | ✅ 完成 | 记忆沉淀「反复失败」根治 + 空体第二段 + skipInvalid splice 修复 | consolidation 合法空数组 `[]` no-op（CONSOLIDATION_PROMPT 允许无问题无需输出；此前 validateDecisions 硬判 non-empty → 整单 failed，模型无关、ChatGPT/Claude 同样踩中；修复：空数组显式短路 ok，不再触发隐式 keep 覆盖率误判）；`dreamMaxTokens` 默认 8192→32768（思考模型推理烧光预算根治余量）；skipInvalid splice 残留 bug（长度相等≠内容一致，被跳决策残留进 apply）；712 测试全绿 |
 | **v0.7.22** | ✅ 完成 | skipInvalid 宽容校验回归（issue #89）+ autoDream 节流 | 恢复 v0.6.9 的 skipInvalid 双轨结构（v0.7.11 重写丢失）：`dreamSkipInvalid` 单条非法决策跳过 + 合法子集应用 + run 记 degraded，`allowCrossTypeMerge` 显式放宽跨类型合并；弱模型（qwen3.8-flash）决策合规抖动不再整单拒绝；新增 `dreamMinIntervalMinutes`（0-10080，默认 0=不限）最小触发间隔，失败/degraded run 也占用间隔；严格模式/sleep 路径行为不变；feature_flags 白名单 34 键；696 测试全绿 |
 | **v0.8.0** | 🚧 计划中（9 月末） | 图谱增强 | 兴趣漂移可视化 + scope 隔离（issue #17）+ 跨 workspace 记忆共享 |
@@ -529,7 +531,7 @@ src/
 ├── api.js            # HTTP 路由（Web 面板数据通道）
 └── index.js          # 插件接线
 lib/                  # src 的同步分发产物（npm run sync；发布前由 root prepack 的 check-sync.js 校验一致性；唯一手写例外 lib/client.js——Web 面板 bundle，sync 不覆盖）
-test/                 # 712 个 node:test 测试（审计与三轴线压测不变量；src↔lib 一致性由 scripts/check-sync.js 发布闸门校验）
+test/                 # 714 个 node:test 测试（审计与三轴线压测不变量；src↔lib 一致性由 scripts/check-sync.js 发布闸门校验）
 scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压测 · sync-lib.js 同步 · check-sync.js 发布闸门 · benchmark-recall.js 召回基准
 ```
 
@@ -538,7 +540,7 @@ scripts/              # e2e-dsh.js 端到端演示 · stress-dsh.js 三轴线压
 ```bash
 cd dsh-mneme
 npm install        # 安装 peer 依赖（以 devDependencies 形式，用于本地测试）
-npm test           # 运行 712 个测试
+npm test           # 运行 714 个测试
 npm run stress     # 三轴线压测：长会话检索 / 冲突仲裁 / 多 Agent 并发（离线 mock LLM）
 npm run sync       # 把 src/ 同步到 lib/（发布时由 prepack 钩子自动执行）
 ```

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -98,6 +98,14 @@ function parseBody(text) {
 export function createApi(ctx, service, settings, commands, embedder, semantic = null, apiToken = "", config = null) {
   const disposers = [];
 
+  // webServer 在 index.js 的 inject 声明中（cordis 等宿主服务就绪后 apply），
+  // 这里做防御性读取：cordis ctx 的 Proxy 不允许直接访问未 inject 的属性
+  // （会抛 "cannot get property without inject"），用 ctx.reflect.get 免
+  // inject 读取（未提供返回 undefined）；对象字面量 mock ctx（测试）没有
+  // reflect，退回直接属性访问。createApi 只在有 webServer 时被调用（index.js
+  // 守卫 + 测试 mock），故下方 register 用之非空。
+  const webServer = typeof ctx.reflect?.get === "function" ? ctx.reflect.get("webServer") : ctx.webServer;
+
   // feature flags 快照（GET/PUT 共用）：overrides 是持久化的用户显式覆盖；
   // effective 是启动配置在白名单键上被 overrides 覆盖后的最终值。config 缺席
   // （旧调用方直连、未传 cfg）时只报被覆盖的键，不把不存在的默认值编造给前端。
@@ -140,7 +148,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   }
 
   const register = (route) => {
-    disposers.push(ctx.webServer.register(route));
+    disposers.push(webServer.register(route));
   };
 
   // /api/dsh-mneme prefix fallback → 404 JSON for unknown sub-paths

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -21,10 +21,13 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 export const name = "dsh-mneme";
-// webServer 为可选依赖（headless/无 UI 宿主兼容）：从 inject 声明中去掉，cordis
-// 不再等待它激活；运行时 ctx.webServer 为空则跳过 API 注册（下方 if 守卫），
-// 记忆工具/注入/dream 全部照常工作。
-export const inject = ["tools", "systemPrompt", "llm", "agentDefaultModel", "commands"];
+// webServer 在 inject 声明中：cordis 会等宿主 webServer 服务激活后才 apply 本
+// 插件，保证 apply 时路由注册不落时序（v0.7.23 曾移出 inject 想支持 headless，
+// 结果 cordis 不再等待，apply 时宿主 webServer 未就绪 → 桌面端 "cannot get
+// property without inject" 崩溃）。守卫用 ctx.reflect.get（免 inject 读取，
+// 未提供返回 undefined）而非 if (ctx.webServer)：直接访问未注入属性在 cordis
+// Proxy 下会抛错而非返回 undefined。
+export const inject = ["tools", "systemPrompt", "llm", "agentDefaultModel", "commands", "webServer"];
 export { Config };
 
 // Arrow (not function declaration): cordis 4 treats any apply with a
@@ -362,7 +365,14 @@ export const apply = (ctx, config) => {
   const summarizer = createSummarizer(ctx, service, cfg);
   disposers.push(summarizer.dispose);
 
-  if (ctx.webServer) {
+  // webServer 可选依赖：cordis 4 的 ctx 是 Proxy，直接访问未在 inject 声明的
+  // 属性会抛 "cannot get property without inject"（不会返回 undefined），所以
+  // 不能用 if (ctx.webServer) 守卫。ctx.reflect.get 是 cordis 提供的免 inject
+  // 读取（未提供时返回 undefined）；对象字面量 mock ctx（测试）没有 reflect，
+  // 退回直接属性访问。headless/无 UI 宿主无 webServer 时跳过 API 注册，其余
+  // 功能（工具/注入/dream）照常。
+  const webServer = typeof ctx.reflect?.get === "function" ? ctx.reflect.get("webServer") : ctx.webServer;
+  if (webServer) {
     const api = createApi(ctx, service, settings, commands ?? {
       add: () => { throw new Error("commands unavailable"); },
       remove: () => false,

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.23",
+      "version": "0.7.24",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -98,6 +98,14 @@ function parseBody(text) {
 export function createApi(ctx, service, settings, commands, embedder, semantic = null, apiToken = "", config = null) {
   const disposers = [];
 
+  // webServer 在 index.js 的 inject 声明中（cordis 等宿主服务就绪后 apply），
+  // 这里做防御性读取：cordis ctx 的 Proxy 不允许直接访问未 inject 的属性
+  // （会抛 "cannot get property without inject"），用 ctx.reflect.get 免
+  // inject 读取（未提供返回 undefined）；对象字面量 mock ctx（测试）没有
+  // reflect，退回直接属性访问。createApi 只在有 webServer 时被调用（index.js
+  // 守卫 + 测试 mock），故下方 register 用之非空。
+  const webServer = typeof ctx.reflect?.get === "function" ? ctx.reflect.get("webServer") : ctx.webServer;
+
   // feature flags 快照（GET/PUT 共用）：overrides 是持久化的用户显式覆盖；
   // effective 是启动配置在白名单键上被 overrides 覆盖后的最终值。config 缺席
   // （旧调用方直连、未传 cfg）时只报被覆盖的键，不把不存在的默认值编造给前端。
@@ -140,7 +148,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   }
 
   const register = (route) => {
-    disposers.push(ctx.webServer.register(route));
+    disposers.push(webServer.register(route));
   };
 
   // /api/dsh-mneme prefix fallback → 404 JSON for unknown sub-paths

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -21,10 +21,13 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 export const name = "dsh-mneme";
-// webServer 为可选依赖（headless/无 UI 宿主兼容）：从 inject 声明中去掉，cordis
-// 不再等待它激活；运行时 ctx.webServer 为空则跳过 API 注册（下方 if 守卫），
-// 记忆工具/注入/dream 全部照常工作。
-export const inject = ["tools", "systemPrompt", "llm", "agentDefaultModel", "commands"];
+// webServer 在 inject 声明中：cordis 会等宿主 webServer 服务激活后才 apply 本
+// 插件，保证 apply 时路由注册不落时序（v0.7.23 曾移出 inject 想支持 headless，
+// 结果 cordis 不再等待，apply 时宿主 webServer 未就绪 → 桌面端 "cannot get
+// property without inject" 崩溃）。守卫用 ctx.reflect.get（免 inject 读取，
+// 未提供返回 undefined）而非 if (ctx.webServer)：直接访问未注入属性在 cordis
+// Proxy 下会抛错而非返回 undefined。
+export const inject = ["tools", "systemPrompt", "llm", "agentDefaultModel", "commands", "webServer"];
 export { Config };
 
 // Arrow (not function declaration): cordis 4 treats any apply with a
@@ -362,7 +365,14 @@ export const apply = (ctx, config) => {
   const summarizer = createSummarizer(ctx, service, cfg);
   disposers.push(summarizer.dispose);
 
-  if (ctx.webServer) {
+  // webServer 可选依赖：cordis 4 的 ctx 是 Proxy，直接访问未在 inject 声明的
+  // 属性会抛 "cannot get property without inject"（不会返回 undefined），所以
+  // 不能用 if (ctx.webServer) 守卫。ctx.reflect.get 是 cordis 提供的免 inject
+  // 读取（未提供时返回 undefined）；对象字面量 mock ctx（测试）没有 reflect，
+  // 退回直接属性访问。headless/无 UI 宿主无 webServer 时跳过 API 注册，其余
+  // 功能（工具/注入/dream）照常。
+  const webServer = typeof ctx.reflect?.get === "function" ? ctx.reflect.get("webServer") : ctx.webServer;
+  if (webServer) {
     const api = createApi(ctx, service, settings, commands ?? {
       add: () => { throw new Error("commands unavailable"); },
       remove: () => false,

--- a/dsh-mneme/test/webServer-optional.test.js
+++ b/dsh-mneme/test/webServer-optional.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Context } from "@deepseek-ai/cordis";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as mneme from "../lib/index.js";
+
+// webServer 可选依赖回归（v0.7.24 修复）：v0.7.23 曾把 webServer 从 inject 声明
+// 中去掉想支持 headless，但 apply 里 `if (ctx.webServer)` 在 cordis 4 的 Proxy
+// 下访问未注入属性会抛 "cannot get property without inject"（不会返回
+// undefined），桌面端插件树直接加载失败。本测试用真实 cordis Context 复现两种
+// 宿主形态，守住「有 webServer 时注册 API 路由 / 无 webServer 时不崩」两条底线。
+//
+// 修复后 webServer 保留在 inject（cordis 等待宿主服务就绪后再 apply，路由注册
+// 不落时序），apply 守卫用 ctx.reflect.get 而非直接属性访问。headless 宿主
+// 缺 webServer 时 fiber 静默不激活（与 v0.7.22 一致），不抛错。
+
+function buildHost(withWebServer) {
+  const ctx = new Context();
+  const apiRoutes = [];
+  ctx.provide("tools", { register() { return () => {}; } });
+  ctx.provide("commands", { register() { return () => {}; } });
+  ctx.provide("systemPrompt", { context() { return () => {}; } });
+  ctx.provide("agentDefaultModel", { currentSelection() { return { provider: "mock", model: "mock" }; } });
+  ctx.provide("llm", {
+    async *stream() { yield { type: "finish", reason: { kind: "stop" } }; }
+  });
+  if (withWebServer) {
+    ctx.provide("webServer", { register(route) { apiRoutes.push(route); return () => {}; } });
+  }
+  return { ctx, apiRoutes };
+}
+
+test("desktop host (webServer present): plugin boots and registers API routes", async () => {
+  const { ctx, apiRoutes } = buildHost(true);
+  const fiber = ctx.plugin(mneme, { memoryDir: mkdtempSync(join(tmpdir(), "mneme-desk-")) });
+  await fiber;
+  assert.ok(apiRoutes.length > 0, "webServer routes must be registered on desktop");
+  assert.ok(apiRoutes.some((r) => r.kind === "exact"), "expect exact routes, got: " + apiRoutes.map((r) => r.kind).join(","));
+});
+
+test("headless host (no webServer): plugin must not throw", async () => {
+  const { ctx } = buildHost(false);
+  const fiber = ctx.plugin(mneme, { memoryDir: mkdtempSync(join(tmpdir(), "mneme-head-")) });
+  // INACTIVE fiber 静默等待依赖，fiber promise 不会 reject；只要不抛错即为通过。
+  await fiber;
+  assert.ok(true, "headless load must not throw");
+});


### PR DESCRIPTION
## 修复内容

v0.7.23 的「webServer 可选化」导致 DSH Desktop 插件树加载崩溃（Windows 重启即报 `cannot get property "webServer" without inject`）。

**根因**：cordis 4 的 ctx 是 Proxy——直接访问未在 inject 声明的属性会**抛错**而非返回 undefined，`if (ctx.webServer)` 守卫失效；且去掉 inject 后 cordis 不再等待宿主 webServer 服务就绪，apply 时服务未提供即崩。

**修复**：
- 恢复 `webServer` 到 inject 声明（cordis 等宿主服务就绪后再 apply，路由注册不落时序）
- apply/register 守卫改 `ctx.reflect.get`（免 inject 读取、未提供返回 undefined 不抛错，未来 headless 移出 inject 也安全）

**验证**：
- 真实 cordis + `dsh-host-webserver` 插件本地实测：`GET /api/dsh-mneme/list` → 200 JSON、未知路径 → 404 JSON、headless 无 webServer → 静默不激活
- 新增 `test/webServer-optional.test.js` 回归测试（真实 cordis 两种宿主形态）
- 714 测试全绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash that prevented the DSH Desktop plugin tree from loading.
  - Improved plugin startup when the host web server is unavailable, preventing unexpected errors in headless environments.
  - Restored reliable API route registration when a web server is present.

- **Documentation**
  - Added v0.7.24 release information and updated documented test counts.

- **Tests**
  - Added regression coverage for desktop and headless plugin startup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->