### PR TITLE
docs: 模型工具正文表补 memory_get（标题 7→8）

### DIFF
--- a/dsh-mneme/README.en.md
+++ b/dsh-mneme/README.en.md
@@ -26,13 +26,14 @@ English | [简体中文](README.md)
   - Per-type `committed / failed / pending` receipts; the health endpoint distinguishes `ok / degraded / unknown`
   - State write failures are never silent: sync failures are logged and leave debt behind, converging automatically on restart
 
-### Model Tools (7)
+### Model Tools (8)
 
 | Tool | Function |
 |------|------|
 | `memory_save` | Save a memory (automatic dedup and merge by title) |
 | `memory_search` | Full-text search (Chinese-substring friendly; vector semantic search can be enabled) |
 | `memory_list` | Paginated listing by type (`include_archived=true` to view archived items) |
+| `memory_get` | Read a single memory's full body by id (v0.7.25; read the full text after a search/list hit) |
 | `memory_update` | Modify an existing memory |
 | `memory_delete` | Delete a memory |
 | `memory_forget` | Suppress injection (down-weighted rather than deleted; recoverable) |

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -49,13 +49,14 @@ dsh web
   - 逐 type 记录 `committed / failed / pending` 回执，健康端点区分 `ok / degraded / unknown`
   - 状态写失败不静默：同步失败落日志并留债务，重启自动收敛
 
-### 模型工具（7 个）
+### 模型工具（8 个）
 
 | 工具 | 功能 |
 |------|------|
 | `memory_save` | 记录一条记忆（自动按标题去重合并） |
 | `memory_search` | 全文搜索（中文子串友好，可启用向量语义搜索） |
 | `memory_list` | 按类型分页列出（`include_archived=true` 可查看已归档） |
+| `memory_get` | 读取单条记忆完整正文（v0.7.25，按 id；memory_search / memory_list 命中后读全文） |
 | `memory_update` | 修改已有记忆 |
 | `memory_delete` | 删除记忆（按记忆 ID 精确删除） |
 | `memory_forget` | 抑制注入（降权不删除，可恢复） |


### PR DESCRIPTION
v0.7.25 加入 memory_get（第 8 个模型工具）时，README 正文「模型工具」一节只改了架构图与源码结构，漏了章节标题与工具表本身——标题仍写 7 个、表里也没有 memory_get。

- dsh-mneme/README.md「模型工具（7 个）→（8 个）」，表格补 `memory_get` 行（按 id 读单条记忆完整正文）
- dsh-mneme/README.en.md 同步（Model Tools 7→8）

纯文档改动，无代码变更。