### PR TITLE
release: v0.7.26 巩固 effort 陷阱根治 + LLM 连通性测试 + 文档收尾

### DIFF
--- a/dsh-mneme/README.en.md
+++ b/dsh-mneme/README.en.md
@@ -67,14 +67,14 @@ The default `32768` reserves headroom for reasoning models, where reasoning alon
 | Medium (10k–50k chars) | `65536` |
 | Large (>50k chars) | `131072` (cap) |
 
-> With **reasoning models** (e.g. DeepSeek-R1-like), the model may spend the entire budget on reasoning and return an empty body (the log shows `no json array in llm output`). Resolution order: ① set `dreamReasoningEffort` to `low` to suppress reasoning overhead (when the provider rejects the parameter it is stripped automatically and retried once — the rejection reason lands in `llm_audit`); ② if the retry still returns an empty body under the model's default reasoning behavior, raise `dreamMaxTokens` (reasoning and body share this budget) or route `dreamProvider`/`dreamModel` to a non-reasoning model. The sleep side has the corresponding `sleepReasoningEffort`.
+> With **reasoning models** (e.g. DeepSeek-R1-like), the model may spend the entire budget on reasoning and return an empty body (the log shows `no json array in llm output`). Resolution order: ① set `dreamReasoningEffort` to `low` to suppress reasoning overhead (v0.7.26+: if the model doesn't support that tier, `resolveDreamEffort` auto-falls back to the model's default/first supported tier or omits the field — the rejection reason lands in `llm_audit`); ② if the retry still returns an empty body under the model's default reasoning behavior, raise `dreamMaxTokens` (reasoning and body share this budget) or route `dreamProvider`/`dreamModel` to a non-reasoning model. The sleep side has the corresponding `sleepReasoningEffort`.
 
 **Consolidation model classification** (settings panel "consolidation model" = `dreamProvider`/`dreamModel`; sleep side: `sleepProvider`/`sleepModel`):
 
 | Model kind | Examples | Notes |
 |-----------|----------|-------|
 | **Non-reasoning (recommended)** | glm-5-2-class | No reasoning declaration; even if an effort is configured and the harness rejects it, the fallback strips the field and the retry succeeds. Lowest risk of empty-body runs |
-| **Reasoning (test first)** | deepseek-v4-flash-ga and other v4-flash-ga family | Reasons by default and may burn the whole token budget on an empty body; some SKUs (e.g. v4-flash-ga) are additionally declared by the harness as accepting **no reasoning effort at all** — the no-effort retry still gets rejected through the harness `defaultEffort` (`UNSUPPORTED_REASONING_EFFORT`), which the plugin fallback cannot bypass. If you use one, set `dreamReasoningEffort` and test; switch to a non-reasoning model otherwise |
+| **Reasoning (test first)** | deepseek-v4-flash-ga and other v4-flash-ga family | Reasons by default and may burn the whole token budget on an empty body; some SKUs (e.g. v4-flash-ga) are additionally declared by the harness as accepting **no reasoning effort at all** (the no-effort retry gets rejected through the harness `defaultEffort`, `UNSUPPORTED_REASONING_EFFORT`). Fixed in v0.7.26+: `resolveDreamEffort` probes the model's supported effort tiers before streaming — an unsupported configured tier auto-falls back to the model's default/first supported tier, and the field is omitted for models that declare no reasoning capability. If you use one, set `dreamReasoningEffort` and test; switch to a non-reasoning model otherwise |
 
 ### Sleep Mode: System-Level Sleep 💤 (v0.4.0, opt-in)
 
@@ -306,7 +306,7 @@ It works out of the box with the defaults. To adjust, override in `~/.dsh/profil
 | `dreamDelayMs` | `2000` | Asynchronous consolidation delay (debounce) |
 | `dreamProvider` / `dreamModel` | empty | Explicit dream LLM route — config wins over the agent's default model (config-first, v0.7.16); left empty, the agent's default model is used |
 | `dreamMaxTokens` | `32768` | Maximum tokens per dream LLM call (cap 131072; reasoning and body share this budget on reasoning models — raise it when the body comes back empty, see the tuning guide below) |
-| `dreamReasoningEffort` | `none` | Reasoning-effort passthrough for the dream LLM: `low` / `medium` / `high` / `none` (`none` = omit the field and use the model default; set `low` when a reasoning model exhausts its budget on reasoning and produces an empty body) |
+| `dreamReasoningEffort` | `none` | Reasoning-effort passthrough for the dream LLM: `low` / `medium` / `high` / `none` (`none` = omit the field and use the model default; set `low` when a reasoning model exhausts its budget on reasoning and produces an empty body; v0.7.26+ auto-falls back to the model's default/first supported tier when the configured tier is unsupported, and omits the field for models without reasoning capability) |
 | `apiToken` | empty | Optional API auth token; once set, write operations and key endpoints require `Authorization: Bearer <apiToken>` |
 | `embedProvider` | `openai` | Semantic backend: `openai` (default, v0.1-compatible) / `local` (ONNX offline) / `ollama` |
 | `localEmbedModel` | `Xenova/bge-small-zh-v1.5` | Local ONNX embedding model |

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -90,14 +90,14 @@ dsh web
 | 中等（1 万-5 万字） | `65536` |
 | 大型（5 万字以上） | `131072`（上限） |
 
-> 若使用**思考型模型**（如 deepseek-v4-flash / DeepSeek-R1 类），模型可能把全部预算花在 reasoning 上导致正文为空（日志出现 `no json array in llm output`）。处理顺序：① 把 `dreamReasoningEffort` 设为 `low` 显式压低思考（被方舟拒绝该参数时自动去掉重试一次，拒绝原因会记入 llm_audit）；② 重试走模型默认思考行为后正文仍为空的，调大 `dreamMaxTokens`（reasoning 与正文共享该预算）或配置 `dreamProvider`/`dreamModel` 指向非思考模型。sleep 侧对应 `sleepReasoningEffort`。
+> 若使用**思考型模型**（如 deepseek-v4-flash / DeepSeek-R1 类），模型可能把全部预算花在 reasoning 上导致正文为空（日志出现 `no json array in llm output`）。处理顺序：① 把 `dreamReasoningEffort` 设为 `low` 显式压低思考（v0.7.26+ 若模型不支持该档位，`resolveDreamEffort` 会自动换用模型支持的默认/首个档位或省略字段，拒绝原因会记入 llm_audit）；② 重试走模型默认思考行为后正文仍为空的，调大 `dreamMaxTokens`（reasoning 与正文共享该预算）或配置 `dreamProvider`/`dreamModel` 指向非思考模型。sleep 侧对应 `sleepReasoningEffort`。
 
 **巩固模型分类声明**（settings panel「巩固模型」= `dreamProvider`/`dreamModel`，睡眠侧对应 `sleepProvider`/`sleepModel`）：
 
 | 模型类别 | 例子 | 说明 |
 |---------|------|------|
 | **非思考模型（推荐）** | glm-5-2 类等 | 无 reasoning 声明；即使配了 effort 被 harness 拒绝，fallback 去掉字段重试即成功。空体风险最低 |
-| **思考模型（需实测）** | deepseek-v4-flash-ga 等 v4-flash-ga 系 | 默认开推理，可能烧光 token 预算返回空体；且部分型号（如 v4-flash-ga）在 harness 侧被声明为**不接受任何 reasoning effort** —— 去掉 effort 重试时 harness 的 `defaultEffort` 仍会顶上来再次拒绝（`UNSUPPORTED_REASONING_EFFORT`），插件侧 fallback 无法绕开。选用时建议配 `dreamReasoningEffort` 实测，不行就换非思考模型 |
+| **思考模型（需实测）** | deepseek-v4-flash-ga 等 v4-flash-ga 系 | 默认开推理，可能烧光 token 预算返回空体；部分型号（如 v4-flash-ga）在 harness 侧被声明为**不接受任何 reasoning effort**（去掉 effort 时 harness 的 `defaultEffort` 会顶上来再次拒绝）。v0.7.26+ 已根治：`resolveDreamEffort` 发流前探测模型支持的档位，不支持的配置档位自动换用模型默认/首个支持档位，声明无 reasoning 能力的型号则省略字段。选用时建议配 `dreamReasoningEffort` 实测，不行就换非思考模型 |
 
 ### Sleep Mode 系统级睡眠 💤（v0.4.0，opt-in）
 
@@ -380,7 +380,7 @@ dsh web
 | `dreamDelayMs` | `2000` | 整理异步延迟（去抖） |
 | `dreamProvider` / `dreamModel` | 空 | dream 的 LLM 路由覆盖（显式配置优先于 agent 默认模型；留空则回退到 agent 默认模型） |
 | `dreamMaxTokens` | `32768` | dream LLM 调用最大 token 数（上限 131072；思考型模型的 reasoning 与正文共享该预算，正文为空时优先调大，见下方调优指南） |
-| `dreamReasoningEffort` | `none` | dream LLM 推理强度透传：`low` / `medium` / `high` / `none`（`none`=不传该字段，沿用模型默认；思考型模型（如 deepseek-v4-flash）想压低思考可设 `low`；被方舟拒绝该参数时 v0.7.16 起自动去掉重试一次） |
+| `dreamReasoningEffort` | `none` | dream LLM 推理强度透传：`low` / `medium` / `high` / `none`（`none`=不传该字段，沿用模型默认；思考型模型（如 deepseek-v4-flash）想压低思考可设 `low`；v0.7.26+ 模型不支持配置档位时自动换用其支持的默认/首个档位，无 reasoning 能力的型号省略字段） |
 | `apiToken` | 空 | 可选 API 鉴权 token；设置后写操作与密钥接口要求 `Authorization: Bearer <apiToken>` |
 | `embedProvider` | `openai` | 语义后端：`openai`（默认，兼容 v0.1）/ `local`（ONNX 离线）/ `ollama` |
 | `localEmbedModel` | `Xenova/bge-small-zh-v1.5` | 本地 ONNX embedding 模型 |

--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modusensus/dsh-mneme",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modusensus/dsh-mneme",
-      "version": "0.7.25",
+      "version": "0.7.26",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
@@ -32,7 +32,7 @@
         "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
         "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
         "@deepseek-ai/schemastery": "^3.18.1",
-        "dsh-better-sidebar": "*"
+        "dsh-better-sidebar": "^0.18.0"
       },
       "peerDependenciesMeta": {
         "dsh-better-sidebar": {

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modusensus/dsh-mneme",
   "description": "Cross-session memory plugin for DeepSeek Harness with autoDream consolidation: SQLite store, Markdown mirrors, 7 model tools, automatic injection, session summarization, user profile/rules, custom slash commands, vector (semantic) search, and a Web GUI panel",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 发版内容（CHANGELOG [0.7.26]）

### 🐛 修复

- **记忆巩固 `UNSUPPORTED_REASONING_EFFORT` 根治（defaultEffort 陷阱）**：harness 在 effort 省略时注入 `reasoning.defaultEffort`，默认档位不被模型支持则任何重试无效 → 新增 `resolveDreamEffort` 经 `ctx.llm.resolveModelInfo()` 发流前探测模型支持的档位（不支持的配置档位自动换用模型默认/首个支持档位，无 reasoning 能力则省略字段）；autoDream 与 sleep 共用。
- **设置面板巩固/睡眠模型字段选型提示**：6 字段补 `.description()`（引导非思考模型）。

### ✨ 新增

- **`GET /api/dsh-mneme/llm-providers`**：宿主侧 provider/model 发现（密钥不经插件侧）。
- **`POST /api/dsh-mneme/test-model`**：模型连通性测试（空 body 按巩固路由解析返回 `modelId`；requireAuth 鉴权）。

### 🏗️ 工程

- 测试清理：移除 identity `.replace()`（CodeQL `js/identity-replacement`）。
- 文档收尾：CHANGELOG [0.7.26]、README 双表 v0.7.25/v0.7.26（#97/#98）、模型工具表补 memory_get、巩固模型引导同步 v0.7.26 新行为（cherry-pick 补入 #98 squash 丢失的第二个 commit）。
- 732 测试全绿。

Co-authored-by: Anans-Ivresse <Ivresse.ai@outlook.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to explain automatic reasoning-effort fallback based on each model’s supported tiers.
  * Clarified that reasoning parameters are omitted for models without reasoning support.
  * Documented behavior for models that accept no reasoning effort.

* **Chores**
  * Updated the package version to 0.7.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->