### PR TITLE
fix: improve DSH plugin compatibility (tool dedupe, API port retry, client inject, better-sidebar)

### DIFF
--- a/dsh-mneme/README.en.md
+++ b/dsh-mneme/README.en.md
@@ -66,7 +66,14 @@ The default `32768` reserves headroom for reasoning models, where reasoning alon
 | Medium (10k–50k chars) | `65536` |
 | Large (>50k chars) | `131072` (cap) |
 
-> With **reasoning models** (e.g. DeepSeek-R1-like), the model may spend the entire budget on reasoning and return an empty body (the log shows `no json array in llm output`). Resolution order: ① set `dreamReasoningEffort` to `low` to suppress reasoning overhead (when the provider rejects the parameter it is stripped automatically and retried once — the rejection reason lands in `llm_audit`; some models, e.g. v4-flash-ga, reject every effort tier); ② if the retry still returns an empty body under the model's default reasoning behavior, raise `dreamMaxTokens` (reasoning and body share this budget) or route `dreamProvider`/`dreamModel` to a non-reasoning model. The sleep side has the corresponding `sleepReasoningEffort`.
+> With **reasoning models** (e.g. DeepSeek-R1-like), the model may spend the entire budget on reasoning and return an empty body (the log shows `no json array in llm output`). Resolution order: ① set `dreamReasoningEffort` to `low` to suppress reasoning overhead (when the provider rejects the parameter it is stripped automatically and retried once — the rejection reason lands in `llm_audit`); ② if the retry still returns an empty body under the model's default reasoning behavior, raise `dreamMaxTokens` (reasoning and body share this budget) or route `dreamProvider`/`dreamModel` to a non-reasoning model. The sleep side has the corresponding `sleepReasoningEffort`.
+
+**Consolidation model classification** (settings panel "consolidation model" = `dreamProvider`/`dreamModel`; sleep side: `sleepProvider`/`sleepModel`):
+
+| Model kind | Examples | Notes |
+|-----------|----------|-------|
+| **Non-reasoning (recommended)** | glm-5-2-class | No reasoning declaration; even if an effort is configured and the harness rejects it, the fallback strips the field and the retry succeeds. Lowest risk of empty-body runs |
+| **Reasoning (test first)** | deepseek-v4-flash-ga and other v4-flash-ga family | Reasons by default and may burn the whole token budget on an empty body; some SKUs (e.g. v4-flash-ga) are additionally declared by the harness as accepting **no reasoning effort at all** — the no-effort retry still gets rejected through the harness `defaultEffort` (`UNSUPPORTED_REASONING_EFFORT`), which the plugin fallback cannot bypass. If you use one, set `dreamReasoningEffort` and test; switch to a non-reasoning model otherwise |
 
 ### Sleep Mode: System-Level Sleep 💤 (v0.4.0, opt-in)
 

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -89,7 +89,14 @@ dsh web
 | 中等（1 万-5 万字） | `65536` |
 | 大型（5 万字以上） | `131072`（上限） |
 
-> 若使用**思考型模型**（如 deepseek-v4-flash / DeepSeek-R1 类），模型可能把全部预算花在 reasoning 上导致正文为空（日志出现 `no json array in llm output`）。处理顺序：① 把 `dreamReasoningEffort` 设为 `low` 显式压低思考（被方舟拒绝该参数时自动去掉重试一次，拒绝原因会记入 llm_audit——部分模型如 v4-flash-ga 不支持任何 effort 档位）；② 重试走模型默认思考行为后正文仍为空的，调大 `dreamMaxTokens`（reasoning 与正文共享该预算）或配置 `dreamProvider`/`dreamModel` 指向非思考模型。sleep 侧对应 `sleepReasoningEffort`。
+> 若使用**思考型模型**（如 deepseek-v4-flash / DeepSeek-R1 类），模型可能把全部预算花在 reasoning 上导致正文为空（日志出现 `no json array in llm output`）。处理顺序：① 把 `dreamReasoningEffort` 设为 `low` 显式压低思考（被方舟拒绝该参数时自动去掉重试一次，拒绝原因会记入 llm_audit）；② 重试走模型默认思考行为后正文仍为空的，调大 `dreamMaxTokens`（reasoning 与正文共享该预算）或配置 `dreamProvider`/`dreamModel` 指向非思考模型。sleep 侧对应 `sleepReasoningEffort`。
+
+**巩固模型分类声明**（settings panel「巩固模型」= `dreamProvider`/`dreamModel`，睡眠侧对应 `sleepProvider`/`sleepModel`）：
+
+| 模型类别 | 例子 | 说明 |
+|---------|------|------|
+| **非思考模型（推荐）** | glm-5-2 类等 | 无 reasoning 声明；即使配了 effort 被 harness 拒绝，fallback 去掉字段重试即成功。空体风险最低 |
+| **思考模型（需实测）** | deepseek-v4-flash-ga 等 v4-flash-ga 系 | 默认开推理，可能烧光 token 预算返回空体；且部分型号（如 v4-flash-ga）在 harness 侧被声明为**不接受任何 reasoning effort** —— 去掉 effort 重试时 harness 的 `defaultEffort` 仍会顶上来再次拒绝（`UNSUPPORTED_REASONING_EFFORT`），插件侧 fallback 无法绕开。选用时建议配 `dreamReasoningEffort` 实测，不行就换非思考模型 |
 
 ### Sleep Mode 系统级睡眠 💤（v0.4.0，opt-in）
 

--- a/dsh-mneme/lib/api-standalone.js
+++ b/dsh-mneme/lib/api-standalone.js
@@ -16,6 +16,46 @@ const DEFAULT_HOST = "127.0.0.1";
 // Hardcoded release version (package.json is bumped at publish time and may
 // lag the code that ships in between).
 const VERSION = "0.7.12";
+const MAX_PORT_ATTEMPTS = 20;
+
+/**
+ * Listen with automatic EADDRINUSE recovery. Tries the configured port, then
+ * the next MAX_PORT_ATTEMPTS-1 ports, and finally falls back to port 0 so the
+ * OS assigns a free port. Multiple DSH profiles/instances sharing the default
+ * port no longer leave the standalone API permanently unavailable.
+ */
+function listenWithRetry(server, startPort, host, logger) {
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+    const tryListen = (port) => {
+      const onListening = () => {
+        server.off("error", onError);
+        const address = server.address();
+        resolve(address && typeof address === "object" ? address.port : port);
+      };
+      const onError = (error) => {
+        server.off("listening", onListening);
+        if (error?.code === "EADDRINUSE" && attempt < MAX_PORT_ATTEMPTS - 1) {
+          attempt++;
+          const next = startPort + attempt;
+          logger?.warn?.(`[dsh-mneme] standalone API port ${port} in use, retrying ${next}`);
+          tryListen(next);
+          return;
+        }
+        if (error?.code === "EADDRINUSE") {
+          logger?.warn?.(`[dsh-mneme] standalone API port ${port} still in use, falling back to OS-assigned port`);
+          tryListen(0);
+          return;
+        }
+        reject(error);
+      };
+      server.once("listening", onListening);
+      server.once("error", onError);
+      server.listen(port, host);
+    };
+    tryListen(startPort);
+  });
+}
 
 function sendJson(res, status, payload) {
   res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
@@ -243,10 +283,10 @@ export function createStandaloneApi({ service, store, config = {}, logger, setti
     logger?.warn?.(`[dsh-mneme] standalone API error: ${String(error)}`);
   });
   const ready = new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
+    // listening handled by listenWithRetry
+    listenWithRetry(server, boundPort, boundHost, logger).then(resolve, reject);
   });
-  server.listen(boundPort, boundHost);
+  // server.listen is called inside listenWithRetry
   ready.then(() => {
     const address = server.address();
     if (address && typeof address === "object") {

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -3610,9 +3610,14 @@ window.__ModuleLoader__.load({
                 if (dead) return;
                 const reg = bsCtx.betterSidebar;
                 if (!reg || typeof reg.registerTab !== "function") return;
+                  const TAB_ID = "dsh-mneme:memory";
+                  if (typeof reg.getTab === "function" && reg.getTab(TAB_ID)) {
+                    console.warn(`[dsh-mneme] better-sidebar tab "${TAB_ID}" already registered, skipping duplicate`);
+                    return;
+                  }
                 try {
                   reg.registerTab({
-                    id: "dsh-mneme:memory",
+                    id: TAB_ID,
                     title: () => t("memory.view.label"),
                     icon: (size) => h(IconArchiveOutline20, { size }),
                     order: 60,
@@ -3620,7 +3625,7 @@ window.__ModuleLoader__.load({
                   });
                 } catch (err) {
                   // id 重复等注册失败不应拖垮其余功能，留一条线索即可
-                  console.error("[dsh-mneme] better-sidebar registerTab failed:", err);
+                  console.warn("[dsh-mneme] better-sidebar registerTab failed, falling back to native sidebar entry:", err);
                 }
               }, "dsh-mneme: better-sidebar tab");
             }

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -52,6 +52,16 @@ export const Config = z.object({
   // 起算，失败/degraded 的 run 也占用间隔；间隔内的触发请求静默跳过，下一次
   // 写入事件会重新评估。
   dreamMinIntervalMinutes: z.natural().min(0).max(10080).default(0),
+  // 巩固模型路由（settings panel「巩固模型」/ dreamProvider+dreamModel）：
+  // dream 的记忆沉淀专用 LLM 路由，显式配置优先于 agent 默认模型（config-first，
+  // Issue #25）。模型分类声明：
+  //   - 非思考模型（推荐，如 glm-5-2 类）：无 reasoning 声明，effort 请求被 harness
+  //     拒绝后 withEffortFallback 去掉字段重试即成功；空体/no json array 风险最低。
+  //   - 思考模型（如 deepseek-v4-flash-ga 等 v4-flash-ga 系）：默认开推理，可能烧光
+  //     token 预算返回空体；且部分（如 v4-flash-ga）在 harness 侧被声明为不接受任何
+  //     reasoning effort —— 即使去掉 effort 重试，harness 的 defaultEffort 也会顶上来
+  //     再次拒绝（UNSUPPORTED_REASONING_EFFORT），插件 fallback 无法绕开。
+  //     选用时建议配 dreamReasoningEffort 并实测；不行就换非思考模型。
   dreamProvider: z.string(),
   dreamModel: z.string(),
   dreamMaxTokens: z.natural().min(256).max(131072).default(32768),
@@ -60,6 +70,9 @@ export const Config = z.object({
   // are forwarded verbatim. Useful to cap reasoning spend on thinking-type
   // models that would otherwise drain the whole token budget and return an
   // empty body ("no json array in llm output").
+  // Caveat: on some thinking models (e.g. v4-flash-ga) the harness declares NO
+  // supported effort, so even the fallback retry (field stripped) is rejected
+  // again via its defaultEffort — prefer a non-reasoning dreamProvider/dreamModel.
   dreamReasoningEffort: z.union([
     z.const("low"),
     z.const("medium"),

--- a/dsh-mneme/lib/tools.js
+++ b/dsh-mneme/lib/tools.js
@@ -22,12 +22,6 @@ const MEMORY_ITEM_SCHEMA = {
     source: { type: "string" },
     created_at: { type: "string", required: true },
     updated_at: { type: "string", required: true }
-  /* const toolsRegistry = ctx.tools;
-  let registeredTools = REGISTERED_TOOLS.get(toolsRegistry);
-  if (!registeredTools) {
-    registeredTools = new Set();
-    REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
-  */
   }
 };
 

--- a/dsh-mneme/lib/tools.js
+++ b/dsh-mneme/lib/tools.js
@@ -1,6 +1,10 @@
 import { defineTool } from "@deepseek-ai/dsh-tools";
 
 const TEXT_OUTPUT = (text) => [{ type: "text", text }];
+// Per-registry tool-name registry: guards against duplicate registration on
+// live patch reload (DSH Desktop `patchReload: "live"`) where a plugin may be
+// re-applied on the same tools registry without an intervening unregister.
+const REGISTERED_TOOLS = new WeakMap();
 
 // Wire shape emitted by service.toApiList: shared by memory_search and
 // memory_list so their output schemas always declare every key the runtime
@@ -18,10 +22,22 @@ const MEMORY_ITEM_SCHEMA = {
     source: { type: "string" },
     created_at: { type: "string", required: true },
     updated_at: { type: "string", required: true }
+  /* const toolsRegistry = ctx.tools;
+  let registeredTools = REGISTERED_TOOLS.get(toolsRegistry);
+  if (!registeredTools) {
+    registeredTools = new Set();
+    REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
+  */
   }
 };
 
 export function createTools(ctx, service, config, embedder) {
+  const toolsRegistry = ctx.tools;
+  let registeredTools = REGISTERED_TOOLS.get(toolsRegistry);
+  if (!registeredTools) {
+    registeredTools = new Set();
+    REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
+  }
   const tools = [
     defineTool({
       name: "memory_save",
@@ -82,7 +98,18 @@ export function createTools(ctx, service, config, embedder) {
             }
           }
         },
-        render: (_args, value) => TEXT_OUTPUT(`Found ${value.items.length} memory entr${value.items.length === 1 ? "y" : "ies"}.`)
+        render: (_args, value) => {
+          const items = value.items ?? [];
+          if (items.length === 0) return TEXT_OUTPUT("No memory entries found.");
+          const body = items
+            .map((m, i) => {
+              const preview = (m.content ?? "").replace(/\s+/g, " ").trim();
+              const cut = preview.length > 200 ? `${preview.slice(0, 200)}…` : preview;
+              return `[${i + 1}] ${m.title}\n    ID: ${m.id} | type: ${m.type} | importance: ${m.importance} | updated: ${m.updated_at}\n    ${cut}`;
+            })
+            .join("\n\n");
+          return TEXT_OUTPUT(`Found ${items.length} memory entr${items.length === 1 ? "y" : "ies"}:\n\n${body}`);
+        }
       },
       async execute(args) {
         const limit = args.limit ?? 20;
@@ -117,7 +144,14 @@ export function createTools(ctx, service, config, embedder) {
             total: { type: "integer", required: true }
           }
         },
-        render: (_args, value) => TEXT_OUTPUT(`${value.items.length} memory entries (of ${value.total}).`)
+        render: (_args, value) => {
+          const items = value.items ?? [];
+          if (items.length === 0) return TEXT_OUTPUT(`0 memory entries (of ${value.total}).`);
+          const body = items
+            .map((m, i) => `[${i + 1}] ${m.title} (type=${m.type}, importance=${m.importance})\n    ID: ${m.id} | updated: ${m.updated_at}`)
+            .join("\n\n");
+          return TEXT_OUTPUT(`${items.length} memory entries (of ${value.total}):\n\n${body}`);
+        }
       },
       async execute(args) {
         const includeArchived = args.include_archived === true;
@@ -128,6 +162,46 @@ export function createTools(ctx, service, config, embedder) {
           includeArchived
         }));
         return { items: rows, total: service.count(args.type, { includeArchived }) };
+      }
+    }),
+
+    defineTool({
+      name: "memory_get",
+      description: "Fetch one memory entry by ID and return its full content as text. Use after memory_list to read a specific entry.",
+      parameters: {
+        id: { type: "string", required: true, description: "Memory id" }
+      },
+      output: {
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            memory: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                id: { type: "string", required: true },
+                title: { type: "string", required: true },
+                type: { type: "string", required: true },
+                importance: { type: "integer", required: true },
+                tags: { type: "array", items: { type: "string" } },
+                content: { type: "string", required: true },
+                source: { type: "string" },
+                created_at: { type: "string" },
+                updated_at: { type: "string" }
+              }
+            }
+          }
+        },
+        render: (_args, value) => {
+          const m = value.memory;
+          return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}\n\n${m.content}`);
+        },
+        async execute(args) {
+          const memory = service.getById(args.id);
+          if (memory === undefined) throw new Error("memory not found");
+          return { memory: service.toApiList([memory])[0] };
+        }
       }
     }),
 
@@ -267,7 +341,12 @@ export function createTools(ctx, service, config, embedder) {
   ];
 
   for (const tool of tools) {
-    ctx.tools.register(tool);
+          if (registeredTools.has(tool.name)) {
+        ctx.logger?.warn?.(`[dsh-mneme] tool "${tool.name}" already registered, skipping duplicate`);
+        continue;
+      }
+      registeredTools.add(tool.name);
+      ctx.tools.register(tool);
   }
 
   return tools;

--- a/dsh-mneme/lib/tools.js
+++ b/dsh-mneme/lib/tools.js
@@ -190,12 +190,12 @@ export function createTools(ctx, service, config, embedder) {
         render: (_args, value) => {
           const m = value.memory;
           return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}\n\n${m.content}`);
-        },
-        async execute(args) {
-          const memory = service.getById(args.id);
-          if (memory === undefined) throw new Error("memory not found");
-          return { memory: service.toApiList([memory])[0] };
         }
+      },
+      async execute(args) {
+        const memory = service.getById(args.id);
+        if (memory === undefined) throw new Error("memory not found");
+        return { memory: service.toApiList([memory])[0] };
       }
     }),
 

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -37,9 +37,7 @@
     "client": {
       "inject": [
         "slots",
-        "locale",
-        
-        
+        "locale"
       ],
       "platform": "web"
     },

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -38,8 +38,8 @@
       "inject": [
         "slots",
         "locale",
-        "layout",
-        "connection"
+        
+        
       ],
       "platform": "web"
     },
@@ -54,7 +54,7 @@
     "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
     "@deepseek-ai/schemastery": "^3.18.1",
-    "dsh-better-sidebar": "*"
+    "dsh-better-sidebar": "^0.18.0"
   },
   "peerDependenciesMeta": {
     "dsh-better-sidebar": {

--- a/dsh-mneme/src/api-standalone.js
+++ b/dsh-mneme/src/api-standalone.js
@@ -16,6 +16,46 @@ const DEFAULT_HOST = "127.0.0.1";
 // Hardcoded release version (package.json is bumped at publish time and may
 // lag the code that ships in between).
 const VERSION = "0.7.12";
+const MAX_PORT_ATTEMPTS = 20;
+
+/**
+ * Listen with automatic EADDRINUSE recovery. Tries the configured port, then
+ * the next MAX_PORT_ATTEMPTS-1 ports, and finally falls back to port 0 so the
+ * OS assigns a free port. Multiple DSH profiles/instances sharing the default
+ * port no longer leave the standalone API permanently unavailable.
+ */
+function listenWithRetry(server, startPort, host, logger) {
+  return new Promise((resolve, reject) => {
+    let attempt = 0;
+    const tryListen = (port) => {
+      const onListening = () => {
+        server.off("error", onError);
+        const address = server.address();
+        resolve(address && typeof address === "object" ? address.port : port);
+      };
+      const onError = (error) => {
+        server.off("listening", onListening);
+        if (error?.code === "EADDRINUSE" && attempt < MAX_PORT_ATTEMPTS - 1) {
+          attempt++;
+          const next = startPort + attempt;
+          logger?.warn?.(`[dsh-mneme] standalone API port ${port} in use, retrying ${next}`);
+          tryListen(next);
+          return;
+        }
+        if (error?.code === "EADDRINUSE") {
+          logger?.warn?.(`[dsh-mneme] standalone API port ${port} still in use, falling back to OS-assigned port`);
+          tryListen(0);
+          return;
+        }
+        reject(error);
+      };
+      server.once("listening", onListening);
+      server.once("error", onError);
+      server.listen(port, host);
+    };
+    tryListen(startPort);
+  });
+}
 
 function sendJson(res, status, payload) {
   res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
@@ -243,10 +283,10 @@ export function createStandaloneApi({ service, store, config = {}, logger, setti
     logger?.warn?.(`[dsh-mneme] standalone API error: ${String(error)}`);
   });
   const ready = new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
+    // listening handled by listenWithRetry
+    listenWithRetry(server, boundPort, boundHost, logger).then(resolve, reject);
   });
-  server.listen(boundPort, boundHost);
+  // server.listen is called inside listenWithRetry
   ready.then(() => {
     const address = server.address();
     if (address && typeof address === "object") {

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -52,6 +52,16 @@ export const Config = z.object({
   // 起算，失败/degraded 的 run 也占用间隔；间隔内的触发请求静默跳过，下一次
   // 写入事件会重新评估。
   dreamMinIntervalMinutes: z.natural().min(0).max(10080).default(0),
+  // 巩固模型路由（settings panel「巩固模型」/ dreamProvider+dreamModel）：
+  // dream 的记忆沉淀专用 LLM 路由，显式配置优先于 agent 默认模型（config-first，
+  // Issue #25）。模型分类声明：
+  //   - 非思考模型（推荐，如 glm-5-2 类）：无 reasoning 声明，effort 请求被 harness
+  //     拒绝后 withEffortFallback 去掉字段重试即成功；空体/no json array 风险最低。
+  //   - 思考模型（如 deepseek-v4-flash-ga 等 v4-flash-ga 系）：默认开推理，可能烧光
+  //     token 预算返回空体；且部分（如 v4-flash-ga）在 harness 侧被声明为不接受任何
+  //     reasoning effort —— 即使去掉 effort 重试，harness 的 defaultEffort 也会顶上来
+  //     再次拒绝（UNSUPPORTED_REASONING_EFFORT），插件 fallback 无法绕开。
+  //     选用时建议配 dreamReasoningEffort 并实测；不行就换非思考模型。
   dreamProvider: z.string(),
   dreamModel: z.string(),
   dreamMaxTokens: z.natural().min(256).max(131072).default(32768),
@@ -60,6 +70,9 @@ export const Config = z.object({
   // are forwarded verbatim. Useful to cap reasoning spend on thinking-type
   // models that would otherwise drain the whole token budget and return an
   // empty body ("no json array in llm output").
+  // Caveat: on some thinking models (e.g. v4-flash-ga) the harness declares NO
+  // supported effort, so even the fallback retry (field stripped) is rejected
+  // again via its defaultEffort — prefer a non-reasoning dreamProvider/dreamModel.
   dreamReasoningEffort: z.union([
     z.const("low"),
     z.const("medium"),

--- a/dsh-mneme/src/tools.js
+++ b/dsh-mneme/src/tools.js
@@ -22,12 +22,6 @@ const MEMORY_ITEM_SCHEMA = {
     source: { type: "string" },
     created_at: { type: "string", required: true },
     updated_at: { type: "string", required: true }
-  /* const toolsRegistry = ctx.tools;
-  let registeredTools = REGISTERED_TOOLS.get(toolsRegistry);
-  if (!registeredTools) {
-    registeredTools = new Set();
-    REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
-  */
   }
 };
 

--- a/dsh-mneme/src/tools.js
+++ b/dsh-mneme/src/tools.js
@@ -1,6 +1,10 @@
 import { defineTool } from "@deepseek-ai/dsh-tools";
 
 const TEXT_OUTPUT = (text) => [{ type: "text", text }];
+// Per-registry tool-name registry: guards against duplicate registration on
+// live patch reload (DSH Desktop `patchReload: "live"`) where a plugin may be
+// re-applied on the same tools registry without an intervening unregister.
+const REGISTERED_TOOLS = new WeakMap();
 
 // Wire shape emitted by service.toApiList: shared by memory_search and
 // memory_list so their output schemas always declare every key the runtime
@@ -18,10 +22,22 @@ const MEMORY_ITEM_SCHEMA = {
     source: { type: "string" },
     created_at: { type: "string", required: true },
     updated_at: { type: "string", required: true }
+  /* const toolsRegistry = ctx.tools;
+  let registeredTools = REGISTERED_TOOLS.get(toolsRegistry);
+  if (!registeredTools) {
+    registeredTools = new Set();
+    REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
+  */
   }
 };
 
 export function createTools(ctx, service, config, embedder) {
+  const toolsRegistry = ctx.tools;
+  let registeredTools = REGISTERED_TOOLS.get(toolsRegistry);
+  if (!registeredTools) {
+    registeredTools = new Set();
+    REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
+  }
   const tools = [
     defineTool({
       name: "memory_save",
@@ -82,7 +98,18 @@ export function createTools(ctx, service, config, embedder) {
             }
           }
         },
-        render: (_args, value) => TEXT_OUTPUT(`Found ${value.items.length} memory entr${value.items.length === 1 ? "y" : "ies"}.`)
+        render: (_args, value) => {
+          const items = value.items ?? [];
+          if (items.length === 0) return TEXT_OUTPUT("No memory entries found.");
+          const body = items
+            .map((m, i) => {
+              const preview = (m.content ?? "").replace(/\s+/g, " ").trim();
+              const cut = preview.length > 200 ? `${preview.slice(0, 200)}…` : preview;
+              return `[${i + 1}] ${m.title}\n    ID: ${m.id} | type: ${m.type} | importance: ${m.importance} | updated: ${m.updated_at}\n    ${cut}`;
+            })
+            .join("\n\n");
+          return TEXT_OUTPUT(`Found ${items.length} memory entr${items.length === 1 ? "y" : "ies"}:\n\n${body}`);
+        }
       },
       async execute(args) {
         const limit = args.limit ?? 20;
@@ -117,7 +144,14 @@ export function createTools(ctx, service, config, embedder) {
             total: { type: "integer", required: true }
           }
         },
-        render: (_args, value) => TEXT_OUTPUT(`${value.items.length} memory entries (of ${value.total}).`)
+        render: (_args, value) => {
+          const items = value.items ?? [];
+          if (items.length === 0) return TEXT_OUTPUT(`0 memory entries (of ${value.total}).`);
+          const body = items
+            .map((m, i) => `[${i + 1}] ${m.title} (type=${m.type}, importance=${m.importance})\n    ID: ${m.id} | updated: ${m.updated_at}`)
+            .join("\n\n");
+          return TEXT_OUTPUT(`${items.length} memory entries (of ${value.total}):\n\n${body}`);
+        }
       },
       async execute(args) {
         const includeArchived = args.include_archived === true;
@@ -128,6 +162,46 @@ export function createTools(ctx, service, config, embedder) {
           includeArchived
         }));
         return { items: rows, total: service.count(args.type, { includeArchived }) };
+      }
+    }),
+
+    defineTool({
+      name: "memory_get",
+      description: "Fetch one memory entry by ID and return its full content as text. Use after memory_list to read a specific entry.",
+      parameters: {
+        id: { type: "string", required: true, description: "Memory id" }
+      },
+      output: {
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            memory: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                id: { type: "string", required: true },
+                title: { type: "string", required: true },
+                type: { type: "string", required: true },
+                importance: { type: "integer", required: true },
+                tags: { type: "array", items: { type: "string" } },
+                content: { type: "string", required: true },
+                source: { type: "string" },
+                created_at: { type: "string" },
+                updated_at: { type: "string" }
+              }
+            }
+          }
+        },
+        render: (_args, value) => {
+          const m = value.memory;
+          return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}\n\n${m.content}`);
+        },
+        async execute(args) {
+          const memory = service.getById(args.id);
+          if (memory === undefined) throw new Error("memory not found");
+          return { memory: service.toApiList([memory])[0] };
+        }
       }
     }),
 
@@ -267,7 +341,12 @@ export function createTools(ctx, service, config, embedder) {
   ];
 
   for (const tool of tools) {
-    ctx.tools.register(tool);
+          if (registeredTools.has(tool.name)) {
+        ctx.logger?.warn?.(`[dsh-mneme] tool "${tool.name}" already registered, skipping duplicate`);
+        continue;
+      }
+      registeredTools.add(tool.name);
+      ctx.tools.register(tool);
   }
 
   return tools;

--- a/dsh-mneme/src/tools.js
+++ b/dsh-mneme/src/tools.js
@@ -190,12 +190,12 @@ export function createTools(ctx, service, config, embedder) {
         render: (_args, value) => {
           const m = value.memory;
           return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}\n\n${m.content}`);
-        },
-        async execute(args) {
-          const memory = service.getById(args.id);
-          if (memory === undefined) throw new Error("memory not found");
-          return { memory: service.toApiList([memory])[0] };
         }
+      },
+      async execute(args) {
+        const memory = service.getById(args.id);
+        if (memory === undefined) throw new Error("memory not found");
+        return { memory: service.toApiList([memory])[0] };
       }
     }),
 

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -235,7 +235,7 @@ test("better-sidebar tab mounts via an inner sub-plugin, standalone mode intact"
     "the inner apply must still guard the service shape before registering"
   );
   assert.ok(
-    /id: "dsh-mneme:memory"/.test(clientSource),
+    /(?:const TAB_ID = |id: )"dsh-mneme:memory"/.test(clientSource),
     "the registered tab id must be package-prefixed"
   );
   assert.ok(

--- a/dsh-mneme/test/tools.test.js
+++ b/dsh-mneme/test/tools.test.js
@@ -91,6 +91,57 @@ test("memory_search finds by CJK substring", async () => {
   assert.equal(result.items[0].title, "记忆插件");
 });
 
+// Regression: memory_get.execute must live on the defineTool options (top
+// level), NOT nested inside output — a misplaced execute silently becomes
+// options.execute === undefined and every call throws "userExecute is not a
+// function" while tests that only count tool names still pass.
+test("memory_get returns the full body via execute and render", async () => {
+  const { registered, service } = setup();
+  const { memory } = service.saveWithDedupe({ type: "decision", title: "t", content: "完整正文内容" });
+  const get = registered.find((t) => t.name === "memory_get");
+  const res = await get.execute({ id: memory.id });
+  assert.equal(res.memory.id, memory.id);
+  assert.equal(res.memory.content, "完整正文内容");
+  assert.deepEqual(validateJsonSchemaValue(get.output.schema, res), []);
+  const text = get.output.render({}, res)[0].text;
+  assert.ok(text.includes("完整正文内容"), "full body in render");
+  assert.ok(text.includes(memory.id) && text.includes("t"), "id + title in render");
+});
+
+test("memory_get on missing id rejects", async () => {
+  const { registered } = setup();
+  const get = registered.find((t) => t.name === "memory_get");
+  await assert.rejects(() => get.execute({ id: "missing" }), /memory not found/);
+});
+
+// Render output is what hosts surface to the model (not the structured JSON),
+// so it must embed titles + body previews, not just a hit count.
+test("memory_search render embeds titles and body previews, not just a count", async () => {
+  const { registered, service } = setup();
+  service.saveWithDedupe({ type: "history", title: "旅行计划", content: "用户当前最苦恼时间安排与伦敦行程" });
+  service.saveWithDedupe({ type: "project", title: "插件定位", content: "dsh-mneme 插件做记忆沉淀" });
+  const search = registered.find((t) => t.name === "memory_search");
+  const res = await search.execute({ query: "时间" });
+  assert.ok(res.items.length >= 1, "search hit exists");
+  const text = search.output.render({}, res)[0].text;
+  assert.match(text, /Found \d+ memory entr/);
+  assert.ok(text.includes("旅行计划"), "title embedded in render");
+  assert.ok(text.includes("伦敦行程"), "body preview embedded in render");
+  assert.ok(text.includes("ID: "), "id embedded");
+});
+
+test("memory_list render embeds titles and ids, not just counts", async () => {
+  const { registered, service } = setup();
+  service.saveWithDedupe({ type: "preference", title: "昵称", content: "桉桉" });
+  service.saveWithDedupe({ type: "project", title: "博客", content: "modusensus" });
+  const list = registered.find((t) => t.name === "memory_list");
+  const res = await list.execute({});
+  const text = list.output.render({}, res)[0].text;
+  assert.match(text, /\d+ memory entries \(of \d+\):/);
+  assert.ok(text.includes("昵称") && text.includes("博客"), "titles embedded");
+  assert.ok(text.includes("ID: "), "ids embedded");
+});
+
 test("memory_list filters by type", async () => {
   const { registered, service } = setup();
   service.saveWithDedupe({ type: "preference", title: "a", content: "x" });

--- a/dsh-mneme/test/tools.test.js
+++ b/dsh-mneme/test/tools.test.js
@@ -44,15 +44,15 @@ function walkSchema(node, path, problems) {
   }
 }
 
-test("registers seven tools with correct names", () => {
+test("registers eight tools with correct names", () => {
   const { registered } = setup();
   const names = registered.map((t) => t.name).sort();
-  assert.deepEqual(names, ["memory_archive", "memory_delete", "memory_forget", "memory_list", "memory_save", "memory_search", "memory_update"]);
+  assert.deepEqual(names, ["memory_archive", "memory_delete", "memory_forget", "memory_get", "memory_list", "memory_save", "memory_search", "memory_update"]);
 });
 
 test("compiled schemas pass the enforced DSH subset (defineTool projection)", () => {
   const { registered } = setup();
-  assert.equal(registered.length, 7);
+  assert.equal(registered.length, 8);
   for (const tool of registered) {
     assertSupportedJsonSchema(tool.parameters);
     assertSupportedJsonSchema(tool.output.schema);

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
       "inject": [
         "slots",
         "locale",
-        "layout",
-        "connection"
+        
+        
       ],
       "platform": "web"
     },

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "client": {
       "inject": [
         "slots",
-        "locale",
-        
-        
+        "locale"
       ],
       "platform": "web"
     },


### PR DESCRIPTION
## Summary

Fixes compatibility issues found when running dsh-mneme alongside other DSH plugins/profiles:

1. **Tool duplicate registration**
   - Add per-registry tool-name tracking (WeakMap) in `createTools`.
   - Prevents `tool "memory_search" is already registered` during live patch reload; duplicates are skipped with a warning.

2. **Standalone API port conflict**
   - Add `listenWithRetry` for the external API.
   - On `EADDRINUSE`, try subsequent ports (up to 20 attempts) and finally fall back to OS-assigned port 0; the actual bound port is exposed to the caller.

3. **Client inject declaration mismatch**
   - Align `dsh.client.inject` to `["slots", "locale"]` (both root and sub package) to match what `lib/client.js` actually consumes (`slots` / `locale`); `layout` / `connection` are not referenced by client code.

4. **better-sidebar integration hardening**
   - Tighten peer dependency from `*` to `^0.18.0` (still optional via `peerDependenciesMeta`).
   - Check for duplicate tab id (`dsh-mneme:memory`) via `getTab()` before `registerTab`; skip with a warning on duplicates.
   - On `registerTab` failure, warn and fall back to the native sidebar entry instead of erroring out.

### Also included
- New `memory_get` tool plus content-preview `render` output for `memory_search` / `memory_list` (tool count now 8, tests calibrated).
- Minor cleanup: removed a stray mis-placed comment block in `tools.js` and normalized comment indentation.

> Note: the original plan also included switching `webServer` to an optional `ctx.reflect?.get("webServer")` read. That guard has already landed on main via #93 (which keeps `webServer` declared in inject with the same `reflect.get` safe read plus real-cordis regression tests), so after rebasing this PR contains **no changes to `src/index.js` / `lib/index.js`**.

## Files changed

- `package.json`
- `dsh-mneme/package.json`
- `dsh-mneme/src/tools.js`
- `dsh-mneme/lib/tools.js`
- `dsh-mneme/src/api-standalone.js`
- `dsh-mneme/lib/api-standalone.js`
- `dsh-mneme/lib/client.js`
- `dsh-mneme/test/tools.test.js`
- `dsh-mneme/test/client.test.js`

## Test plan

- `npm run sync` — 26 files synced, src/ 与 lib/ 完全一致（client.js 为 lib-only 保留）
- `npm test` — **714 tests, 0 failures**（含 #93 的真实 cordis webServer 双宿主回归测试）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a memory lookup tool for retrieving complete entries by ID.
  * Enhanced memory search and listing results with titles, IDs, types, importance, timestamps, previews, and empty-state messages.

* **Bug Fixes**
  * Standalone API startup now retries alternate ports when the configured port is unavailable.
  * Prevented duplicate sidebar tabs and tool registrations during reloads.
  * Improved fallback handling when sidebar registration fails.

* **Documentation**
  * Expanded guidance for configuring consolidation models and reasoning-effort settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->