### PR TITLE
fix: 补齐 LLM 连通性测试端点（v0.7.26 遗漏的 settings-panel 后端）

### DIFF
--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -4,7 +4,7 @@ import { timingSafeEqual, randomBytes } from "node:crypto";
 import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
-import { describeStreamFailure } from "./dream.js";
+import { describeStreamFailure, resolveRoute } from "./dream.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -287,6 +287,8 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   // actually accepts the configured effort without tripping a full run.
   async function testLlmConnectivity(llm, provider, model, reasoningEffort) {
     const startedAt = Date.now();
+    const elapsed = () => Date.now() - startedAt;
+    const modelId = `${provider}:${model}`;
     try {
       let reply = "";
       let error = "";
@@ -304,11 +306,10 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           break;
         }
       }
-      const latencyMs = Date.now() - startedAt;
-      if (error) return { ok: false, latencyMs, error };
-      return { ok: true, latencyMs, reply: reply.trim().slice(0, 100) };
+      if (error) return { ok: false, durationMs: elapsed(), error, modelId };
+      return { ok: true, durationMs: elapsed(), modelId, reply: reply.trim().slice(0, 100) };
     } catch (error) {
-      return { ok: false, latencyMs: Date.now() - startedAt, error: String(error?.message ?? error) };
+      return { ok: false, durationMs: elapsed(), error: String(error?.message ?? error), modelId };
     }
   }
 
@@ -331,8 +332,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           let models = [];
           try { models = (await llm.listModels(p.id)) ?? []; } catch { models = []; }
           return {
-            id: p.id,
-            name: p.name ?? p.id,
+            provider: p.id,
             models: models.map((m) => ({ id: m.id, name: m.name ?? m.id }))
           };
         })).then((rows) => sendJson(res, 200, { providers: rows }));
@@ -354,9 +354,17 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
         if (!requireAuth(req, res, apiToken)) return;
         return readBody(req).then(async (text) => {
           const body = parseBody(text);
-          const provider = typeof body.provider === "string" ? body.provider.trim() : "";
-          const model = typeof body.model === "string" ? body.model.trim() : "";
-          if (!provider || !model) return sendJson(res, 400, { error: "missing-provider-or-model" });
+          let provider = typeof body.provider === "string" ? body.provider.trim() : "";
+          let model = typeof body.model === "string" ? body.model.trim() : "";
+          if ((!provider && model) || (provider && !model)) return sendJson(res, 400, { error: "missing-provider-or-model" });
+          if (!provider && !model) {
+            // 空 = 按巩固路由解析（dreamProvider/dreamModel > agent 默认模型），
+            // 让面板一键测"当前巩固模型"而无需手填。
+            const route = resolveRoute(ctx, config ?? {}, ctx.logger);
+            if (!route) return sendJson(res, 400, { error: "no-route" });
+            provider = route.provider;
+            model = route.model;
+          }
           const llm = ctx.llm;
           if (typeof llm?.stream !== "function") return sendJson(res, 501, { error: "llm-unavailable" });
           const result = await testLlmConnectivity(llm, provider, model, body.reasoningEffort);

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -4,6 +4,7 @@ import { timingSafeEqual, randomBytes } from "node:crypto";
 import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
+import { describeStreamFailure } from "./dream.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -273,6 +274,96 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
         sendJson(res, 200, { profile: settings.getProfile() });
       } catch {
         sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- dream/sleep 模型连通性 + 模型发现（settings 面板）----------------------
+  // Connectivity probe for a dream/sleep model route: runs one minimal LLM call
+  // through the same harness path the consolidation uses and reports success /
+  // failure + latency + error. Reuses describeStreamFailure so the panel shows
+  // the same error wording the audit rows carry. Optional reasoningEffort
+  // mirrors what the consolidation would send — the panel can verify a model
+  // actually accepts the configured effort without tripping a full run.
+  async function testLlmConnectivity(llm, provider, model, reasoningEffort) {
+    const startedAt = Date.now();
+    try {
+      let reply = "";
+      let error = "";
+      for await (const chunk of llm.stream({
+        provider,
+        model,
+        purpose: "dsh-mneme-connectivity-test",
+        maxTokens: 16,
+        ...(reasoningEffort && reasoningEffort !== "none" ? { reasoningEffort } : {}),
+        messages: [{ role: "system", content: [{ type: "text", text: "Reply with exactly one word: ok" }] }]
+      })) {
+        if (chunk.type === "text-delta" && typeof chunk.text === "string") reply += chunk.text;
+        if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) {
+          error = describeStreamFailure(chunk.reason);
+          break;
+        }
+      }
+      const latencyMs = Date.now() - startedAt;
+      if (error) return { ok: false, latencyMs, error };
+      return { ok: true, latencyMs, reply: reply.trim().slice(0, 100) };
+    } catch (error) {
+      return { ok: false, latencyMs: Date.now() - startedAt, error: String(error?.message ?? error) };
+    }
+  }
+
+  // List every provider + model the host has registered, so the panel can offer
+  // a dropdown over REAL models instead of free-text guesses. Read-only, no auth
+  // (same as list/search). Best-effort per provider: one whose model list can't
+  // be resolved yields an empty models array instead of failing the whole call.
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/llm-providers",
+    handler(req, res) {
+      try {
+        const llm = ctx.llm;
+        if (typeof llm?.listProviders !== "function" || typeof llm?.listModels !== "function") {
+          return sendJson(res, 501, { error: "llm-unavailable" });
+        }
+        let providers;
+        try { providers = llm.listProviders() ?? []; } catch { providers = []; }
+        return Promise.all(providers.map(async (p) => {
+          let models = [];
+          try { models = (await llm.listModels(p.id)) ?? []; } catch { models = []; }
+          return {
+            id: p.id,
+            name: p.name ?? p.id,
+            models: models.map((m) => ({ id: m.id, name: m.name ?? m.id }))
+          };
+        })).then((rows) => sendJson(res, 200, { providers: rows }));
+      } catch {
+        return sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // Connectivity test for a dream/sleep model route. Runs one tiny LLM call and
+  // reports ok / failure + latency + error. Auth-gated: it spends the user's
+  // API quota, so a stray local page must not be able to drain it via loopback.
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/test-model",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") return sendJson(res, 404, { error: "not-found" });
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then(async (text) => {
+          const body = parseBody(text);
+          const provider = typeof body.provider === "string" ? body.provider.trim() : "";
+          const model = typeof body.model === "string" ? body.model.trim() : "";
+          if (!provider || !model) return sendJson(res, 400, { error: "missing-provider-or-model" });
+          const llm = ctx.llm;
+          if (typeof llm?.stream !== "function") return sendJson(res, 501, { error: "llm-unavailable" });
+          const result = await testLlmConnectivity(llm, provider, model, body.reasoningEffort);
+          return sendJson(res, result.ok ? 200 : 502, result);
+        });
+      } catch {
+        return sendJson(res, 500, { error: "internal" });
       }
     }
   });

--- a/dsh-mneme/lib/dream.js
+++ b/dsh-mneme/lib/dream.js
@@ -1,7 +1,7 @@
 import { validateDecisions, applyDecisions } from "./dream/decisions.js";
 import { clusterMemories, findPotentialConflicts } from "./dream/clustering.js";
 import { createHash, randomUUID } from "node:crypto";
-export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure, resolveDreamEffort };
+export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure, resolveDreamEffort, resolveRoute };
 
 
 // Extract the first JSON array from LLM output, tolerating markdown fences,

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -4,7 +4,7 @@ import { timingSafeEqual, randomBytes } from "node:crypto";
 import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
-import { describeStreamFailure } from "./dream.js";
+import { describeStreamFailure, resolveRoute } from "./dream.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -287,6 +287,8 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   // actually accepts the configured effort without tripping a full run.
   async function testLlmConnectivity(llm, provider, model, reasoningEffort) {
     const startedAt = Date.now();
+    const elapsed = () => Date.now() - startedAt;
+    const modelId = `${provider}:${model}`;
     try {
       let reply = "";
       let error = "";
@@ -304,11 +306,10 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           break;
         }
       }
-      const latencyMs = Date.now() - startedAt;
-      if (error) return { ok: false, latencyMs, error };
-      return { ok: true, latencyMs, reply: reply.trim().slice(0, 100) };
+      if (error) return { ok: false, durationMs: elapsed(), error, modelId };
+      return { ok: true, durationMs: elapsed(), modelId, reply: reply.trim().slice(0, 100) };
     } catch (error) {
-      return { ok: false, latencyMs: Date.now() - startedAt, error: String(error?.message ?? error) };
+      return { ok: false, durationMs: elapsed(), error: String(error?.message ?? error), modelId };
     }
   }
 
@@ -331,8 +332,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           let models = [];
           try { models = (await llm.listModels(p.id)) ?? []; } catch { models = []; }
           return {
-            id: p.id,
-            name: p.name ?? p.id,
+            provider: p.id,
             models: models.map((m) => ({ id: m.id, name: m.name ?? m.id }))
           };
         })).then((rows) => sendJson(res, 200, { providers: rows }));
@@ -354,9 +354,17 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
         if (!requireAuth(req, res, apiToken)) return;
         return readBody(req).then(async (text) => {
           const body = parseBody(text);
-          const provider = typeof body.provider === "string" ? body.provider.trim() : "";
-          const model = typeof body.model === "string" ? body.model.trim() : "";
-          if (!provider || !model) return sendJson(res, 400, { error: "missing-provider-or-model" });
+          let provider = typeof body.provider === "string" ? body.provider.trim() : "";
+          let model = typeof body.model === "string" ? body.model.trim() : "";
+          if ((!provider && model) || (provider && !model)) return sendJson(res, 400, { error: "missing-provider-or-model" });
+          if (!provider && !model) {
+            // 空 = 按巩固路由解析（dreamProvider/dreamModel > agent 默认模型），
+            // 让面板一键测"当前巩固模型"而无需手填。
+            const route = resolveRoute(ctx, config ?? {}, ctx.logger);
+            if (!route) return sendJson(res, 400, { error: "no-route" });
+            provider = route.provider;
+            model = route.model;
+          }
           const llm = ctx.llm;
           if (typeof llm?.stream !== "function") return sendJson(res, 501, { error: "llm-unavailable" });
           const result = await testLlmConnectivity(llm, provider, model, body.reasoningEffort);

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -4,6 +4,7 @@ import { timingSafeEqual, randomBytes } from "node:crypto";
 import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
+import { describeStreamFailure } from "./dream.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -273,6 +274,96 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
         sendJson(res, 200, { profile: settings.getProfile() });
       } catch {
         sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // --- dream/sleep 模型连通性 + 模型发现（settings 面板）----------------------
+  // Connectivity probe for a dream/sleep model route: runs one minimal LLM call
+  // through the same harness path the consolidation uses and reports success /
+  // failure + latency + error. Reuses describeStreamFailure so the panel shows
+  // the same error wording the audit rows carry. Optional reasoningEffort
+  // mirrors what the consolidation would send — the panel can verify a model
+  // actually accepts the configured effort without tripping a full run.
+  async function testLlmConnectivity(llm, provider, model, reasoningEffort) {
+    const startedAt = Date.now();
+    try {
+      let reply = "";
+      let error = "";
+      for await (const chunk of llm.stream({
+        provider,
+        model,
+        purpose: "dsh-mneme-connectivity-test",
+        maxTokens: 16,
+        ...(reasoningEffort && reasoningEffort !== "none" ? { reasoningEffort } : {}),
+        messages: [{ role: "system", content: [{ type: "text", text: "Reply with exactly one word: ok" }] }]
+      })) {
+        if (chunk.type === "text-delta" && typeof chunk.text === "string") reply += chunk.text;
+        if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) {
+          error = describeStreamFailure(chunk.reason);
+          break;
+        }
+      }
+      const latencyMs = Date.now() - startedAt;
+      if (error) return { ok: false, latencyMs, error };
+      return { ok: true, latencyMs, reply: reply.trim().slice(0, 100) };
+    } catch (error) {
+      return { ok: false, latencyMs: Date.now() - startedAt, error: String(error?.message ?? error) };
+    }
+  }
+
+  // List every provider + model the host has registered, so the panel can offer
+  // a dropdown over REAL models instead of free-text guesses. Read-only, no auth
+  // (same as list/search). Best-effort per provider: one whose model list can't
+  // be resolved yields an empty models array instead of failing the whole call.
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/llm-providers",
+    handler(req, res) {
+      try {
+        const llm = ctx.llm;
+        if (typeof llm?.listProviders !== "function" || typeof llm?.listModels !== "function") {
+          return sendJson(res, 501, { error: "llm-unavailable" });
+        }
+        let providers;
+        try { providers = llm.listProviders() ?? []; } catch { providers = []; }
+        return Promise.all(providers.map(async (p) => {
+          let models = [];
+          try { models = (await llm.listModels(p.id)) ?? []; } catch { models = []; }
+          return {
+            id: p.id,
+            name: p.name ?? p.id,
+            models: models.map((m) => ({ id: m.id, name: m.name ?? m.id }))
+          };
+        })).then((rows) => sendJson(res, 200, { providers: rows }));
+      } catch {
+        return sendJson(res, 500, { error: "internal" });
+      }
+    }
+  });
+
+  // Connectivity test for a dream/sleep model route. Runs one tiny LLM call and
+  // reports ok / failure + latency + error. Auth-gated: it spends the user's
+  // API quota, so a stray local page must not be able to drain it via loopback.
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/test-model",
+    handler(req, res) {
+      try {
+        if (req.method !== "POST") return sendJson(res, 404, { error: "not-found" });
+        if (!requireAuth(req, res, apiToken)) return;
+        return readBody(req).then(async (text) => {
+          const body = parseBody(text);
+          const provider = typeof body.provider === "string" ? body.provider.trim() : "";
+          const model = typeof body.model === "string" ? body.model.trim() : "";
+          if (!provider || !model) return sendJson(res, 400, { error: "missing-provider-or-model" });
+          const llm = ctx.llm;
+          if (typeof llm?.stream !== "function") return sendJson(res, 501, { error: "llm-unavailable" });
+          const result = await testLlmConnectivity(llm, provider, model, body.reasoningEffort);
+          return sendJson(res, result.ok ? 200 : 502, result);
+        });
+      } catch {
+        return sendJson(res, 500, { error: "internal" });
       }
     }
   });

--- a/dsh-mneme/src/dream.js
+++ b/dsh-mneme/src/dream.js
@@ -1,7 +1,7 @@
 import { validateDecisions, applyDecisions } from "./dream/decisions.js";
 import { clusterMemories, findPotentialConflicts } from "./dream/clustering.js";
 import { createHash, randomUUID } from "node:crypto";
-export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure, resolveDreamEffort };
+export { validateDecisions, applyDecisions, withEffortFallback, describeStreamFailure, resolveDreamEffort, resolveRoute };
 
 
 // Extract the first JSON array from LLM output, tolerating markdown fences,

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -1085,3 +1085,139 @@ test("GET /api/dsh-mneme/list projects per-memory heat only when heatEnabled=tru
     assert.ok(typeof v === "number" && v >= 0 && v <= 1, "heat values stay within [0,1]");
   }
 });
+
+// ---------------------------------------------------------------- llm-providers / test-model
+// Settings-panel support: enumerate host-registered providers/models so the
+// panel can offer a dropdown over real models, and probe connectivity with a
+// minimal LLM call (same harness path the consolidation uses).
+
+function setupLlm(llm, apiToken = "") {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const settings = createSettings(store.db);
+  const commands = { add: () => {}, remove: () => {}, list: () => [] };
+  const routes = [];
+  const ctx = {
+    webServer: { register(route) { routes.push(route); return () => {}; } },
+    llm
+  };
+  const api = createApi(ctx, service, settings, commands, undefined, undefined, apiToken);
+  return { routes };
+}
+
+const MOCK_LLM = {
+  listProviders: () => [
+    { id: "deepseek", name: "DeepSeek" },
+    { id: "broken", name: "Broken Adapter" }
+  ],
+  listModels: async (provider) => {
+    if (provider === "broken") throw new Error("provider not reachable");
+    return [{ id: "deepseek-chat", name: "DeepSeek Chat" }, { id: "deepseek-reasoner", name: "DeepSeek Reasoner" }];
+  },
+  async *stream(options) {
+    MOCK_LLM.lastOptions = options;
+    if (options.model === "bad-model") {
+      yield {
+        type: "finish",
+        reason: { kind: "error", failure: { code: "AUTH_FAILED", message: "invalid api key" } }
+      };
+      return;
+    }
+    if (options.reasoningEffort === "reject") {
+      throw new Error('UNSUPPORTED_REASONING_EFFORT: provider "mock" model "mock-model" does not support reasoning effort "reject"');
+    }
+    yield { type: "text-delta", index: 0, text: " ok " };
+    yield { type: "finish", reason: { kind: "stop" } };
+  }
+};
+
+test("GET /api/dsh-mneme/llm-providers lists host providers with models, per-provider best effort", async () => {
+  const { routes } = setupLlm(MOCK_LLM);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/llm-providers");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/llm-providers"), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.equal(data.providers.length, 2);
+  const deepseek = data.providers.find((p) => p.id === "deepseek");
+  assert.deepEqual(deepseek.models.map((m) => m.id), ["deepseek-chat", "deepseek-reasoner"]);
+  const broken = data.providers.find((p) => p.id === "broken");
+  assert.deepEqual(broken.models, [], "a provider whose model list throws degrades to empty, not a hard fail");
+});
+
+test("GET /api/dsh-mneme/llm-providers without ctx.llm returns 501", async () => {
+  const { routes } = setup();
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/llm-providers");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/llm-providers"), res);
+  assert.equal(res.statusCode, 501);
+  assert.equal(JSON.parse(res.body).error, "llm-unavailable");
+});
+
+test("POST /api/dsh-mneme/test-model succeeds and reports reply + latency", async () => {
+  const { routes } = setupLlm(MOCK_LLM);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "deepseek", model: "deepseek-chat" }), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.equal(data.ok, true);
+  assert.equal(data.reply, "ok", "reply trimmed");
+  assert.ok(data.latencyMs >= 0);
+  assert.equal(MOCK_LLM.lastOptions.provider, "deepseek");
+  assert.equal(MOCK_LLM.lastOptions.purpose, "dsh-mneme-connectivity-test");
+  assert.equal("reasoningEffort" in MOCK_LLM.lastOptions, false, "no effort configured -> field omitted");
+});
+
+test("POST /api/dsh-mneme/test-model forwards reasoningEffort verbatim", async () => {
+  const { routes } = setupLlm(MOCK_LLM);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "deepseek", model: "deepseek-chat", reasoningEffort: "low" }), res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(MOCK_LLM.lastOptions.reasoningEffort, "low", "effort forwarded to the probe call");
+});
+
+test("POST /api/dsh-mneme/test-model reports stream-level failure with 502", async () => {
+  const { routes } = setupLlm(MOCK_LLM);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "deepseek", model: "bad-model" }), res);
+  assert.equal(res.statusCode, 502);
+  const data = JSON.parse(res.body);
+  assert.equal(data.ok, false);
+  assert.match(data.error, /AUTH_FAILED/, "stream failure reason surfaced like audit rows");
+});
+
+test("POST /api/dsh-mneme/test-model reports thrown failure with 502", async () => {
+  const { routes } = setupLlm(MOCK_LLM);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "mock", model: "mock-model", reasoningEffort: "reject" }), res);
+  assert.equal(res.statusCode, 502);
+  const data = JSON.parse(res.body);
+  assert.equal(data.ok, false);
+  assert.match(data.error, /UNSUPPORTED_REASONING_EFFORT/, "throw path surfaces the harness rejection");
+});
+
+test("POST /api/dsh-mneme/test-model validates input and llm availability", async () => {
+  const { routes } = setupLlm(MOCK_LLM);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  let res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", {}), res);
+  assert.equal(res.statusCode, 400, "missing provider+model rejected");
+
+  const { routes: routesNoLlm } = setup();
+  const routeNoLlm = routesNoLlm.find((r) => r.path === "/api/dsh-mneme/test-model");
+  res = new FakeRes();
+  await routeNoLlm.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "deepseek", model: "deepseek-chat" }), res);
+  assert.equal(res.statusCode, 501, "no ctx.llm -> llm-unavailable");
+});
+
+test("POST /api/dsh-mneme/test-model is auth-gated like other expensive endpoints", async () => {
+  const { routes } = setupLlm(MOCK_LLM, "secret-token");
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "deepseek", model: "deepseek-chat" }), res);
+  assert.equal(res.statusCode, 401, "probe spends the user's API quota, so it must require auth");
+});

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -1091,7 +1091,7 @@ test("GET /api/dsh-mneme/list projects per-memory heat only when heatEnabled=tru
 // panel can offer a dropdown over real models, and probe connectivity with a
 // minimal LLM call (same harness path the consolidation uses).
 
-function setupLlm(llm, apiToken = "") {
+function setupLlm(llm, apiToken = "", extraCtx = {}, config = null) {
   const store = createStore(":memory:");
   const service = createService({ store, mirror: null, config: {} });
   const settings = createSettings(store.db);
@@ -1099,9 +1099,10 @@ function setupLlm(llm, apiToken = "") {
   const routes = [];
   const ctx = {
     webServer: { register(route) { routes.push(route); return () => {}; } },
-    llm
+    llm,
+    ...extraCtx
   };
-  const api = createApi(ctx, service, settings, commands, undefined, undefined, apiToken);
+  const api = createApi(ctx, service, settings, commands, undefined, undefined, apiToken, config);
   return { routes };
 }
 
@@ -1139,9 +1140,9 @@ test("GET /api/dsh-mneme/llm-providers lists host providers with models, per-pro
   assert.equal(res.statusCode, 200);
   const data = JSON.parse(res.body);
   assert.equal(data.providers.length, 2);
-  const deepseek = data.providers.find((p) => p.id === "deepseek");
+  const deepseek = data.providers.find((p) => p.provider === "deepseek");
   assert.deepEqual(deepseek.models.map((m) => m.id), ["deepseek-chat", "deepseek-reasoner"]);
-  const broken = data.providers.find((p) => p.id === "broken");
+  const broken = data.providers.find((p) => p.provider === "broken");
   assert.deepEqual(broken.models, [], "a provider whose model list throws degrades to empty, not a hard fail");
 });
 
@@ -1163,7 +1164,8 @@ test("POST /api/dsh-mneme/test-model succeeds and reports reply + latency", asyn
   const data = JSON.parse(res.body);
   assert.equal(data.ok, true);
   assert.equal(data.reply, "ok", "reply trimmed");
-  assert.ok(data.latencyMs >= 0);
+  assert.ok(data.durationMs >= 0);
+  assert.equal(data.modelId, "deepseek:deepseek-chat", "modelId reports the probed route");
   assert.equal(MOCK_LLM.lastOptions.provider, "deepseek");
   assert.equal(MOCK_LLM.lastOptions.purpose, "dsh-mneme-connectivity-test");
   assert.equal("reasoningEffort" in MOCK_LLM.lastOptions, false, "no effort configured -> field omitted");
@@ -1200,12 +1202,37 @@ test("POST /api/dsh-mneme/test-model reports thrown failure with 502", async () 
   assert.match(data.error, /UNSUPPORTED_REASONING_EFFORT/, "throw path surfaces the harness rejection");
 });
 
+test("POST /api/dsh-mneme/test-model resolves empty body against the consolidation route", async () => {
+  // Empty provider/model = "test whatever consolidation uses now": the route
+  // falls back to agentDefaultModel (config dreamProvider/dreamModel absent),
+  // the probe runs against that model, and modelId reports what was tested.
+  const { routes } = setupLlm(MOCK_LLM, "", {
+    agentDefaultModel: { currentSelection: () => ({ provider: "sel-provider", model: "sel-model" }) }
+  });
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", {}), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  assert.equal(data.ok, true);
+  assert.equal(data.modelId, "sel-provider:sel-model", "probe ran against the resolved consolidation route");
+  assert.equal(MOCK_LLM.lastOptions.provider, "sel-provider");
+  assert.equal(MOCK_LLM.lastOptions.model, "sel-model");
+});
+
 test("POST /api/dsh-mneme/test-model validates input and llm availability", async () => {
   const { routes } = setupLlm(MOCK_LLM);
   const route = routes.find((r) => r.path === "/api/dsh-mneme/test-model");
   let res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/test-model", "POST", { provider: "deepseek" }), res);
+  assert.equal(res.statusCode, 400, "partial input (provider without model) rejected");
+  assert.equal(JSON.parse(res.body).error, "missing-provider-or-model");
+
+  // empty body with no route (no agentDefaultModel, no config route) -> no-route
+  res = new FakeRes();
   await route.handler(req("/api/dsh-mneme/test-model", "POST", {}), res);
-  assert.equal(res.statusCode, 400, "missing provider+model rejected");
+  assert.equal(res.statusCode, 400, "empty body with no resolvable route rejected");
+  assert.equal(JSON.parse(res.body).error, "no-route");
 
   const { routes: routesNoLlm } = setup();
   const routeNoLlm = routesNoLlm.find((r) => r.path === "/api/dsh-mneme/test-model");


### PR DESCRIPTION
## 背景
v0.7.26 已发布但端点分支未合入 main：面板的「级联下拉 + 测试连通性」调用 `llm-providers` / `test-model`，而 main 的 api.js 中无此二端点（前端侧 #96/#99 已落地，后端缺位会 404）。

## 内容
- settings-panel LLM 支持：provider/model 端点发现 + 连通性测试（bd4c97e）
- 对齐 Windows 前端契约（05d585c）
- 已 rebase 到当前 main，重复的 docs 提交及已上游内容自动丢弃
- lib/ 已同步，check-sync 通过；测试 733 全绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to list available LLM providers and their models.
  * Added an authenticated model connectivity test that reports the response, latency, and selected model.
  * Supports optional reasoning effort settings and automatic route selection when provider or model details are omitted.
* **Bug Fixes**
  * Added clear handling for unavailable providers, invalid model details, failed connections, and streaming errors.
  * Provider listing continues gracefully when an individual provider cannot be queried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->