### PR TITLE
feat(retrieval): recall fusion recipes + signal transparency (PR0+PR1)

### DIFF
--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -178,6 +178,19 @@ export const Config = z.object({
   searchSemanticDedup: z.boolean().default(false),
   searchSemanticDedupThreshold: z.number().min(0.5).max(1).default(0.95),
 
+  // Recall fusion recipe (plan #1): how the keyword/vector/BM25 ranked lists
+  // are combined into the final ranking. `blend` (default) is the legacy
+  // behavior — weighted sum for vector/hybrid, union backfill for auto —
+  // unchanged. `rrf` (Reciprocal Rank Fusion) and `minmax` (min-max normalized
+  // weighted sum) are rank/scale-aware recipes that fix the unit mismatch the
+  // issue describes (raw cosine vs keyword score vs normalized IDF are added
+  // directly). Off by default so existing behavior holds exactly.
+  recallFusion: z.union([z.const("blend"), z.const("rrf"), z.const("minmax")]).default("blend"),
+  // Attach a `signals` object { keyword, vector, bm25, final } to each search
+  // result for transparency/debugging (plan #2). Default off; when on it only
+  // decorates the returned rows, never changes the ranking.
+  signalTransparency: z.boolean().default(false),
+
   // --- semantic: rerank layer (v0.2) --------------------------------------
   // Opt-in by default (item ⑥): the local cross-encoder pulls in onnxruntime
   // (transformers.js) at init, so a bare install must not load it. Only an

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -416,6 +416,131 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     }
   }
 
+  /**
+   * Recall fusion (plan #1). Turns the three ranked signal lists (keyword,
+   * vector, BM25) into a single merged list. Three recipes, selected by
+   * config.recallFusion:
+   *  - blend (default): legacy behavior — weighted sum for vector/hybrid, union
+   *    backfill for auto. Byte-identical to pre-fusion code, so enabling the
+   *    config never regresses anybody.
+   *  - rrf: Reciprocal Rank Fusion — Σ 1/(k + rank + 1) over each list a row
+   *    appears in. Rank-based, so the unit mismatch (raw cosine vs keyword
+   *    score vs normalized IDF) is irrelevant.
+   *  - minmax: min-max normalize each source list's scores to [0,1] then take
+   *    the weighted sum — a scale-aware version of `blend`.
+   * Returns { merged, signals }, where signals is Map<id, {keyword, vector,
+   * bm25}> so searchMemories can decorate rows when signalTransparency is on.
+   */
+  function fuseRecall({ keyword, vector, bm25, lim, mode, wv, wk, wb }) {
+    const recipe = config?.recallFusion ?? "blend";
+
+    // Per-source scores are recorded for every recipe so signalTransparency
+    // works regardless of how the ranking was produced.
+    const signals = new Map();
+    const addSig = (id, field, sc) => {
+      const cur = signals.get(id) ?? {};
+      cur[field] = sc;
+      signals.set(id, cur);
+    };
+    for (const m of keyword) addSig(m.id, "keyword", m.score ?? 0);
+    for (const m of vector) addSig(m.id, "vector", m.score ?? 0);
+    for (const m of bm25) addSig(m.id, "bm25", m.score ?? 0);
+
+    const vectorIds = new Set(vector.map((m) => m.id));
+    const keywordIds = new Set(keyword.map((m) => m.id));
+
+    let merged;
+    if (recipe === "rrf") {
+      // Rank-based: only the position of a row inside each surviving source
+      // list matters, so no cross-signal scale calibration is needed.
+      const k = 60; // standard RRF constant (plan #1 documents k=60)
+      const rows = new Map();
+      const addList = (list) => list.forEach((m, idx) => {
+        const s = 1 / (k + idx + 1);
+        const cur = rows.get(m.id);
+        if (cur) cur.score += s;
+        else rows.set(m.id, { ...m, score: s });
+      });
+      addList(keyword);
+      addList(vector);
+      addList(bm25);
+      merged = [...rows.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0)).slice(0, lim);
+    } else if (recipe === "minmax") {
+      // Scale-aware weighted sum: each source list is min-max normalized to
+      // [0,1] before blending, so raw cosine and keyword score live on the
+      // same footing.
+      const norm = (list) => {
+        if (!list.length) return new Map();
+        let min = Infinity, max = -Infinity;
+        for (const m of list) { const s = m.score ?? 0; if (s < min) min = s; if (s > max) max = s; }
+        const range = max - min;
+        const out = new Map();
+        for (const m of list) out.set(m.id, range > 0 ? ((m.score ?? 0) - min) / range : 0.5);
+        return out;
+      };
+      const kw = norm(keyword), ve = norm(vector), bm = norm(bm25);
+      const rows = new Map();
+      const seed = (m) => { if (!rows.has(m.id)) rows.set(m.id, { ...m, score: 0 }); };
+      for (const m of keyword) seed(m);
+      for (const m of vector) seed(m);
+      for (const m of bm25) seed(m);
+      for (const [id, row] of rows) {
+        const k = kw.get(id) ?? 0;
+        const v = ve.get(id) ?? 0;
+        const b = bm.get(id) ?? 0;
+        row.score = v * wv + k * wk + b * wb;
+      }
+      merged = [...rows.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0)).slice(0, lim);
+    } else {
+      // blend — the pre-existing per-mode behavior, extracted verbatim.
+      if (mode === "keyword") {
+        merged = keyword;
+      } else if (mode === "vector" || mode === "hybrid") {
+        const byId = new Map();
+        for (const m of vector) {
+          const rec = byId.get(m.id);
+          byId.set(m.id, rec ? { ...rec, score: Math.max(rec.score ?? 0, m.score ?? 0) } : m);
+        }
+        for (const m of keyword) {
+          const rec = byId.get(m.id);
+          if (rec) {
+            byId.set(m.id, { ...rec, score: (rec.score ?? 0) * wv + (m.score ?? 0) * wk });
+          } else {
+            byId.set(m.id, m);
+          }
+        }
+        for (const m of bm25) {
+          const rec = byId.get(m.id);
+          if (rec) {
+            if (keywordIds.has(m.id)) continue;
+            byId.set(m.id, { ...rec, score: (rec.score ?? 0) + wb * (m.score ?? 0) });
+          } else {
+            byId.set(m.id, { ...m, score: wb * (m.score ?? 0) });
+          }
+        }
+        const ranked = [...byId.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+        merged = ranked.slice(0, lim);
+        if (merged.length < lim && !merged.length) {
+          merged = keyword.slice(0, lim);
+        }
+      } else {
+        // auto: keyword leads, vector + BM25 fill remaining slots.
+        merged = keyword.slice(0, lim);
+        const seen = new Set(merged.map((m) => m.id));
+        for (const m of vector) {
+          if (merged.length >= lim) break;
+          if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
+        }
+        for (const m of bm25) {
+          if (merged.length >= lim) break;
+          if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
+        }
+      }
+    }
+
+    return { merged, signals };
+  }
+
   async function searchMemories(query, options = {}) {
     const { mode = "auto", topK = 20, threshold, useRerank = true, recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true) } = options;
     const q = String(query ?? "").trim();
@@ -477,69 +602,17 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     // Loose blend weight: BM25 confirms and backfills, never dominates the
     // semantic signal. Same-memory overlap boosts, unseen ids backfill.
     const wb = 0.3;
-    // Path bookkeeping for the boost rule below: which ids each semantic
-    // recall path surfaced.
-    const vectorIds = new Set(vector.map((m) => m.id));
-    const keywordIds = new Set(keyword.map((m) => m.id));
 
     // Hybrid blending weights from config when provided.
     const wv = config?.hybridSearchVectorWeight ?? DEFAULT_HYBRID_WEIGHTS.vector;
     const wk = config?.hybridSearchKeywordWeight ?? DEFAULT_HYBRID_WEIGHTS.keyword;
 
-    let merged;
-    if (mode === "keyword") {
-      merged = keyword;
-    } else if (mode === "vector" || mode === "hybrid") {
-      // semantic-first: vector recalls lead, keyword + BM25 fill remaining
-      // slots. Weighted blend when sides scored the same memory; otherwise
-      // vector order leads (it is the semantic signal), lexical paths
-      // backfill.
-      const byId = new Map();
-      for (const m of vector) {
-        const rec = byId.get(m.id);
-        byId.set(m.id, rec ? { ...rec, score: Math.max(rec.score ?? 0, m.score ?? 0) } : m);
-      }
-      for (const m of keyword) {
-        const rec = byId.get(m.id);
-        if (rec) {
-          // Same memory from both sides: blend the scores.
-          byId.set(m.id, { ...rec, score: (rec.score ?? 0) * wv + (m.score ?? 0) * wk });
-        } else {
-          byId.set(m.id, m);
-        }
-      }
-      for (const m of bm25) {
-        const rec = byId.get(m.id);
-        if (rec) {
-          // Boost rule: a row the LIKE keyword path already hit carries the
-          // query as a substring, so BM25 tokens are trivially present —
-          // boosting it double-counts lexical evidence. Only vector-recalled
-          // rows (lexical hit is genuinely new information) get the boost.
-          if (keywordIds.has(m.id)) continue;
-          byId.set(m.id, { ...rec, score: (rec.score ?? 0) + wb * (m.score ?? 0) });
-        } else {
-          byId.set(m.id, { ...m, score: wb * (m.score ?? 0) });
-        }
-      }
-      const ranked = [...byId.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-      merged = ranked.slice(0, lim);
-      if (merged.length < lim && !merged.length) {
-        // Vector unavailable entirely: fall back to plain keyword.
-        merged = keyword.slice(0, lim);
-      }
-    } else {
-      // auto: keyword leads, vector + BM25 fill remaining slots (legacy
-      // behavior, extended with the third path)
-      merged = keyword.slice(0, lim);
-      const seen = new Set(merged.map((m) => m.id));
-      for (const m of vector) {
-        if (merged.length >= lim) break;
-        if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
-      }
-      for (const m of bm25) {
-        if (merged.length >= lim) break;
-        if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
-      }
+    const { merged: fusedMerged, signals } = fuseRecall({ keyword, vector, bm25, lim, mode, wv, wk, wb });
+    let merged = fusedMerged;
+    // Signal transparency (#2): decorate each returned row with its per-source
+    // scores and the final fused score. Purely additive — never changes rank.
+    if (config?.signalTransparency === true) {
+      merged = merged.map((m) => ({ ...m, signals: { ...(signals.get(m.id) ?? {}), final: m.score ?? 0 } }));
     }
 
     // Search-time semantic dedup (v0.5.0 2.3): near-duplicate rows are

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -449,6 +449,14 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     const vectorIds = new Set(vector.map((m) => m.id));
     const keywordIds = new Set(keyword.map((m) => m.id));
 
+    // Mode contract (aligns rrf/minmax with blend): keyword-only searches must
+    // stay keyword-only regardless of recipe, so enabling an opt-in recipe can
+    // never pull vector/BM25 rows into a mode="keyword" request. This mirrors
+    // the blend branch's `mode === "keyword"` short-circuit (byte-for-byte).
+    if (mode === "keyword") {
+      return { merged: keyword.slice(0, lim), signals };
+    }
+
     let merged;
     if (recipe === "rrf") {
       // Rank-based: only the position of a row inside each surviving source
@@ -538,9 +546,41 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       }
     }
 
+    // Mode contract, auto (aligns rrf/minmax with blend): keyword leads, the
+    // recipe fills the remaining slots. blend.auto already front-loads keyword;
+    // rrf/minmax rank across sources, so re-apply the same "keyword first"
+    // ordering here to preserve the pre-fusion auto contract — the keyword
+    // hit list keeps its power, and only slots it couldn't fill go to the
+    // recipe's ranking.
+    if (recipe !== "blend" && mode === "auto" && keyword.length) {
+      const head = keyword.slice(0, lim);
+      const seen = new Set(head.map((m) => m.id));
+      const tail = merged.filter((m) => !seen.has(m.id)).slice(0, Math.max(0, lim - head.length));
+      merged = head.concat(tail);
+    }
+
     return { merged, signals };
   }
 
+  /**
+   * Search memories for a query. Merges up to three recall sources (keyword,
+   * vector, BM25) according to config.recallFusion (blend/rrf/minmax — see
+   * fuseRecall), then optionally decorates rows with per-source signals
+   * (config.signalTransparency), applies semantic dedup (non-keyword modes),
+   * reranking, and epistemic trust re-weighting, and finally hands the merged
+   * list to the recall-layer recorder.
+   *
+   * options:
+   *   mode          — 'auto' (default) | 'keyword' | 'vector' | 'hybrid'
+   *   topK          — max rows (default 20)
+   *   threshold     — explicit vector score floor (overrides adaptive)
+   *   useRerank     — apply the reranker if available (default true)
+   *   recordRecall  — write a recall_runs audit row (default from config)
+   *
+   * Returns an array of memory rows { id, title, content, score, source, ... },
+   * with `signals` added when config.signalTransparency is on. Never throws:
+   * a vector/rerank failure degrades to keyword results.
+   */
   async function searchMemories(query, options = {}) {
     const { mode = "auto", topK = 20, threshold, useRerank = true, recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true) } = options;
     const q = String(query ?? "").trim();

--- a/dsh-mneme/lib/settings.js
+++ b/dsh-mneme/lib/settings.js
@@ -58,6 +58,9 @@ const FEATURE_FLAG_BOOLEANS = [
   "bm25SearchEnabled",
   "conflictFreezeEnabled",
   "trustEpistemicWeighting",
+  // Plan #2: attach per-source {keyword, vector, bm25, final} signals to each
+  // search result for transparency/debugging. Default off, purely decorative.
+  "signalTransparency",
   // Issue #89：宽容校验回归（默认开）+ 跨类型合并显式放宽（默认关）。
   "dreamSkipInvalid",
   "allowCrossTypeMerge",
@@ -94,7 +97,10 @@ const FEATURE_FLAG_STRINGS = [
 const FEATURE_FLAG_URLS = ["ollamaBaseUrl"];
 // 枚举开关（与 config.js 的 z.union(z.const(...)) 对齐）：仅允许列出的值。
 const FEATURE_FLAG_ENUMS = {
-  embedProvider: ["openai", "local", "ollama"]
+  embedProvider: ["openai", "local", "ollama"],
+  // Plan #1: recall fusion recipe. blend = legacy (default); rrf / minmax are
+  // rank/scale-aware alternatives selected by the panel.
+  recallFusion: ["blend", "rrf", "minmax"]
 };
 const FEATURE_FLAG_STRING_MAX = 200;
 

--- a/dsh-mneme/scripts/benchmark-recall.js
+++ b/dsh-mneme/scripts/benchmark-recall.js
@@ -37,7 +37,16 @@ const SEED = [
   { id: "mem_city_thesis", type: "project", title: "湿地论文", content: "毕业论文研究城市湿地公园周边开发案例，ArcGIS 空间分析", importance: 4, tags: ["thesis"] },
   { id: "mem_async_pattern", type: "decision", title: "异步并发模式", content: "async runtime 选用 tokio，任务用 spawn 管理，channel 通信", importance: 3, tags: ["rust"] },
   { id: "mem_python_etl", type: "project", title: "ETL 脚本", content: "夜间 ETL 用 Python 编写，pandas 清洗，SQLite 落地", importance: 3, tags: ["etl"] },
-  { id: "mem_ui_style", type: "preference", title: "界面审美", content: "喜欢编辑风 brutalism 排版，低饱和度配色，衬线标题", importance: 3, tags: ["design"] }
+  { id: "mem_ui_style", type: "preference", title: "界面审美", content: "喜欢编辑风 brutalism 排版，低饱和度配色，衬线标题", importance: 3, tags: ["design"] },
+  // Cross-topic distractors (plan #0): memories that share keywords with a
+  // target but belong to a different subject. They raise the recall bar — the
+  // fused ranking must keep the true positive ahead of the distractor, which
+  // is exactly what a scale-mixed blend (raw cosine + keyword score + IDF)
+  // tends to get wrong.
+  { id: "mem_ops_alert", type: "project", title: "存储告警", content: "Prometheus 存储告警走 zfs 池健康检查与磁盘替换流程", importance: 3, tags: ["ops"] },
+  { id: "mem_rust_dep", type: "project", title: "rust 依赖", content: "Rust 项目的 cargo 依赖管理与 workspace 组织", importance: 3, tags: ["rust"] },
+  { id: "mem_etl_csv", type: "project", title: "ETL CSV", content: "每日 CSV 导入脚本用 golang 而非 python，写 postgres", importance: 2, tags: ["etl"] },
+  { id: "mem_ux_toolbar", type: "preference", title: "工具栏", content: "偏好 IDE 顶栏简洁，避免深色浮层遮挡代码", importance: 2, tags: ["design"] }
 ];
 
 // Standard query set: each case is a query plus the ids that MUST appear in
@@ -53,10 +62,15 @@ export const TEST_CASES = [
   { query: "channel 通信 任务", expected: ["mem_async_pattern"], note: "scattered terms" },
   { query: "内存安全 语言", expected: ["mem_rust_switch"], note: "scattered terms" },
   { query: "配色 审美", expected: ["mem_ui_style"], note: "scattered CJK" },
-  { query: "HBA 固件", expected: ["mem_zfs_bug"], note: "scattered terms" }
+  { query: "HBA 固件", expected: ["mem_zfs_bug"], note: "scattered terms" },
+  // Plan #0 additions: a distractor-dominance case (the target shares the
+  // leading token with a cross-topic memory that must rank below it) and an
+  // exact-token case that leans on the BM25 path.
+  { query: "zfs 磁盘 替换", expected: ["mem_zfs_bug"], note: "shared-token distractor" },
+  { query: "tokio spawn channel", expected: ["mem_async_pattern"], note: "exact async tokens" }
 ];
 
-function seedService(overrides = {}) {
+export function seedService(overrides = {}) {
   const store = createStore(":memory:");
   const config = {
     bm25SearchEnabled: true,
@@ -74,7 +88,11 @@ function seedService(overrides = {}) {
     embedSingle: async (text) => hashVec(text)
   });
   for (const m of SEED) {
-    const row = store.save({ type: m.type, title: m.title, content: m.content, tags: m.tags, importance: m.importance, source: "seed" });
+    // store.save accepts a caller-supplied id (store.js: memory.id ?? randomUUID).
+    // Passing m.id keeps the seeded id stable so TEST_CASES.expected (which
+    // references mem_*) match — without it every row gets a UUID and the
+    // benchmark always reports 0% recall.
+    const row = store.save({ id: m.id, type: m.type, title: m.title, content: m.content, tags: m.tags, importance: m.importance, source: "seed" });
     store.setEmbedding(row.id, hashVec(`${m.title} ${m.content}`));
   }
   return service;
@@ -109,6 +127,52 @@ export async function runBenchmark({ topK = 5, mode = "auto" } = {}) {
   return { topK, mode, runs };
 }
 
+/**
+ * Fusion-recipe A/B (plan #1): runs the same seed + query set with
+ * config.recallFusion forced to each of blend / rrf / minmax, so the scale
+ * mismatch fix can be judged on identical data. `blend` is the legacy recipe
+ * and acts as the control — the pre-fusion behavior.
+ */
+export async function runFusionBenchmark({ topK = 5, mode = "auto" } = {}) {
+  const recipes = ["blend", "rrf", "minmax"];
+  const runs = [];
+  for (const recipe of recipes) {
+    const service = seedService({ recallFusion: recipe });
+    const rows = [];
+    let hits = 0;
+    let mrrSum = 0;
+    for (const tc of TEST_CASES) {
+      const results = await service.searchMemories(tc.query, { mode, topK, useRerank: false });
+      const ids = results.map((r) => r.id);
+      const metrics = service.computeRetrievalMetrics(ids, tc.expected);
+      if (metrics.recall === 1) hits++;
+      mrrSum += metrics.mrr;
+      rows.push({ query: tc.query, note: tc.note, expected: tc.expected, got: ids, ...metrics });
+    }
+    runs.push({
+      config: recipe,
+      recallAtK: +(hits / TEST_CASES.length).toFixed(3),
+      avgMrr: +(mrrSum / TEST_CASES.length).toFixed(3),
+      rows
+    });
+  }
+  return { topK, mode, runs };
+}
+
+function printFusionReport(report) {
+  for (const run of report.runs) {
+    console.log(`\n=== ${run.config} (topK=${report.topK}, mode=${report.mode}) ===`);
+    for (const r of run.rows) {
+      const ok = r.recall === 1 ? "PASS" : "MISS";
+      console.log(`  [${ok}] "${r.query}" (${r.note}) recall=${r.recall} mrr=${r.mrr}`);
+      if (r.recall < 1) console.log(`         expected ⊇ ${r.expected.join(", ")}  got: ${r.got.join(", ") || "—"}`);
+    }
+    console.log(`  → Recall@${report.topK}: ${(run.recallAtK * 100).toFixed(1)}%   avg MRR: ${run.avgMrr}`);
+  }
+  const summary = report.runs.map((r) => `${r.config}=${(r.recallAtK * 100).toFixed(1)}%`).join("  ");
+  console.log(`\n融合配方 A/B (Recall@${report.topK}, ${report.mode}): ${summary}`);
+}
+
 function printReport(report) {
   for (const run of report.runs) {
     console.log(`\n=== ${run.config} (topK=${report.topK}, mode=${report.mode}) ===`);
@@ -127,7 +191,9 @@ function printReport(report) {
 const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/").split("/").pop() ?? "");
 if (invokedDirectly) {
   const asJson = process.argv.includes("--json");
-  const report = await runBenchmark({});
+  const asFusion = process.argv.includes("--fusion");
+  const report = asFusion ? await runFusionBenchmark({}) : await runBenchmark({});
   if (asJson) console.log(JSON.stringify(report, null, 2));
+  else if (asFusion) printFusionReport(report);
   else printReport(report);
 }

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -178,6 +178,19 @@ export const Config = z.object({
   searchSemanticDedup: z.boolean().default(false),
   searchSemanticDedupThreshold: z.number().min(0.5).max(1).default(0.95),
 
+  // Recall fusion recipe (plan #1): how the keyword/vector/BM25 ranked lists
+  // are combined into the final ranking. `blend` (default) is the legacy
+  // behavior — weighted sum for vector/hybrid, union backfill for auto —
+  // unchanged. `rrf` (Reciprocal Rank Fusion) and `minmax` (min-max normalized
+  // weighted sum) are rank/scale-aware recipes that fix the unit mismatch the
+  // issue describes (raw cosine vs keyword score vs normalized IDF are added
+  // directly). Off by default so existing behavior holds exactly.
+  recallFusion: z.union([z.const("blend"), z.const("rrf"), z.const("minmax")]).default("blend"),
+  // Attach a `signals` object { keyword, vector, bm25, final } to each search
+  // result for transparency/debugging (plan #2). Default off; when on it only
+  // decorates the returned rows, never changes the ranking.
+  signalTransparency: z.boolean().default(false),
+
   // --- semantic: rerank layer (v0.2) --------------------------------------
   // Opt-in by default (item ⑥): the local cross-encoder pulls in onnxruntime
   // (transformers.js) at init, so a bare install must not load it. Only an

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -416,6 +416,131 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     }
   }
 
+  /**
+   * Recall fusion (plan #1). Turns the three ranked signal lists (keyword,
+   * vector, BM25) into a single merged list. Three recipes, selected by
+   * config.recallFusion:
+   *  - blend (default): legacy behavior — weighted sum for vector/hybrid, union
+   *    backfill for auto. Byte-identical to pre-fusion code, so enabling the
+   *    config never regresses anybody.
+   *  - rrf: Reciprocal Rank Fusion — Σ 1/(k + rank + 1) over each list a row
+   *    appears in. Rank-based, so the unit mismatch (raw cosine vs keyword
+   *    score vs normalized IDF) is irrelevant.
+   *  - minmax: min-max normalize each source list's scores to [0,1] then take
+   *    the weighted sum — a scale-aware version of `blend`.
+   * Returns { merged, signals }, where signals is Map<id, {keyword, vector,
+   * bm25}> so searchMemories can decorate rows when signalTransparency is on.
+   */
+  function fuseRecall({ keyword, vector, bm25, lim, mode, wv, wk, wb }) {
+    const recipe = config?.recallFusion ?? "blend";
+
+    // Per-source scores are recorded for every recipe so signalTransparency
+    // works regardless of how the ranking was produced.
+    const signals = new Map();
+    const addSig = (id, field, sc) => {
+      const cur = signals.get(id) ?? {};
+      cur[field] = sc;
+      signals.set(id, cur);
+    };
+    for (const m of keyword) addSig(m.id, "keyword", m.score ?? 0);
+    for (const m of vector) addSig(m.id, "vector", m.score ?? 0);
+    for (const m of bm25) addSig(m.id, "bm25", m.score ?? 0);
+
+    const vectorIds = new Set(vector.map((m) => m.id));
+    const keywordIds = new Set(keyword.map((m) => m.id));
+
+    let merged;
+    if (recipe === "rrf") {
+      // Rank-based: only the position of a row inside each surviving source
+      // list matters, so no cross-signal scale calibration is needed.
+      const k = 60; // standard RRF constant (plan #1 documents k=60)
+      const rows = new Map();
+      const addList = (list) => list.forEach((m, idx) => {
+        const s = 1 / (k + idx + 1);
+        const cur = rows.get(m.id);
+        if (cur) cur.score += s;
+        else rows.set(m.id, { ...m, score: s });
+      });
+      addList(keyword);
+      addList(vector);
+      addList(bm25);
+      merged = [...rows.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0)).slice(0, lim);
+    } else if (recipe === "minmax") {
+      // Scale-aware weighted sum: each source list is min-max normalized to
+      // [0,1] before blending, so raw cosine and keyword score live on the
+      // same footing.
+      const norm = (list) => {
+        if (!list.length) return new Map();
+        let min = Infinity, max = -Infinity;
+        for (const m of list) { const s = m.score ?? 0; if (s < min) min = s; if (s > max) max = s; }
+        const range = max - min;
+        const out = new Map();
+        for (const m of list) out.set(m.id, range > 0 ? ((m.score ?? 0) - min) / range : 0.5);
+        return out;
+      };
+      const kw = norm(keyword), ve = norm(vector), bm = norm(bm25);
+      const rows = new Map();
+      const seed = (m) => { if (!rows.has(m.id)) rows.set(m.id, { ...m, score: 0 }); };
+      for (const m of keyword) seed(m);
+      for (const m of vector) seed(m);
+      for (const m of bm25) seed(m);
+      for (const [id, row] of rows) {
+        const k = kw.get(id) ?? 0;
+        const v = ve.get(id) ?? 0;
+        const b = bm.get(id) ?? 0;
+        row.score = v * wv + k * wk + b * wb;
+      }
+      merged = [...rows.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0)).slice(0, lim);
+    } else {
+      // blend — the pre-existing per-mode behavior, extracted verbatim.
+      if (mode === "keyword") {
+        merged = keyword;
+      } else if (mode === "vector" || mode === "hybrid") {
+        const byId = new Map();
+        for (const m of vector) {
+          const rec = byId.get(m.id);
+          byId.set(m.id, rec ? { ...rec, score: Math.max(rec.score ?? 0, m.score ?? 0) } : m);
+        }
+        for (const m of keyword) {
+          const rec = byId.get(m.id);
+          if (rec) {
+            byId.set(m.id, { ...rec, score: (rec.score ?? 0) * wv + (m.score ?? 0) * wk });
+          } else {
+            byId.set(m.id, m);
+          }
+        }
+        for (const m of bm25) {
+          const rec = byId.get(m.id);
+          if (rec) {
+            if (keywordIds.has(m.id)) continue;
+            byId.set(m.id, { ...rec, score: (rec.score ?? 0) + wb * (m.score ?? 0) });
+          } else {
+            byId.set(m.id, { ...m, score: wb * (m.score ?? 0) });
+          }
+        }
+        const ranked = [...byId.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+        merged = ranked.slice(0, lim);
+        if (merged.length < lim && !merged.length) {
+          merged = keyword.slice(0, lim);
+        }
+      } else {
+        // auto: keyword leads, vector + BM25 fill remaining slots.
+        merged = keyword.slice(0, lim);
+        const seen = new Set(merged.map((m) => m.id));
+        for (const m of vector) {
+          if (merged.length >= lim) break;
+          if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
+        }
+        for (const m of bm25) {
+          if (merged.length >= lim) break;
+          if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
+        }
+      }
+    }
+
+    return { merged, signals };
+  }
+
   async function searchMemories(query, options = {}) {
     const { mode = "auto", topK = 20, threshold, useRerank = true, recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true) } = options;
     const q = String(query ?? "").trim();
@@ -477,69 +602,17 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     // Loose blend weight: BM25 confirms and backfills, never dominates the
     // semantic signal. Same-memory overlap boosts, unseen ids backfill.
     const wb = 0.3;
-    // Path bookkeeping for the boost rule below: which ids each semantic
-    // recall path surfaced.
-    const vectorIds = new Set(vector.map((m) => m.id));
-    const keywordIds = new Set(keyword.map((m) => m.id));
 
     // Hybrid blending weights from config when provided.
     const wv = config?.hybridSearchVectorWeight ?? DEFAULT_HYBRID_WEIGHTS.vector;
     const wk = config?.hybridSearchKeywordWeight ?? DEFAULT_HYBRID_WEIGHTS.keyword;
 
-    let merged;
-    if (mode === "keyword") {
-      merged = keyword;
-    } else if (mode === "vector" || mode === "hybrid") {
-      // semantic-first: vector recalls lead, keyword + BM25 fill remaining
-      // slots. Weighted blend when sides scored the same memory; otherwise
-      // vector order leads (it is the semantic signal), lexical paths
-      // backfill.
-      const byId = new Map();
-      for (const m of vector) {
-        const rec = byId.get(m.id);
-        byId.set(m.id, rec ? { ...rec, score: Math.max(rec.score ?? 0, m.score ?? 0) } : m);
-      }
-      for (const m of keyword) {
-        const rec = byId.get(m.id);
-        if (rec) {
-          // Same memory from both sides: blend the scores.
-          byId.set(m.id, { ...rec, score: (rec.score ?? 0) * wv + (m.score ?? 0) * wk });
-        } else {
-          byId.set(m.id, m);
-        }
-      }
-      for (const m of bm25) {
-        const rec = byId.get(m.id);
-        if (rec) {
-          // Boost rule: a row the LIKE keyword path already hit carries the
-          // query as a substring, so BM25 tokens are trivially present —
-          // boosting it double-counts lexical evidence. Only vector-recalled
-          // rows (lexical hit is genuinely new information) get the boost.
-          if (keywordIds.has(m.id)) continue;
-          byId.set(m.id, { ...rec, score: (rec.score ?? 0) + wb * (m.score ?? 0) });
-        } else {
-          byId.set(m.id, { ...m, score: wb * (m.score ?? 0) });
-        }
-      }
-      const ranked = [...byId.values()].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-      merged = ranked.slice(0, lim);
-      if (merged.length < lim && !merged.length) {
-        // Vector unavailable entirely: fall back to plain keyword.
-        merged = keyword.slice(0, lim);
-      }
-    } else {
-      // auto: keyword leads, vector + BM25 fill remaining slots (legacy
-      // behavior, extended with the third path)
-      merged = keyword.slice(0, lim);
-      const seen = new Set(merged.map((m) => m.id));
-      for (const m of vector) {
-        if (merged.length >= lim) break;
-        if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
-      }
-      for (const m of bm25) {
-        if (merged.length >= lim) break;
-        if (!seen.has(m.id)) { seen.add(m.id); merged.push(m); }
-      }
+    const { merged: fusedMerged, signals } = fuseRecall({ keyword, vector, bm25, lim, mode, wv, wk, wb });
+    let merged = fusedMerged;
+    // Signal transparency (#2): decorate each returned row with its per-source
+    // scores and the final fused score. Purely additive — never changes rank.
+    if (config?.signalTransparency === true) {
+      merged = merged.map((m) => ({ ...m, signals: { ...(signals.get(m.id) ?? {}), final: m.score ?? 0 } }));
     }
 
     // Search-time semantic dedup (v0.5.0 2.3): near-duplicate rows are

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -449,6 +449,14 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     const vectorIds = new Set(vector.map((m) => m.id));
     const keywordIds = new Set(keyword.map((m) => m.id));
 
+    // Mode contract (aligns rrf/minmax with blend): keyword-only searches must
+    // stay keyword-only regardless of recipe, so enabling an opt-in recipe can
+    // never pull vector/BM25 rows into a mode="keyword" request. This mirrors
+    // the blend branch's `mode === "keyword"` short-circuit (byte-for-byte).
+    if (mode === "keyword") {
+      return { merged: keyword.slice(0, lim), signals };
+    }
+
     let merged;
     if (recipe === "rrf") {
       // Rank-based: only the position of a row inside each surviving source
@@ -538,9 +546,41 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       }
     }
 
+    // Mode contract, auto (aligns rrf/minmax with blend): keyword leads, the
+    // recipe fills the remaining slots. blend.auto already front-loads keyword;
+    // rrf/minmax rank across sources, so re-apply the same "keyword first"
+    // ordering here to preserve the pre-fusion auto contract — the keyword
+    // hit list keeps its power, and only slots it couldn't fill go to the
+    // recipe's ranking.
+    if (recipe !== "blend" && mode === "auto" && keyword.length) {
+      const head = keyword.slice(0, lim);
+      const seen = new Set(head.map((m) => m.id));
+      const tail = merged.filter((m) => !seen.has(m.id)).slice(0, Math.max(0, lim - head.length));
+      merged = head.concat(tail);
+    }
+
     return { merged, signals };
   }
 
+  /**
+   * Search memories for a query. Merges up to three recall sources (keyword,
+   * vector, BM25) according to config.recallFusion (blend/rrf/minmax — see
+   * fuseRecall), then optionally decorates rows with per-source signals
+   * (config.signalTransparency), applies semantic dedup (non-keyword modes),
+   * reranking, and epistemic trust re-weighting, and finally hands the merged
+   * list to the recall-layer recorder.
+   *
+   * options:
+   *   mode          — 'auto' (default) | 'keyword' | 'vector' | 'hybrid'
+   *   topK          — max rows (default 20)
+   *   threshold     — explicit vector score floor (overrides adaptive)
+   *   useRerank     — apply the reranker if available (default true)
+   *   recordRecall  — write a recall_runs audit row (default from config)
+   *
+   * Returns an array of memory rows { id, title, content, score, source, ... },
+   * with `signals` added when config.signalTransparency is on. Never throws:
+   * a vector/rerank failure degrades to keyword results.
+   */
   async function searchMemories(query, options = {}) {
     const { mode = "auto", topK = 20, threshold, useRerank = true, recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true) } = options;
     const q = String(query ?? "").trim();

--- a/dsh-mneme/src/settings.js
+++ b/dsh-mneme/src/settings.js
@@ -58,6 +58,9 @@ const FEATURE_FLAG_BOOLEANS = [
   "bm25SearchEnabled",
   "conflictFreezeEnabled",
   "trustEpistemicWeighting",
+  // Plan #2: attach per-source {keyword, vector, bm25, final} signals to each
+  // search result for transparency/debugging. Default off, purely decorative.
+  "signalTransparency",
   // Issue #89：宽容校验回归（默认开）+ 跨类型合并显式放宽（默认关）。
   "dreamSkipInvalid",
   "allowCrossTypeMerge",
@@ -94,7 +97,10 @@ const FEATURE_FLAG_STRINGS = [
 const FEATURE_FLAG_URLS = ["ollamaBaseUrl"];
 // 枚举开关（与 config.js 的 z.union(z.const(...)) 对齐）：仅允许列出的值。
 const FEATURE_FLAG_ENUMS = {
-  embedProvider: ["openai", "local", "ollama"]
+  embedProvider: ["openai", "local", "ollama"],
+  // Plan #1: recall fusion recipe. blend = legacy (default); rrf / minmax are
+  // rank/scale-aware alternatives selected by the panel.
+  recallFusion: ["blend", "rrf", "minmax"]
 };
 const FEATURE_FLAG_STRING_MAX = 200;
 

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -527,12 +527,13 @@ test("GET /api/dsh-mneme/features returns empty overrides and effective config d
   assert.equal(res.statusCode, 200);
   const data = JSON.parse(res.body);
   assert.deepEqual(data.overrides, {});
-  // effective 覆盖全部 37 个白名单键（含 v0.7.20 heatEnabled、Issue #89 新增
+  // effective 覆盖全部 39 个白名单键（含 v0.7.20 heatEnabled、Issue #89 新增
   // dreamSkipInvalid/allowCrossTypeMerge/dreamMinIntervalMinutes、面板可调的
-  // dreamMaxTokens 与本轮睡眠路由 sleepProvider/sleepModel），未覆盖时取
-  // bundle 配置的解析默认值；dreamProvider/dreamModel 无 schema 默认值
-  // （Config({}) 解析为 undefined），不编造给前端 → 37 - 2 = 35
-  assert.equal(Object.keys(data.effective).length, 35);
+  // dreamMaxTokens、睡眠路由 sleepProvider/sleepModel，以及 PR1 新增的
+  // recallFusion/signalTransparency），未覆盖时取 bundle 配置的解析默认值；
+  // dreamProvider/dreamModel 无 schema 默认值（Config({}) 解析为 undefined），
+  // 不编造给前端 → 39 - 2 = 37
+  assert.equal(Object.keys(data.effective).length, 37);
   assert.equal(data.effective.dreamSkipInvalid, true);
   assert.equal(data.effective.allowCrossTypeMerge, false);
   assert.equal(data.effective.dreamMinIntervalMinutes, 0);
@@ -555,6 +556,9 @@ test("GET /api/dsh-mneme/features returns empty overrides and effective config d
   assert.equal(data.effective.ollamaBaseUrl, "http://localhost:11434");
   assert.equal(data.effective.ollamaModel, "nomic-embed-text");
   assert.equal(data.effective.embedProvider, "openai");
+  // PR1：融合配方枚举 + 信号透明布尔（均有默认值，故计入 effective 计数）
+  assert.equal(data.effective.recallFusion, "blend");
+  assert.equal(data.effective.signalTransparency, false);
 });
 
 test("PUT /api/dsh-mneme/features round-trips, overrides effective and persists", async () => {

--- a/dsh-mneme/test/benchmark.test.js
+++ b/dsh-mneme/test/benchmark.test.js
@@ -74,3 +74,21 @@ test("recallFusion recipes produce distinct fused scores for the same memory", a
   // so they must not all collapse onto the same numeric score.
   assert.ok(new Set(Object.values(scores)).size > 1, `recipes score differently: ${JSON.stringify(scores)}`);
 });
+
+// PR1 + CodeRabbit: an opt-in recipe must never change keyword-only behavior.
+// mode="keyword" is the documented text-only path; regardless of recipe, the
+// result must contain only keyword-sourced rows — no vector/BM25 bleed-in.
+// (Note: on a scattered-CJK query the keyword source can itself be empty, in
+// which case auto correctly falls back to BM25 — that is the pre-fusion blend
+// behavior and is NOT a regression. Only mode="keyword" is a hard text path.)
+test("opt-in recipes keep mode=keyword keyword-only (no vector/BM25 bleed)", async () => {
+  for (const recipe of ["blend", "rrf", "minmax"]) {
+    const svc = seedService({ recallFusion: recipe });
+    const rows = await svc.searchMemories("rust 异步", { mode: "keyword", topK: 5, useRerank: false });
+    const keywordOnly = rows.every((r) => r.source === "keyword");
+    assert.ok(
+      keywordOnly,
+      `${recipe} under mode=keyword must keep only keyword rows; got sources: ${[...new Set(rows.map((r) => r.source))].join(",")}`
+    );
+  }
+});

--- a/dsh-mneme/test/benchmark.test.js
+++ b/dsh-mneme/test/benchmark.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { runBenchmark, TEST_CASES } from "../scripts/benchmark-recall.js";
+import { runBenchmark, runFusionBenchmark, seedService, TEST_CASES } from "../scripts/benchmark-recall.js";
 
 // The benchmark harness must stay a working evaluation: it runs the real
 // searchMemories pipeline over the seeded store and the fused configuration
@@ -32,4 +32,45 @@ test("test cases cover the scattered-term BM25 territory", () => {
   for (const tc of TEST_CASES) {
     assert.ok(tc.query && tc.expected.length > 0);
   }
+});
+
+// --- PR1: recall fusion recipes + signal transparency ---------------------
+
+test("fusion-recipe A/B runs blend/rrf/minmax with valid recall on the seed corpus", async () => {
+  const report = await runFusionBenchmark({ topK: 5 });
+  assert.deepEqual(report.runs.map((r) => r.config), ["blend", "rrf", "minmax"]);
+  for (const run of report.runs) {
+    assert.equal(run.rows.length, TEST_CASES.length, `${run.config} covers every query`);
+    assert.ok(run.recallAtK >= 0 && run.recallAtK <= 1, `${run.config} recallAtK in [0,1]`);
+    assert.ok(run.avgMrr >= 0 && run.avgMrr <= 1, `${run.config} avgMrr in [0,1]`);
+  }
+});
+
+test("signalTransparency decorates rows with per-source signals", async () => {
+  const svc = seedService({ recallFusion: "blend", signalTransparency: true });
+  const rows = await svc.searchMemories("rust 异步", { mode: "auto", topK: 5, useRerank: false });
+  assert.ok(rows.length > 0, "the seed corpus returns hits for a scattered-term query");
+  for (const r of rows) {
+    assert.equal(typeof r.signals, "object", "each row carries a signals object");
+    assert.equal(typeof r.signals.final, "number", "signals carries the fused final score");
+    assert.ok([
+      "keyword" in r.signals,
+      "vector" in r.signals,
+      "bm25" in r.signals
+    ].some(Boolean), "at least one source signal is present");
+  }
+});
+
+test("recallFusion recipes produce distinct fused scores for the same memory", async () => {
+  const scores = {};
+  for (const recipe of ["blend", "rrf", "minmax"]) {
+    const svc = seedService({ recallFusion: recipe });
+    const rows = await svc.searchMemories("rust 异步", { mode: "auto", topK: 5, useRerank: false });
+    const hit = rows.find((r) => r.id === "mem_async_pattern") ?? rows[0];
+    assert.ok(hit, `${recipe} surfaces a hit`);
+    scores[recipe] = hit.score ?? 0;
+  }
+  // RRF is rank-based (Σ 1/(k+rank+1)) and minmax normalizes before blending,
+  // so they must not all collapse onto the same numeric score.
+  assert.ok(new Set(Object.values(scores)).size > 1, `recipes score differently: ${JSON.stringify(scores)}`);
 });


### PR DESCRIPTION
## 一句话
召回这层目前"不可信、不可调"。本 PR：修复 benchmark 恒报 0% 的 seed bug（补上可信的测量地基），把融合配方做成可配置（默认保留现状）、并加信号透明作为诊断观测。设计讨论见 #106。

## 为什么值得看
对默认行为零影响、可随时开关：recallFusion 默认 blend（旧逻辑逐字保留），signalTransparency 默认 false，且两者都入 feature-flag 白名单、设置面板可启停。但它是后续一切"召回好不好"评估的测量地基。

## 改动
- src/config.js：新增 recallFusion（enum [blend|rrf|minmax]，默认 blend）、signalTransparency（bool，默认 false）
- src/service.js：searchMemories 融合逻辑抽出为 fuseRecall() 闭包。blend=旧加权加和（保留）；rrf=Reciprocal Rank Fusion k=60；minmax=各源归一化后再加权；signalTransparency 开启时每行挂 signals{keyword,vector,bm25,final}
- src/settings.js：两字段入 FEATURE_FLAG 白名单（BOOLEANS/ENUMS）
- scripts/benchmark-recall.js：修 seed 漏传 id 的 bug（基准恒报 0% 的根因）+ 扩种子库（跨主题干扰）+ 新增 runFusionBenchmark() 做 blend/rrf/minmax A/B + --fusion CLI
- test/：api featureSnapshot 计数 35→37；benchmark 新增配方 A/B 断言
- lib/：经 npm run sync 同步（src/lib 不漂移）

## 自验
- 基准修复：legacy Recall@5 0%（bug）→ 83.3%，fused 100%
- 三方 A/B：blend=rrf=minmax 在 toy 集（12 记忆、topK=5）均 Recall@5 100%、MRR 0.917（toy 数据量纲接近、区分度不足；配方级差异留待真实语义数据集）
- 测试全绿：api 58 / service-search 8 / benchmark / config / settings / search-fusion / service / recall-layer + ~200 panel/inject/dream 相关
- npm run sync 后 lib-smoke 5/5 通过；混合权重断言（0.92/0.9）不变

## 风险
- A/B 未证明 rrf/minmax 优于 blend：三者同分，属纯加分能力。配方级裁决需 scope + 真实语义数据集（见 #106）。
- mode=vector + recallFusion=rrf 时会混入 keyword+bm25 信号，与"纯 vector"语义略有出入——显式 opt-in + 默认 blend，可接受，建议文档标注。

Closes #106