### PR TITLE
fix: 记忆巩固因 defaultEffort trap 反复失败（resolveDreamEffort 主动探测能力）

### DIFF
--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -62,8 +62,8 @@ export const Config = z.object({
   //     reasoning effort —— 即使去掉 effort 重试，harness 的 defaultEffort 也会顶上来
   //     再次拒绝（UNSUPPORTED_REASONING_EFFORT），插件 fallback 无法绕开。
   //     选用时建议配 dreamReasoningEffort 并实测；不行就换非思考模型。
-  dreamProvider: z.string(),
-  dreamModel: z.string(),
+  dreamProvider: z.string().description("记忆巩固专用模型的服务商（settings「巩固模型」）。巩固反复失败时，优先改用官方非思考模型的服务商（如 deepseek / glm）。"),
+  dreamModel: z.string().description("记忆巩固专用模型。建议选非思考模型（如 deepseek-chat、glm-5-2 类）：思考模型可能烧光 token 预算返回空体，导致巩固失败（UNSUPPORTED_REASONING_EFFORT）。"),
   dreamMaxTokens: z.natural().min(256).max(131072).default(32768),
   // Pass-through reasoning effort for dream's LLM calls. 'none' (default)
   // omits the field so the provider's own default applies; low/medium/high
@@ -78,7 +78,7 @@ export const Config = z.object({
     z.const("medium"),
     z.const("high"),
     z.const("none")
-  ]).default("none"),
+  ]).default("none").description("巩固模型的推理档位：'none'（默认）用服务商自带默认；low/medium/high 原样传递。模型不支持的值会自动换用其支持的档位（v0.7.26+）。"),
   // 滑动窗口上限（v0.4.4）：autoDream 每次只对最近 dreamMaxSnapshotSize 条
   // 记忆做 consolidation。大记忆量下全量快照会把 LLM 输入撑爆（636 记忆 →
   // 677 "missing" errors、applied=0），窗口外的旧记忆不进 snapshot。
@@ -251,8 +251,8 @@ export const Config = z.object({
   sleepMaxPatternPerRun: z.natural().min(0).max(10).default(3),
   // Optional LLM route override for sleep's bulk passes (empty = use dream
   // route / agent default model).
-  sleepProvider: z.string().default(""),
-  sleepModel: z.string().default(""),
+  sleepProvider: z.string().default("").description("sleep 深维护专用模型服务商，留空用巩固模型或当前模型。"),
+  sleepModel: z.string().default("").description("sleep 深维护专用模型，留空用巩固模型或当前模型；建议同巩固模型选非思考模型。"),
   // Pass-through reasoning effort for sleep's LLM passes, same semantics as
   // dreamReasoningEffort: 'none' (default) omits the field; low/medium/high
   // are forwarded verbatim.
@@ -261,7 +261,7 @@ export const Config = z.object({
     z.const("medium"),
     z.const("high"),
     z.const("none")
-  ]).default("none"),
+  ]).default("none").description("同 dreamReasoningEffort：sleep 各阶段 LLM 的推理档位，'none' 用服务商默认。"),
 
   // --- epistemic trust: memory source credibility (v0.4.5) -----------------
   // Distinguish memories by source: observation (measured / witnessed),

--- a/dsh-mneme/lib/dream.js
+++ b/dsh-mneme/lib/dream.js
@@ -1,7 +1,7 @@
 import { validateDecisions, applyDecisions } from "./dream/decisions.js";
 import { clusterMemories, findPotentialConflicts } from "./dream/clustering.js";
 import { createHash, randomUUID } from "node:crypto";
-export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure };
+export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure, resolveDreamEffort };
 
 
 // Extract the first JSON array from LLM output, tolerating markdown fences,
@@ -374,6 +374,60 @@ async function withEffortFallback(ctx, effort, attempt, fallback, getStreamError
 }
 
 /**
+ * Resolve the reasoning effort to actually send for a dream/sleep route.
+ *
+ * Reasoning-effort config that the provider does not accept trips the harness's
+ * UNSUPPORTED_REASONING_EFFORT, and the defaultEffort trap makes retrying
+ * "without the field" useless: the harness substitutes `reasoning.defaultEffort`,
+ * which may itself be unsupported (DSH Desktop volcano-engine adapter declares
+ * defaultEffort=low that its model rejects). So instead of blind retries, ask
+ * the harness for the model's declared capability and pick a value that is
+ * actually accepted — or omit the field entirely when the model declares no
+ * reasoning capability at all.
+ *
+ * @returns a supported effort id, or null when no effort should be sent, or the
+ *   configured value unchanged when the capability query is unavailable.
+ */
+async function resolveDreamEffort(ctx, route, configuredEffort, logger) {
+  if (!configuredEffort || configuredEffort === "none") return null;
+  // Capability query unavailable (older harness / minimal mocks): forward the
+  // configured value as before — absence of the API proves nothing about the
+  // model, and withEffortFallback still guards against rejection.
+  if (typeof ctx?.llm?.resolveModelInfo !== "function") return configuredEffort;
+  try {
+    const info = await ctx.llm.resolveModelInfo(route.provider, route.model);
+    const reasoning = info?.reasoning;
+    if (!reasoning) {
+      // Model declares no reasoning capability: the harness rejects ANY
+      // explicit effort for such a model, and omitting the field is safe
+      // (no reasoning capability → no defaultEffort substitution).
+      logger?.warn?.(`dsh-mneme dream: model ${route.provider}:${route.model} declares no reasoning capability; ignoring configured effort "${configuredEffort}"`);
+      return null;
+    }
+    const supported = reasoning.efforts?.map((effort) => effort.id) ?? [];
+    if (supported.includes(configuredEffort)) return configuredEffort;
+    // Configured effort unsupported → pick defaultEffort if it is supported,
+    // else the first declared effort, so the run never trips
+    // UNSUPPORTED_REASONING_EFFORT (nor the defaultEffort trap: we always
+    // pass an explicit value, so the harness never falls back to a poison
+    // default).
+    const picked = reasoning.defaultEffort && supported.includes(reasoning.defaultEffort)
+      ? reasoning.defaultEffort
+      : supported[0];
+    if (picked) {
+      logger?.warn?.(`dsh-mneme dream: model ${route.provider}:${route.model} does not support effort "${configuredEffort}" (supported: ${supported.join(", ")}); using "${picked}"`);
+      return picked;
+    }
+    return null;
+  } catch (error) {
+    // Capability query failed — forward the configured value; withEffortFallback
+    // still retries on rejection as before.
+    logger?.warn?.(`dsh-mneme dream: resolveModelInfo failed (${String(error?.message ?? error)}); forwarding effort as configured`);
+    return configuredEffort;
+  }
+}
+
+/**
  * Resolve the LLM route (Issue #25): an explicit plugin config
  * (dreamProvider/dreamModel) is the user's declared override and wins; the
  * agent default model (deployment) is only a fallback when no config route is
@@ -665,7 +719,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
     // （不带该字段），避免 thinking 模型配置 low/medium 直接整单失败。解析放
     // 在 auditError 检查器里、闭包交回主流程，避免二次解析；解析失败同时如实
     // 记 audit error 并在日志带原始输出前 300 字节，便于定位"推理吞预算返回空体"。
-    const effort = config.dreamReasoningEffort && config.dreamReasoningEffort !== "none" ? config.dreamReasoningEffort : null;
+    const effort = await resolveDreamEffort(ctx, route, config.dreamReasoningEffort, logger);
     let decisions = null;
     let streamFailure = "";
     const runConsolidation = (withEffort) => {

--- a/dsh-mneme/lib/dream/sleep.js
+++ b/dsh-mneme/lib/dream/sleep.js
@@ -17,7 +17,7 @@
 import { randomUUID, createHash } from "node:crypto";
 import { validateDecisions, applyDecisions } from "./decisions.js";
 import { findPotentialConflicts } from "./clustering.js";
-import { buildReceipt, describeStreamFailure, withEffortFallback } from "../dream.js";
+import { buildReceipt, describeStreamFailure, resolveDreamEffort, withEffortFallback } from "../dream.js";
 import { computeHeat } from "../heat.js";
 
 const SUMMARY_MAX = 120;
@@ -190,7 +190,7 @@ async function phaseConflicts(ctx, service, config, logger, runId, semantic = nu
   const listText = selected.map((p) =>
     `候选冲突：\nid=${p.a.id} | type=${p.a.type} | title=${p.a.title}\n${p.a.content}\n---\nid=${p.b.id} | type=${p.b.type} | title=${p.b.title}\n${p.b.content}\n（相似度 ${p.similarity.toFixed(2)}）`
   ).join("\n\n");
-  const sleepEffort = config.sleepReasoningEffort && config.sleepReasoningEffort !== "none" ? config.sleepReasoningEffort : null;
+  const sleepEffort = await resolveDreamEffort(ctx, route, config.sleepReasoningEffort, logger);
   let conflictStreamFailure = "";
   const runConflict = (withEffort) => {
     conflictStreamFailure = "";
@@ -309,7 +309,7 @@ async function phasePatterns(ctx, service, config, logger, runId, signal = null)
     .map((m) => `id=${m.id} | type=${m.type} | importance=${m.importance} | updated=${m.updated_at} | title=${m.title} | content=${m.content}`)
     .join("\n");
   const maxPatterns = config.sleepMaxPatternPerRun ?? 3;
-  const sleepEffort = config.sleepReasoningEffort && config.sleepReasoningEffort !== "none" ? config.sleepReasoningEffort : null;
+  const sleepEffort = await resolveDreamEffort(ctx, route, config.sleepReasoningEffort, logger);
   let patternStreamFailure = "";
   const runPattern = (withEffort) => {
     patternStreamFailure = "";

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -62,8 +62,8 @@ export const Config = z.object({
   //     reasoning effort —— 即使去掉 effort 重试，harness 的 defaultEffort 也会顶上来
   //     再次拒绝（UNSUPPORTED_REASONING_EFFORT），插件 fallback 无法绕开。
   //     选用时建议配 dreamReasoningEffort 并实测；不行就换非思考模型。
-  dreamProvider: z.string(),
-  dreamModel: z.string(),
+  dreamProvider: z.string().description("记忆巩固专用模型的服务商（settings「巩固模型」）。巩固反复失败时，优先改用官方非思考模型的服务商（如 deepseek / glm）。"),
+  dreamModel: z.string().description("记忆巩固专用模型。建议选非思考模型（如 deepseek-chat、glm-5-2 类）：思考模型可能烧光 token 预算返回空体，导致巩固失败（UNSUPPORTED_REASONING_EFFORT）。"),
   dreamMaxTokens: z.natural().min(256).max(131072).default(32768),
   // Pass-through reasoning effort for dream's LLM calls. 'none' (default)
   // omits the field so the provider's own default applies; low/medium/high
@@ -78,7 +78,7 @@ export const Config = z.object({
     z.const("medium"),
     z.const("high"),
     z.const("none")
-  ]).default("none"),
+  ]).default("none").description("巩固模型的推理档位：'none'（默认）用服务商自带默认；low/medium/high 原样传递。模型不支持的值会自动换用其支持的档位（v0.7.26+）。"),
   // 滑动窗口上限（v0.4.4）：autoDream 每次只对最近 dreamMaxSnapshotSize 条
   // 记忆做 consolidation。大记忆量下全量快照会把 LLM 输入撑爆（636 记忆 →
   // 677 "missing" errors、applied=0），窗口外的旧记忆不进 snapshot。
@@ -251,8 +251,8 @@ export const Config = z.object({
   sleepMaxPatternPerRun: z.natural().min(0).max(10).default(3),
   // Optional LLM route override for sleep's bulk passes (empty = use dream
   // route / agent default model).
-  sleepProvider: z.string().default(""),
-  sleepModel: z.string().default(""),
+  sleepProvider: z.string().default("").description("sleep 深维护专用模型服务商，留空用巩固模型或当前模型。"),
+  sleepModel: z.string().default("").description("sleep 深维护专用模型，留空用巩固模型或当前模型；建议同巩固模型选非思考模型。"),
   // Pass-through reasoning effort for sleep's LLM passes, same semantics as
   // dreamReasoningEffort: 'none' (default) omits the field; low/medium/high
   // are forwarded verbatim.
@@ -261,7 +261,7 @@ export const Config = z.object({
     z.const("medium"),
     z.const("high"),
     z.const("none")
-  ]).default("none"),
+  ]).default("none").description("同 dreamReasoningEffort：sleep 各阶段 LLM 的推理档位，'none' 用服务商默认。"),
 
   // --- epistemic trust: memory source credibility (v0.4.5) -----------------
   // Distinguish memories by source: observation (measured / witnessed),

--- a/dsh-mneme/src/dream.js
+++ b/dsh-mneme/src/dream.js
@@ -1,7 +1,7 @@
 import { validateDecisions, applyDecisions } from "./dream/decisions.js";
 import { clusterMemories, findPotentialConflicts } from "./dream/clustering.js";
 import { createHash, randomUUID } from "node:crypto";
-export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure };
+export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure, resolveDreamEffort };
 
 
 // Extract the first JSON array from LLM output, tolerating markdown fences,
@@ -374,6 +374,60 @@ async function withEffortFallback(ctx, effort, attempt, fallback, getStreamError
 }
 
 /**
+ * Resolve the reasoning effort to actually send for a dream/sleep route.
+ *
+ * Reasoning-effort config that the provider does not accept trips the harness's
+ * UNSUPPORTED_REASONING_EFFORT, and the defaultEffort trap makes retrying
+ * "without the field" useless: the harness substitutes `reasoning.defaultEffort`,
+ * which may itself be unsupported (DSH Desktop volcano-engine adapter declares
+ * defaultEffort=low that its model rejects). So instead of blind retries, ask
+ * the harness for the model's declared capability and pick a value that is
+ * actually accepted — or omit the field entirely when the model declares no
+ * reasoning capability at all.
+ *
+ * @returns a supported effort id, or null when no effort should be sent, or the
+ *   configured value unchanged when the capability query is unavailable.
+ */
+async function resolveDreamEffort(ctx, route, configuredEffort, logger) {
+  if (!configuredEffort || configuredEffort === "none") return null;
+  // Capability query unavailable (older harness / minimal mocks): forward the
+  // configured value as before — absence of the API proves nothing about the
+  // model, and withEffortFallback still guards against rejection.
+  if (typeof ctx?.llm?.resolveModelInfo !== "function") return configuredEffort;
+  try {
+    const info = await ctx.llm.resolveModelInfo(route.provider, route.model);
+    const reasoning = info?.reasoning;
+    if (!reasoning) {
+      // Model declares no reasoning capability: the harness rejects ANY
+      // explicit effort for such a model, and omitting the field is safe
+      // (no reasoning capability → no defaultEffort substitution).
+      logger?.warn?.(`dsh-mneme dream: model ${route.provider}:${route.model} declares no reasoning capability; ignoring configured effort "${configuredEffort}"`);
+      return null;
+    }
+    const supported = reasoning.efforts?.map((effort) => effort.id) ?? [];
+    if (supported.includes(configuredEffort)) return configuredEffort;
+    // Configured effort unsupported → pick defaultEffort if it is supported,
+    // else the first declared effort, so the run never trips
+    // UNSUPPORTED_REASONING_EFFORT (nor the defaultEffort trap: we always
+    // pass an explicit value, so the harness never falls back to a poison
+    // default).
+    const picked = reasoning.defaultEffort && supported.includes(reasoning.defaultEffort)
+      ? reasoning.defaultEffort
+      : supported[0];
+    if (picked) {
+      logger?.warn?.(`dsh-mneme dream: model ${route.provider}:${route.model} does not support effort "${configuredEffort}" (supported: ${supported.join(", ")}); using "${picked}"`);
+      return picked;
+    }
+    return null;
+  } catch (error) {
+    // Capability query failed — forward the configured value; withEffortFallback
+    // still retries on rejection as before.
+    logger?.warn?.(`dsh-mneme dream: resolveModelInfo failed (${String(error?.message ?? error)}); forwarding effort as configured`);
+    return configuredEffort;
+  }
+}
+
+/**
  * Resolve the LLM route (Issue #25): an explicit plugin config
  * (dreamProvider/dreamModel) is the user's declared override and wins; the
  * agent default model (deployment) is only a fallback when no config route is
@@ -665,7 +719,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
     // （不带该字段），避免 thinking 模型配置 low/medium 直接整单失败。解析放
     // 在 auditError 检查器里、闭包交回主流程，避免二次解析；解析失败同时如实
     // 记 audit error 并在日志带原始输出前 300 字节，便于定位"推理吞预算返回空体"。
-    const effort = config.dreamReasoningEffort && config.dreamReasoningEffort !== "none" ? config.dreamReasoningEffort : null;
+    const effort = await resolveDreamEffort(ctx, route, config.dreamReasoningEffort, logger);
     let decisions = null;
     let streamFailure = "";
     const runConsolidation = (withEffort) => {

--- a/dsh-mneme/src/dream/sleep.js
+++ b/dsh-mneme/src/dream/sleep.js
@@ -17,7 +17,7 @@
 import { randomUUID, createHash } from "node:crypto";
 import { validateDecisions, applyDecisions } from "./decisions.js";
 import { findPotentialConflicts } from "./clustering.js";
-import { buildReceipt, describeStreamFailure, withEffortFallback } from "../dream.js";
+import { buildReceipt, describeStreamFailure, resolveDreamEffort, withEffortFallback } from "../dream.js";
 import { computeHeat } from "../heat.js";
 
 const SUMMARY_MAX = 120;
@@ -190,7 +190,7 @@ async function phaseConflicts(ctx, service, config, logger, runId, semantic = nu
   const listText = selected.map((p) =>
     `候选冲突：\nid=${p.a.id} | type=${p.a.type} | title=${p.a.title}\n${p.a.content}\n---\nid=${p.b.id} | type=${p.b.type} | title=${p.b.title}\n${p.b.content}\n（相似度 ${p.similarity.toFixed(2)}）`
   ).join("\n\n");
-  const sleepEffort = config.sleepReasoningEffort && config.sleepReasoningEffort !== "none" ? config.sleepReasoningEffort : null;
+  const sleepEffort = await resolveDreamEffort(ctx, route, config.sleepReasoningEffort, logger);
   let conflictStreamFailure = "";
   const runConflict = (withEffort) => {
     conflictStreamFailure = "";
@@ -309,7 +309,7 @@ async function phasePatterns(ctx, service, config, logger, runId, signal = null)
     .map((m) => `id=${m.id} | type=${m.type} | importance=${m.importance} | updated=${m.updated_at} | title=${m.title} | content=${m.content}`)
     .join("\n");
   const maxPatterns = config.sleepMaxPatternPerRun ?? 3;
-  const sleepEffort = config.sleepReasoningEffort && config.sleepReasoningEffort !== "none" ? config.sleepReasoningEffort : null;
+  const sleepEffort = await resolveDreamEffort(ctx, route, config.sleepReasoningEffort, logger);
   let patternStreamFailure = "";
   const runPattern = (withEffort) => {
     patternStreamFailure = "";

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -147,7 +147,7 @@ test("sidebar entry portals above the workspaces region with footer fallback", (
     "the portal entry persists across collapse (no footer jump); footer fallback only covers portal failure"
   );
   assert.ok(
-    clientSource.includes('className: `${nativeCls} mneme-topentry-native`'.replace("${nativeCls} mneme-topentry-native", "${nativeCls} mneme-topentry-native")),
+    clientSource.includes('className: `${nativeCls} mneme-topentry-native`'),
     "the entry must reuse the host New-Session button class for native geometry alignment"
   );
   assert.ok(

--- a/dsh-mneme/test/reasoning-effort.test.js
+++ b/dsh-mneme/test/reasoning-effort.test.js
@@ -413,3 +413,166 @@ test("sleep passes the stream failure accessor so a stream-level effort rejectio
   assert.equal("reasoningEffort" in captured[1], false, "conflict retry omits the rejected effort field");
   store.close();
 });
+
+// ------------------------------------------------------------------ defaultEffort trap
+// DSH Desktop's volcano-engine adapter declares reasoning.defaultEffort="low"
+// for a model that rejects "low", so omitting the field is NOT a safe retry —
+// the harness substitutes the poison default and fails again. resolveDreamEffort
+// queries resolveModelInfo up front and forwards a value that is actually in
+// the model's declared efforts, so the first attempt already carries a
+// supported effort and never trips UNSUPPORTED_REASONING_EFFORT.
+
+test("defaultEffort trap: configured 'low' remapped to the first supported effort when default is poison", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const dream = createDreamScheduler({ onRun: () => Promise.resolve({ ok: true, skipped: true }) });
+  const { memory: a } = service.saveWithDedupe({ type: "project", title: "插件", content: "旧", importance: 3 });
+  const { memory: b } = service.saveWithDedupe({ type: "project", title: "插件2", content: "新细节", importance: 4 });
+  const captured = [];
+  const infoCalls = [];
+  const ctx = dreamCtx({
+    captured,
+    onConsolidation: () => JSON.stringify([
+      { action: "merge", ids: [a.id, b.id], keepSource: b.id, title: "合并标题", content: "合并内容", importance: 4 }
+    ])
+  });
+  // The adapter's capability report: defaultEffort "low" is NOT in efforts
+  // (the model rejects it) — exactly the volcano-engine/deepseek-v4-flash trap.
+  ctx.llm.resolveModelInfo = async (provider, model) => {
+    infoCalls.push([provider, model]);
+    return {
+      provider,
+      model,
+      reasoning: {
+        efforts: [{ id: "medium" }, { id: "high" }],
+        defaultEffort: "low"
+      }
+    };
+  };
+  const result = await dream.runDream(ctx, service, { dreamReasoningEffort: "low" });
+  assert.equal(result.ok, true, "run succeeds without ever tripping the poison default");
+  assert.ok(result.applied > 0, "consolidation lands changes");
+  assert.deepEqual(infoCalls[0], ["mock", "mock-model"], "capability queried for the exact dream route");
+  assert.equal(captured[0].reasoningEffort, "medium", "poison 'low' remapped to the first supported effort");
+  assert.equal(captured[1].reasoningEffort, "medium", "summary pass uses the same resolved effort");
+  store.close();
+});
+
+test("defaultEffort trap: model with no reasoning capability omits the field entirely", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const dream = createDreamScheduler({ onRun: () => Promise.resolve({ ok: true, skipped: true }) });
+  const { memory: a } = service.saveWithDedupe({ type: "project", title: "插件", content: "旧", importance: 3 });
+  const { memory: b } = service.saveWithDedupe({ type: "project", title: "插件2", content: "新细节", importance: 4 });
+  const captured = [];
+  const ctx = dreamCtx({
+    captured,
+    onConsolidation: () => JSON.stringify([
+      { action: "merge", ids: [a.id, b.id], keepSource: b.id, title: "合并标题", content: "合并内容", importance: 4 }
+    ])
+  });
+  // Non-thinking model (e.g. deepseek-v4-flash): adapter reports no reasoning
+  // capability, so ANY explicit effort would be rejected — the helper must
+  // drop it, which is the harness's safe "no reasoning" path.
+  ctx.llm.resolveModelInfo = async () => ({ provider: "mock", model: "mock-model", reasoning: undefined });
+  const result = await dream.runDream(ctx, service, { dreamReasoningEffort: "high" });
+  assert.equal(result.ok, true);
+  for (const options of captured) {
+    assert.equal("reasoningEffort" in options, false, "no reasoning capability -> effort omitted, never rejected");
+  }
+  store.close();
+});
+
+test("defaultEffort trap: configured effort supported is forwarded verbatim", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const dream = createDreamScheduler({ onRun: () => Promise.resolve({ ok: true, skipped: true }) });
+  const { memory: a } = service.saveWithDedupe({ type: "project", title: "插件", content: "旧", importance: 3 });
+  const { memory: b } = service.saveWithDedupe({ type: "project", title: "插件2", content: "新细节", importance: 4 });
+  const captured = [];
+  const ctx = dreamCtx({
+    captured,
+    onConsolidation: () => JSON.stringify([
+      { action: "merge", ids: [a.id, b.id], keepSource: b.id, title: "合并标题", content: "合并内容", importance: 4 }
+    ])
+  });
+  ctx.llm.resolveModelInfo = async () => ({
+    provider: "mock",
+    model: "mock-model",
+    reasoning: { efforts: [{ id: "high" }, { id: "low" }], defaultEffort: "low" }
+  });
+  const result = await dream.runDream(ctx, service, { dreamReasoningEffort: "high" });
+  assert.equal(result.ok, true);
+  for (const options of captured) {
+    assert.equal(options.reasoningEffort, "high", "supported configured value untouched");
+  }
+  store.close();
+});
+
+test("defaultEffort trap: capability query failure falls back to configured effort (retry still guards)", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const dream = createDreamScheduler({ onRun: () => Promise.resolve({ ok: true, skipped: true }) });
+  const { memory: a } = service.saveWithDedupe({ type: "project", title: "插件", content: "旧", importance: 3 });
+  const { memory: b } = service.saveWithDedupe({ type: "project", title: "插件2", content: "新细节", importance: 4 });
+  const calls = [];
+  const warnings = [];
+  const ctx = {
+    logger: { warn: (m) => warnings.push(String(m)) },
+    agentDefaultModel: { currentSelection: () => ({ provider: "mock", model: "mock-model" }) },
+    llm: {
+      async *stream(options) {
+        calls.push(options);
+        if (options.reasoningEffort) {
+          throw new Error("UNSUPPORTED_REASONING_EFFORT: mock does not support reasoning effort \"high\"");
+        }
+        const userText = options.messages.find((m) => m.role === "user")?.content?.[0]?.text ?? "";
+        if (userText.startsWith("id=")) {
+          yield { type: "text-delta", index: 0, text: JSON.stringify([
+            { action: "merge", ids: [a.id, b.id], keepSource: b.id, title: "合并标题", content: "合并内容", importance: 4 }
+          ]) };
+        } else {
+          yield { type: "text-delta", index: 0, text: "记忆库总览：用户偏好中文。" };
+        }
+        yield { type: "finish", reason: { kind: "stop" } };
+      },
+      // Adapter knows nothing about the model — helper must not crash, and the
+      // configured effort flows through so withEffortFallback still retries.
+      resolveModelInfo: async () => { throw new Error("adapter not reachable"); }
+    }
+  };
+  const result = await dream.runDream(ctx, service, { dreamReasoningEffort: "high" });
+  assert.equal(result.ok, true, "run succeeds via the no-effort retry");
+  assert.equal(calls[0].reasoningEffort, "high", "configured effort forwarded when capability query fails");
+  assert.equal("reasoningEffort" in calls[1], false, "rejected effort retried without the field");
+  assert.ok(warnings.some((w) => w.includes("resolveModelInfo failed")), "capability-query failure is logged");
+  store.close();
+});
+
+test("defaultEffort trap: sleep conflict pass remaps a poison effort too", async () => {
+  const { store, service, vectorIndex } = sleepSetup();
+  const a = service.saveWithDedupe({ type: "project", title: "主题X", content: "内容A 关于主题X", importance: 3 }).memory;
+  const b = service.saveWithDedupe({ type: "project", title: "主题X副本", content: "内容B 关于主题X", importance: 3 }).memory;
+  vectorIndex.saveEmbedding(a.id, [1, 0, 0]);
+  vectorIndex.saveEmbedding(b.id, [1, 0, 0]);
+  const captured = [];
+  const ctx = sleepCtx(
+    (userText) => userText.startsWith("候选冲突")
+      ? JSON.stringify([{ action: "conflict", winner: a.id, loser: b.id, reason: "重复覆盖" }])
+      : "[]",
+    { provider: "mock", model: "sleep-model" },
+    captured
+  );
+  ctx.llm.resolveModelInfo = async (provider, model) => ({
+    provider,
+    model,
+    reasoning: { efforts: [{ id: "medium" }, { id: "high" }], defaultEffort: "low" }
+  });
+  const result = await runSleep(ctx, service, baseConfig({ sleepReasoningEffort: "low" }), ctx.logger, { embedder, vectorIndex }, null);
+  assert.equal(result.status, "ok");
+  assert.ok(captured.length >= 2, "conflict + pattern passes both hit the LLM");
+  for (const options of captured) {
+    assert.equal(options.reasoningEffort, "medium", "poison 'low' remapped on sleep passes too");
+  }
+  store.close();
+});


### PR DESCRIPTION
## 问题
UI「记忆巩固 · 失败」，报错 `UNSUPPORTED_REASONING_EFFORT: provider "volcano-engine" model "deepseek-v4-flash-ga-260731" does not support reasoning effort "low"`。

根因是 harness 的 **defaultEffort trap**：volcano 适配器声明 `reasoning.defaultEffort = "low"`，但模型并不支持 "low"，导致不管传不传 effort 字段，harness 都会代入 "low" → 必失败。v0.7.21 的「去掉字段重试」绕不过这个坑。

## 修复
新增 `resolveDreamEffort`（dream.js + sleep.js 共用），跑 LLM 前先调 `ctx.llm.resolveModelInfo(provider, model)` 查模型真实能力：
- 配置的 effort 受支持 → 原样透传
- 不支持 → 重映射到 defaultEffort / 第一个声明的 effort
- 模型无推理能力 → 彻底不传该字段
- 能力查询不可用或报错 → 退回配置值，withEffortFallback 仍兜底

第一次请求即携带合法 effort，不再触发 defaultEffort trap。

## 验证
新增 5 个回归测试（毒 default 重映射 / 无推理能力省略字段 / 支持值透传 / 查询失败回退 / sleep 路径），723/723 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reasoning-effort handling for dream and sleep operations.
  - Configured effort levels are now checked against the selected model’s supported capabilities.
  - Unsupported settings are omitted or replaced with a supported fallback, reducing failed requests.
  - Models without reasoning support continue to work without sending unsupported options.
  - Existing fallback behavior remains available when capability information cannot be retrieved.

- **Documentation**
  - Added descriptions to dream and sleep provider, model, and reasoning-effort configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->