### PR TITLE
fix: 实体抽取路由契约修复 + 面板控件 + 帮助与反馈入口（#108 #109）

### DIFF
--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -161,6 +161,16 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // 反馈入口预填用的插件版本（面板「帮助与反馈」卡片拉取）。读取失败（打包
+  // 环境）返回 "unknown"，链接照常可用，纯展示信息不拦截。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/info",
+    handler(req, res) {
+      sendJson(res, 200, { version: PACKAGE_VERSION });
+    }
+  });
+
   register({
     kind: "exact",
     path: "/api/dsh-mneme/list",

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -276,6 +276,14 @@ window.__ModuleLoader__.load({
         "memory.features.hotMemoryEnabled.hint": "最近几轮对话原文随注入携带，不写入长期记忆",
         "memory.features.entityExtractionEnabled": "实体抽取",
         "memory.features.entityExtractionEnabled.hint": "从记忆中提取人物/项目/概念，图谱随之生长",
+        "memory.features.entityExtractionProvider": "实体抽取 Provider",
+        "memory.features.entityExtractionModel": "实体抽取模型",
+        "memory.features.entityExtractionReasoning": "实体抽取思考强度",
+        "memory.features.entityExtractionReasoning.none": "跟随默认",
+        "memory.features.entityExtractionReasoning.low": "低",
+        "memory.features.entityExtractionReasoning.medium": "中",
+        "memory.features.entityExtractionReasoning.high": "高",
+        "memory.features.entityExtractionModelHint": "Provider/模型留空 = 跟随主对话模型；思考强度 none = 服务商默认",
         "memory.features.codingRetrospect": "编码记忆蒸馏",
         "memory.features.codingRetrospect.hint": "用完整转录（含工具调用与报错）提炼踩坑、约束与被否决方案",
         "memory.features.rerankEnabled": "结果重排",
@@ -565,6 +573,14 @@ window.__ModuleLoader__.load({
         "memory.features.hotMemoryEnabled.hint": "Carry the last few turns verbatim; never written to long-term memory",
         "memory.features.entityExtractionEnabled": "Entity extraction",
         "memory.features.entityExtractionEnabled.hint": "Extract people / projects / concepts so the graph grows by itself",
+        "memory.features.entityExtractionProvider": "Entity extraction provider",
+        "memory.features.entityExtractionModel": "Entity extraction model",
+        "memory.features.entityExtractionReasoning": "Entity extraction reasoning",
+        "memory.features.entityExtractionReasoning.none": "Follow default",
+        "memory.features.entityExtractionReasoning.low": "Low",
+        "memory.features.entityExtractionReasoning.medium": "Medium",
+        "memory.features.entityExtractionReasoning.high": "High",
+        "memory.features.entityExtractionModelHint": "Provider / model empty = follow the main conversation model; reasoning none = provider default",
         "memory.features.codingRetrospect": "Coding retrospection",
         "memory.features.codingRetrospect.hint": "Distill pitfalls, constraints and rejected solutions from full transcripts (tools and errors included)",
         "memory.features.rerankEnabled": "Reranking",
@@ -1592,8 +1608,10 @@ window.__ModuleLoader__.load({
     const FEATURE_ADVANCED_BOOLS = ["hybridInject", "selectiveInjectEnabled", "adaptiveThresholdEnabled", "reflectionUpdateEnabled", "reflectionFailureTracking", "conflictFreezeEnabled", "trustEpistemicWeighting"];
     // 字符串键（blur/Enter 提交，空串合法 = 跟随默认）：巩固模型与语义
     // 检索路线。embedProvider 是枚举，用下拉单独渲染。
-    const FEATURE_STRINGS = ["dreamProvider", "dreamModel", "sleepProvider", "sleepModel", "localEmbedModel", "ollamaBaseUrl", "ollamaModel"];
+    const FEATURE_STRINGS = ["dreamProvider", "dreamModel", "sleepProvider", "sleepModel", "entityExtractionProvider", "entityExtractionModel", "localEmbedModel", "ollamaBaseUrl", "ollamaModel"];
     const EMBED_PROVIDERS = ["openai", "local", "ollama"];
+    // 实体抽取思考强度（issue #109）：与后端 FEATURE_FLAG_ENUMS 枚举对齐。
+    const ENTITY_REASONING = ["none", "low", "medium", "high"];
 
     function FeatureRow({ name, hint, on, disabled, onToggle }) {
       return h("div", { className: "mneme-featrow" },
@@ -1623,9 +1641,10 @@ window.__ModuleLoader__.load({
       // 巩固/睡眠模型路由下拉的数据源：GET /llm-providers 探测（云端 v0.7.26+
       // 的插件侧端点）。null = 端点不可用（404/失败）→ 回退纯文本输入，不挡旧后端。
       const [routes, setRoutes] = useState(null);
-      // 连通性测试结果（巩固/睡眠各一份，互不串扰）：{ running: true } | { ok, ms, detail }
+      // 连通性测试结果（巩固/睡眠/实体抽取各一份，互不串扰）：{ running: true } | { ok, ms, detail }
       const [dreamTest, setDreamTest] = useState(null);
       const [sleepTest, setSleepTest] = useState(null);
+      const [entityTest, setEntityTest] = useState(null);
 
       useEffect(() => {
         let cancelled = false;
@@ -1825,6 +1844,26 @@ window.__ModuleLoader__.load({
         h("div", { className: "mneme-featsubhint" }, t("memory.features.sleepModelHint"))
       );
 
+      // 实体抽取路由与思考强度（issue #109）：entityExtractionEnabled 开着才
+      // 展开。provider/model 级联下拉 + 连通性测试（同巩固/睡眠），reasoning
+      // 枚举即时提交；旧后端（/llm-providers 404）回退纯文本输入。
+      const entitySub = eff.entityExtractionEnabled && h("div", { className: "mneme-featsub" },
+        Array.isArray(routes)
+          ? routeSelects("entityExtractionProvider", "entityExtractionModel", entityTest, setEntityTest)
+          : h(react.Fragment, null, strRow("entityExtractionProvider"), strRow("entityExtractionModel")),
+        h("div", { className: "mneme-featnum" },
+          h("span", { className: "mneme-featnumlabel" }, t("memory.features.entityExtractionReasoning")),
+          h("select", {
+            className: "mneme-select",
+            value: eff.entityExtractionReasoning || "none",
+            disabled: busy,
+            onChange: (e) => put({ entityExtractionReasoning: e.target.value })
+          },
+            ENTITY_REASONING.map((r) => h("option", { key: r, value: r }, t(`memory.features.entityExtractionReasoning.${r}`))))
+        ),
+        h("div", { className: "mneme-featsubhint" }, t("memory.features.entityExtractionModelHint"))
+      );
+
       if (error && !state) return h("section", { className: "mneme-set-card" },
         h("div", { className: "mneme-set-title" }, t("memory.features.title")),
         h("div", { className: "mneme-set-hint" }, error));
@@ -1841,7 +1880,7 @@ window.__ModuleLoader__.load({
               FEATURE_GROUPS.map((g) => h(react.Fragment, { key: g.key },
                 h("div", { className: "mneme-featgroup" }, t(`memory.features.${g.key}`)),
                 g.items.map(boolRow),
-                g.key === "group.enhance" && embedSub,
+                g.key === "group.enhance" && h(react.Fragment, null, embedSub, entitySub),
                 g.key === "group.dream" && h(react.Fragment, null, dreamSub, sleepSub)
               )),
               h("div", { className: "mneme-featgroup" },

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -239,6 +239,12 @@ window.__ModuleLoader__.load({
         "memory.settings.apiTokenPlaceholder": "留空 = 不鉴权（默认）",
         "memory.settings.apiTokenSave": "保存 Token",
         "memory.settings.apiTokenSaved": "Token 已保存",
+        "memory.settings.feedback.title": "帮助与反馈",
+        "memory.settings.feedback.desc": "遇到问题？先看看仓库已有的 issue，或直接把情况反馈过来：",
+        "memory.settings.feedback.newIssue": "GitHub 新建 issue（自动带上环境信息）",
+        "memory.settings.feedback.email": "邮件反馈（work@modusensus.space）",
+        "memory.settings.feedback.browse": "浏览仓库已知问题",
+        "memory.settings.feedback.hint": "反馈前先搜搜是否已有相同问题，能省一份重复的 issue～",
         "memory.settings.mode.title": "运行模式",
         "memory.settings.mode.desc": "轻量模式只保留核心的记忆读写与自动注入（关闭 autoDream 巩固、实体抽取、语义搜索等高级功能），适合只想「记住偏好」的轻量使用；标准模式开启全部功能。",
         "memory.settings.mode.light": "轻量",
@@ -536,6 +542,12 @@ window.__ModuleLoader__.load({
         "memory.settings.apiTokenPlaceholder": "Empty = no auth (default)",
         "memory.settings.apiTokenSave": "Save Token",
         "memory.settings.apiTokenSaved": "Token saved",
+        "memory.settings.feedback.title": "Help & feedback",
+        "memory.settings.feedback.desc": "Stuck? Search the existing issues, or tell us what happened:",
+        "memory.settings.feedback.newIssue": "Open a GitHub issue (environment info prefilled)",
+        "memory.settings.feedback.email": "Email feedback (work@modusensus.space)",
+        "memory.settings.feedback.browse": "Browse known issues",
+        "memory.settings.feedback.hint": "Search for an existing issue first — it saves a duplicate.",
         "memory.settings.mode.title": "Runtime mode",
         "memory.settings.mode.desc": "Light mode keeps only the core memory read/write and auto-injection (autoDream consolidation, entity extraction and semantic search are off) — for light use where you just want preferences remembered. Standard mode enables everything.",
         "memory.settings.mode.light": "Light",
@@ -966,6 +978,7 @@ window.__ModuleLoader__.load({
       ".mneme-numinput:focus{border-color:var(--dsw-alias-state-business-primary);box-shadow:0 0 0 3px color-mix(in srgb,var(--dsw-alias-state-business-primary) 15%,transparent)}",
       // 字符串开关的输入框（provider/model 等）与其子块容器
       ".mneme-strinput{box-sizing:border-box;width:240px;max-width:60%;height:30px;padding:0 10px;border-radius:8px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-base,transparent);color:var(--dsw-alias-label-primary);font-family:inherit;font-size:13px;outline:none;text-align:left;transition:border-color .12s,box-shadow .12s}",
+      ".mneme-feed-link{display:block;color:var(--dsw-alias-brand,var(--dsw-alias-label-primary));text-decoration:none;font-size:13px;line-height:20px;padding:4px 2px;border-radius:6px;transition:opacity .12s}.mneme-feed-link:hover{opacity:.8;text-decoration:underline}",
       ".mneme-strinput:focus{border-color:var(--dsw-alias-state-business-primary);box-shadow:0 0 0 3px color-mix(in srgb,var(--dsw-alias-state-business-primary) 15%,transparent)}",
       ".mneme-featsub{margin:2px 0 8px;padding:10px 12px;border:1px solid var(--dsw-alias-border-l1);border-radius:10px;display:flex;flex-direction:column;gap:6px}",
       ".mneme-featsub .mneme-featnum{padding:6px 0;border-bottom:none}",
@@ -1906,6 +1919,18 @@ window.__ModuleLoader__.load({
       return `${s.slice(0, 5)}${"•".repeat(10)}${s.slice(-4)}`;
     }
 
+    // 反馈预填用的平台标签：从 userAgent 提一个粗粒度 OS 名，够定位问题即可，
+    // 不引第三方解析库。浏览器/Electron webview 里都能取到。
+    const platformLabel = () => {
+      const ua = (typeof navigator !== "undefined" && navigator.userAgent) || "";
+      if (/Windows NT/.test(ua)) return "Windows";
+      if (/Mac OS X/.test(ua)) return "macOS";
+      if (/Android/.test(ua)) return "Android";
+      if (/iPhone|iPad/.test(ua)) return "iOS";
+      if (/Linux/.test(ua)) return "Linux";
+      return "Unknown";
+    };
+
     function SettingsContent({ t }) {
       const [profile, setProfile] = react.useState("");
       const [rules, setRules] = react.useState([]);
@@ -1922,6 +1947,8 @@ window.__ModuleLoader__.load({
         (typeof window !== "undefined" && window.localStorage) ? window.localStorage.getItem("dsh-mneme-api-token") || "" : ""
       );
       const [apiTokenSaved, setApiTokenSaved] = react.useState(false);
+      // 反馈入口的插件版本（GET /info）。失败保持 "unknown"，链接仍可用。
+      const [pkgVersion, setPkgVersion] = react.useState("unknown");
       // 运行模式 — light vs standard; null = still loading. The card keeps
       // its own busy/saved/error state so it never blocks the others.
       const [mode, setMode] = react.useState(null);
@@ -1956,6 +1983,27 @@ window.__ModuleLoader__.load({
       }, []);
 
       react.useEffect(() => { load(); }, [load]);
+
+      // 帮助与反馈卡片的版本号：独立小请求，失败不影响其它卡片。
+      react.useEffect(() => {
+        let cancelled = false;
+        apiFetch("/api/dsh-mneme/info")
+          .then((res) => (res.ok ? res.json() : null))
+          .then((j) => { if (!cancelled && j && typeof j.version === "string") setPkgVersion(j.version); })
+          .catch(() => {});
+        return () => { cancelled = true; };
+      }, []);
+
+      // 反馈链接预填：环境信息（插件版本 + 平台）+ 问题描述骨架。邮件主题带
+      // 版本/平台方便归档，正文同款模板；纯链接零后端成本。
+      const feedbackEnv = `**插件版本**: ${pkgVersion}\n**平台**: ${platformLabel()}\n`;
+      const feedbackBody = feedbackEnv + "**问题描述**:\n- 期望行为:\n- 实际行为:\n- 复现步骤:\n";
+      const issueHref = "https://github.com/modusensus/dsh-mneme/issues/new?title="
+        + encodeURIComponent("[dsh-mneme] 问题反馈")
+        + "&body=" + encodeURIComponent(feedbackBody);
+      const mailHref = "mailto:work@modusensus.space?subject="
+        + encodeURIComponent(`[dsh-mneme 反馈] ${pkgVersion} / ${platformLabel()}`)
+        + "&body=" + encodeURIComponent(feedbackBody);
 
       // Runtime mode + external API — two independent fetches: one failing
       // endpoint only errors its own card, never the other one.
@@ -2357,6 +2405,19 @@ window.__ModuleLoader__.load({
             h("button", { className: "mneme-btn", onClick: saveToken }, t("memory.settings.apiTokenSave"))
           ),
           apiTokenSaved && h("div", { style: { marginTop: 8 } }, h("span", { className: "mneme-saved" }, t("memory.settings.apiTokenSaved")))
+        ),
+        // 帮助与反馈 — 反馈问题三入口（新建 issue 预填 / 邮件 / 浏览已知问题）。
+        // 纯前端链接零后端成本；插件版本来自 /info，平台取 userAgent。GitHub
+        // 仓库当前没有 issue 模板，故用 issues/new?title=&body= 直接预填。
+        h("section", { className: "mneme-set-sec" },
+          h("div", { className: "mneme-set-title" }, t("memory.settings.feedback.title")),
+          h("div", { className: "mneme-set-desc" }, t("memory.settings.feedback.desc")),
+          h("div", { style: { display: "flex", flexDirection: "column", gap: 2 } },
+            h("a", { className: "mneme-feed-link", href: issueHref, target: "_blank", rel: "noopener noreferrer" }, t("memory.settings.feedback.newIssue")),
+            h("a", { className: "mneme-feed-link", href: mailHref }, t("memory.settings.feedback.email")),
+            h("a", { className: "mneme-feed-link", href: "https://github.com/modusensus/dsh-mneme/issues", target: "_blank", rel: "noopener noreferrer" }, t("memory.settings.feedback.browse"))
+          ),
+          h("div", { className: "mneme-featsubhint", style: { marginTop: 8 } }, t("memory.settings.feedback.hint"))
         )
       );
     }

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -220,9 +220,23 @@ export const Config = z.object({
   // The storage layer (entities/entity_attrs/entity_relations tables + CRUD)
   // is always available regardless of this flag.
   entityExtractionEnabled: z.boolean().default(false),
+  // Optional provider override for entity extraction; empty = use the caller's
+  // default provider/model. Combined with entityExtractionModel — provider
+  // without model (or vice versa) falls through to the caller default.
+  entityExtractionProvider: z.string().default(""),
   // Optional model override for entity extraction; empty = use the caller's
   // default provider/model.
   entityExtractionModel: z.string().default(""),
+  // Reasoning effort for entity extraction (issue #109), mirrors
+  // dreamReasoningEffort: 'none' (default) omits the field / provider default;
+  // low/medium/high passed through. A provider that rejects the effort retries
+  // once without it, so opting in is safe to experiment with.
+  entityExtractionReasoning: z.union([
+    z.const("low"),
+    z.const("medium"),
+    z.const("high"),
+    z.const("none")
+  ]).default("none"),
   // Cap on entities per extraction pass and attributes per entity.
   entityExtractionMaxEntities: z.natural().min(1).max(20).default(10),
   entityExtractionMaxAttrs: z.natural().min(1).max(50).default(20),

--- a/dsh-mneme/lib/entities/extractor.js
+++ b/dsh-mneme/lib/entities/extractor.js
@@ -146,16 +146,23 @@ export async function extractEntities(memory, { store, config, callLLM, logger }
       return { ok: false, error: "Invalid memory: missing content" };
     }
     
-    const model = config.entityExtractionModel || null;
     const systemPrompt = buildSystemPrompt(config);
     const userText = buildUserMessage(memory.content);
-    
+
     const messages = [
       { role: "system", content: [{ type: "text", text: systemPrompt }] },
       { role: "user", content: [{ type: "text", text: userText }] }
     ];
-    
-    const options = model ? { model } : {};
+
+    // Issue #109: optional provider/model override + reasoning effort are
+    // passed through to callLLM's options; the index.js adapter maps them onto
+    // the route (or falls back to the caller's default model). Empty provider/
+    // model both mean "use the caller default".
+    const options = {};
+    if (config.entityExtractionProvider) options.provider = config.entityExtractionProvider;
+    if (config.entityExtractionModel) options.model = config.entityExtractionModel;
+    const reasoning = config.entityExtractionReasoning;
+    if (reasoning && reasoning !== "none") options.reasoningEffort = reasoning;
     const llmResponse = await callLLM(messages, options);
     
     if (!llmResponse) {
@@ -219,7 +226,7 @@ export async function extractEntities(memory, { store, config, callLLM, logger }
           to_entity: toId,
           relation_type: rel.type,
           memory_id: memory.id,
-          metadata: { model: model || "default" }
+          metadata: { model: options.model || "default" }
         });
         savedRelations.push(saved);
       } catch (err) {

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -35,6 +35,57 @@ export { Config };
 // value, so a `function apply` disposer would never run on unload. An arrow
 // has no prototype, is called normally, and its returned disposer is collected
 // and run by the fiber on unload.
+// Entity-extraction LLM adapter (issue #108/#109): maps the extractor's
+// options (provider/model override + reasoningEffort) onto a real dsh-llm
+// stream route and retries once without the effort when the first attempt is
+// rejected. Extracted from apply() so the effort-fallback branch is
+// unit-testable; the extractor only ever sees a callLLM(messages, options)
+// => Promise<string>. The route always carries a real provider/model (dsh-llm
+// GenerateOptions requires both) — never a bare stream.
+export function createEntityStreamAdapter({ llm, agentDefaultModel, logger }) {
+  return async function streamEntityText(messages, options = {}) {
+    let route = {};
+    if (options.provider) route.provider = options.provider;
+    if (options.model) route.model = options.model;
+    if (!route.provider || !route.model) {
+      try {
+        const sel = agentDefaultModel?.currentSelection?.();
+        if (sel?.provider && sel?.model) {
+          route.provider ??= sel.provider;
+          route.model ??= sel.model;
+        }
+      } catch { /* fall through to whatever route we already have */ }
+    }
+    const effort = options.reasoningEffort;
+    const tryStream = (withEffort) => {
+      let text = "";
+      return (async () => {
+        for await (const chunk of llm.stream({
+          ...route,
+          maxTokens: 4096,
+          ...(withEffort && effort ? { reasoningEffort: effort } : {}),
+          messages
+        })) {
+          if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
+          if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
+        }
+        return text;
+      })().catch((err) => {
+        logger?.warn?.(`[dsh-mneme] entity extraction llm stream failed: ${String(err)}`);
+        return undefined;
+      });
+    };
+    let text = await tryStream(true);
+    if (text === undefined && effort) {
+      // Mirror dream's effort fallback: a provider rejecting the reasoning
+      // effort must not sink the whole extraction — retry once without it.
+      logger?.warn?.(`[dsh-mneme] entity extraction: reasoningEffort "${effort}" rejected, retrying without it`);
+      text = await tryStream(false);
+    }
+    return text;
+  };
+}
+
 export const apply = (ctx, config) => {
   const rawCfg = Config(config);
 
@@ -328,51 +379,11 @@ export const apply = (ctx, config) => {
       // from "extraction failed".
       ctx.logger?.warn?.("[dsh-mneme] entityExtractionEnabled=true but ctx.llm unavailable — entity extractor NOT installed");
     } else {
-      const streamEntityText = async (messages, options = {}) => {
-        // Issue #109: explicit provider/model from the panel win; otherwise
-        // fall back to the caller's current default model. Either way the
-        // request always carries a real provider/model route (dsh-llm
-        // GenerateOptions requires both) — never a bare stream.
-        let route = {};
-        if (options.provider) route.provider = options.provider;
-        if (options.model) route.model = options.model;
-        if (!route.provider || !route.model) {
-          try {
-            const sel = ctx.agentDefaultModel?.currentSelection?.();
-            if (sel?.provider && sel?.model) {
-              route.provider ??= sel.provider;
-              route.model ??= sel.model;
-            }
-          } catch { /* fall through to whatever route we already have */ }
-        }
-        const effort = options.reasoningEffort;
-        const tryStream = (withEffort) => {
-          let text = "";
-          return (async () => {
-            for await (const chunk of ctx.llm.stream({
-              ...route,
-              maxTokens: 4096,
-              ...(withEffort && effort ? { reasoningEffort: effort } : {}),
-              messages
-            })) {
-              if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
-              if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
-            }
-            return text;
-          })().catch((err) => {
-            ctx.logger?.warn?.(`[dsh-mneme] entity extraction llm stream failed: ${String(err)}`);
-            return undefined;
-          });
-        };
-        let text = await tryStream(true);
-        if (text === undefined && effort) {
-          // Mirror dream's effort fallback: a provider rejecting the reasoning
-          // effort must not sink the whole extraction — retry once without it.
-          ctx.logger?.warn?.(`[dsh-mneme] entity extraction: reasoningEffort "${effort}" rejected, retrying without it`);
-          text = await tryStream(false);
-        }
-        return text;
-      };
+      const streamEntityText = createEntityStreamAdapter({
+        llm: ctx.llm,
+        agentDefaultModel: ctx.agentDefaultModel,
+        logger: ctx.logger
+      });
       service.setEntityExtractor((memory) =>
         extractEntities(memory, { store, config: cfg, callLLM: streamEntityText, logger: ctx.logger })
           .catch((err) => {

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -320,36 +320,67 @@ export const apply = (ctx, config) => {
   // expects, reusing the same ctx.llm.stream consumption pattern as dream.js.
   // Explicit opt-in only (entityExtractionEnabled defaults to false); any LLM
   // failure degrades inside the extractor to { ok:false }, never a write error.
-  if (cfg.entityExtractionEnabled && ctx.llm) {
-    const streamEntityText = async (messages, options = {}) => {
-      let route = null;
-      if (options.model) {
-        route = { model: options.model };
-      } else {
-        try {
-          const sel = ctx.agentDefaultModel?.currentSelection?.();
-          if (sel?.provider && sel?.model) route = sel;
-        } catch { /* fall through to no route */ }
-      }
-      let text = "";
-      for await (const chunk of ctx.llm.stream({
-        ...(route ?? {}),
-        purpose: "entity-extract",
-        maxTokens: 4096,
-        messages
-      })) {
-        if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
-        if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
-      }
-      return text;
-    };
-    service.setEntityExtractor((memory) =>
-      extractEntities(memory, { store, config: cfg, callLLM: streamEntityText, logger: ctx.logger })
-        .catch((err) => {
-          ctx.logger?.warn?.(`[dsh-mneme] entity extraction failed: ${String(err)}`);
-          return { ok: false, error: String(err) };
-        })
-    );
+  if (cfg.entityExtractionEnabled) {
+    if (!ctx.llm) {
+      // Issue #108: an enabled-but-unwired extractor failed silently before —
+      // zero entities, zero llm_audit_logs, no log line anywhere. Make the
+      // missing dependency visible so a user can tell "extractor not installed"
+      // from "extraction failed".
+      ctx.logger?.warn?.("[dsh-mneme] entityExtractionEnabled=true but ctx.llm unavailable — entity extractor NOT installed");
+    } else {
+      const streamEntityText = async (messages, options = {}) => {
+        // Issue #109: explicit provider/model from the panel win; otherwise
+        // fall back to the caller's current default model. Either way the
+        // request always carries a real provider/model route (dsh-llm
+        // GenerateOptions requires both) — never a bare stream.
+        let route = {};
+        if (options.provider) route.provider = options.provider;
+        if (options.model) route.model = options.model;
+        if (!route.provider || !route.model) {
+          try {
+            const sel = ctx.agentDefaultModel?.currentSelection?.();
+            if (sel?.provider && sel?.model) {
+              route.provider ??= sel.provider;
+              route.model ??= sel.model;
+            }
+          } catch { /* fall through to whatever route we already have */ }
+        }
+        const effort = options.reasoningEffort;
+        const tryStream = (withEffort) => {
+          let text = "";
+          return (async () => {
+            for await (const chunk of ctx.llm.stream({
+              ...route,
+              maxTokens: 4096,
+              ...(withEffort && effort ? { reasoningEffort: effort } : {}),
+              messages
+            })) {
+              if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
+              if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
+            }
+            return text;
+          })().catch((err) => {
+            ctx.logger?.warn?.(`[dsh-mneme] entity extraction llm stream failed: ${String(err)}`);
+            return undefined;
+          });
+        };
+        let text = await tryStream(true);
+        if (text === undefined && effort) {
+          // Mirror dream's effort fallback: a provider rejecting the reasoning
+          // effort must not sink the whole extraction — retry once without it.
+          ctx.logger?.warn?.(`[dsh-mneme] entity extraction: reasoningEffort "${effort}" rejected, retrying without it`);
+          text = await tryStream(false);
+        }
+        return text;
+      };
+      service.setEntityExtractor((memory) =>
+        extractEntities(memory, { store, config: cfg, callLLM: streamEntityText, logger: ctx.logger })
+          .catch((err) => {
+            ctx.logger?.warn?.(`[dsh-mneme] entity extraction failed: ${String(err)}`);
+            return { ok: false, error: String(err) };
+          })
+      );
+    }
   }
 
   const disposers = [];

--- a/dsh-mneme/lib/settings.js
+++ b/dsh-mneme/lib/settings.js
@@ -89,6 +89,10 @@ const FEATURE_FLAG_STRINGS = [
   // /llm-providers 端点一起提供，留空 = 用巩固模型或当前模型。
   "sleepProvider",
   "sleepModel",
+  // 实体抽取侧专用路由（issue #109）：provider/model 显式指定，
+  // 留空 = 用当前默认模型。
+  "entityExtractionProvider",
+  "entityExtractionModel",
   "localEmbedModel",
   "ollamaModel"
 ];
@@ -100,7 +104,9 @@ const FEATURE_FLAG_ENUMS = {
   embedProvider: ["openai", "local", "ollama"],
   // Plan #1: recall fusion recipe. blend = legacy (default); rrf / minmax are
   // rank/scale-aware alternatives selected by the panel.
-  recallFusion: ["blend", "rrf", "minmax"]
+  recallFusion: ["blend", "rrf", "minmax"],
+  // 实体抽取思考强度（issue #109）：与 dreamReasoningEffort 枚举对齐。
+  entityExtractionReasoning: ["low", "medium", "high", "none"]
 };
 const FEATURE_FLAG_STRING_MAX = 200;
 

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -161,6 +161,16 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     }
   });
 
+  // 反馈入口预填用的插件版本（面板「帮助与反馈」卡片拉取）。读取失败（打包
+  // 环境）返回 "unknown"，链接照常可用，纯展示信息不拦截。
+  register({
+    kind: "exact",
+    path: "/api/dsh-mneme/info",
+    handler(req, res) {
+      sendJson(res, 200, { version: PACKAGE_VERSION });
+    }
+  });
+
   register({
     kind: "exact",
     path: "/api/dsh-mneme/list",

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -220,9 +220,23 @@ export const Config = z.object({
   // The storage layer (entities/entity_attrs/entity_relations tables + CRUD)
   // is always available regardless of this flag.
   entityExtractionEnabled: z.boolean().default(false),
+  // Optional provider override for entity extraction; empty = use the caller's
+  // default provider/model. Combined with entityExtractionModel — provider
+  // without model (or vice versa) falls through to the caller default.
+  entityExtractionProvider: z.string().default(""),
   // Optional model override for entity extraction; empty = use the caller's
   // default provider/model.
   entityExtractionModel: z.string().default(""),
+  // Reasoning effort for entity extraction (issue #109), mirrors
+  // dreamReasoningEffort: 'none' (default) omits the field / provider default;
+  // low/medium/high passed through. A provider that rejects the effort retries
+  // once without it, so opting in is safe to experiment with.
+  entityExtractionReasoning: z.union([
+    z.const("low"),
+    z.const("medium"),
+    z.const("high"),
+    z.const("none")
+  ]).default("none"),
   // Cap on entities per extraction pass and attributes per entity.
   entityExtractionMaxEntities: z.natural().min(1).max(20).default(10),
   entityExtractionMaxAttrs: z.natural().min(1).max(50).default(20),

--- a/dsh-mneme/src/entities/extractor.js
+++ b/dsh-mneme/src/entities/extractor.js
@@ -146,16 +146,23 @@ export async function extractEntities(memory, { store, config, callLLM, logger }
       return { ok: false, error: "Invalid memory: missing content" };
     }
     
-    const model = config.entityExtractionModel || null;
     const systemPrompt = buildSystemPrompt(config);
     const userText = buildUserMessage(memory.content);
-    
+
     const messages = [
       { role: "system", content: [{ type: "text", text: systemPrompt }] },
       { role: "user", content: [{ type: "text", text: userText }] }
     ];
-    
-    const options = model ? { model } : {};
+
+    // Issue #109: optional provider/model override + reasoning effort are
+    // passed through to callLLM's options; the index.js adapter maps them onto
+    // the route (or falls back to the caller's default model). Empty provider/
+    // model both mean "use the caller default".
+    const options = {};
+    if (config.entityExtractionProvider) options.provider = config.entityExtractionProvider;
+    if (config.entityExtractionModel) options.model = config.entityExtractionModel;
+    const reasoning = config.entityExtractionReasoning;
+    if (reasoning && reasoning !== "none") options.reasoningEffort = reasoning;
     const llmResponse = await callLLM(messages, options);
     
     if (!llmResponse) {
@@ -219,7 +226,7 @@ export async function extractEntities(memory, { store, config, callLLM, logger }
           to_entity: toId,
           relation_type: rel.type,
           memory_id: memory.id,
-          metadata: { model: model || "default" }
+          metadata: { model: options.model || "default" }
         });
         savedRelations.push(saved);
       } catch (err) {

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -35,6 +35,57 @@ export { Config };
 // value, so a `function apply` disposer would never run on unload. An arrow
 // has no prototype, is called normally, and its returned disposer is collected
 // and run by the fiber on unload.
+// Entity-extraction LLM adapter (issue #108/#109): maps the extractor's
+// options (provider/model override + reasoningEffort) onto a real dsh-llm
+// stream route and retries once without the effort when the first attempt is
+// rejected. Extracted from apply() so the effort-fallback branch is
+// unit-testable; the extractor only ever sees a callLLM(messages, options)
+// => Promise<string>. The route always carries a real provider/model (dsh-llm
+// GenerateOptions requires both) — never a bare stream.
+export function createEntityStreamAdapter({ llm, agentDefaultModel, logger }) {
+  return async function streamEntityText(messages, options = {}) {
+    let route = {};
+    if (options.provider) route.provider = options.provider;
+    if (options.model) route.model = options.model;
+    if (!route.provider || !route.model) {
+      try {
+        const sel = agentDefaultModel?.currentSelection?.();
+        if (sel?.provider && sel?.model) {
+          route.provider ??= sel.provider;
+          route.model ??= sel.model;
+        }
+      } catch { /* fall through to whatever route we already have */ }
+    }
+    const effort = options.reasoningEffort;
+    const tryStream = (withEffort) => {
+      let text = "";
+      return (async () => {
+        for await (const chunk of llm.stream({
+          ...route,
+          maxTokens: 4096,
+          ...(withEffort && effort ? { reasoningEffort: effort } : {}),
+          messages
+        })) {
+          if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
+          if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
+        }
+        return text;
+      })().catch((err) => {
+        logger?.warn?.(`[dsh-mneme] entity extraction llm stream failed: ${String(err)}`);
+        return undefined;
+      });
+    };
+    let text = await tryStream(true);
+    if (text === undefined && effort) {
+      // Mirror dream's effort fallback: a provider rejecting the reasoning
+      // effort must not sink the whole extraction — retry once without it.
+      logger?.warn?.(`[dsh-mneme] entity extraction: reasoningEffort "${effort}" rejected, retrying without it`);
+      text = await tryStream(false);
+    }
+    return text;
+  };
+}
+
 export const apply = (ctx, config) => {
   const rawCfg = Config(config);
 
@@ -328,51 +379,11 @@ export const apply = (ctx, config) => {
       // from "extraction failed".
       ctx.logger?.warn?.("[dsh-mneme] entityExtractionEnabled=true but ctx.llm unavailable — entity extractor NOT installed");
     } else {
-      const streamEntityText = async (messages, options = {}) => {
-        // Issue #109: explicit provider/model from the panel win; otherwise
-        // fall back to the caller's current default model. Either way the
-        // request always carries a real provider/model route (dsh-llm
-        // GenerateOptions requires both) — never a bare stream.
-        let route = {};
-        if (options.provider) route.provider = options.provider;
-        if (options.model) route.model = options.model;
-        if (!route.provider || !route.model) {
-          try {
-            const sel = ctx.agentDefaultModel?.currentSelection?.();
-            if (sel?.provider && sel?.model) {
-              route.provider ??= sel.provider;
-              route.model ??= sel.model;
-            }
-          } catch { /* fall through to whatever route we already have */ }
-        }
-        const effort = options.reasoningEffort;
-        const tryStream = (withEffort) => {
-          let text = "";
-          return (async () => {
-            for await (const chunk of ctx.llm.stream({
-              ...route,
-              maxTokens: 4096,
-              ...(withEffort && effort ? { reasoningEffort: effort } : {}),
-              messages
-            })) {
-              if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
-              if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
-            }
-            return text;
-          })().catch((err) => {
-            ctx.logger?.warn?.(`[dsh-mneme] entity extraction llm stream failed: ${String(err)}`);
-            return undefined;
-          });
-        };
-        let text = await tryStream(true);
-        if (text === undefined && effort) {
-          // Mirror dream's effort fallback: a provider rejecting the reasoning
-          // effort must not sink the whole extraction — retry once without it.
-          ctx.logger?.warn?.(`[dsh-mneme] entity extraction: reasoningEffort "${effort}" rejected, retrying without it`);
-          text = await tryStream(false);
-        }
-        return text;
-      };
+      const streamEntityText = createEntityStreamAdapter({
+        llm: ctx.llm,
+        agentDefaultModel: ctx.agentDefaultModel,
+        logger: ctx.logger
+      });
       service.setEntityExtractor((memory) =>
         extractEntities(memory, { store, config: cfg, callLLM: streamEntityText, logger: ctx.logger })
           .catch((err) => {

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -320,36 +320,67 @@ export const apply = (ctx, config) => {
   // expects, reusing the same ctx.llm.stream consumption pattern as dream.js.
   // Explicit opt-in only (entityExtractionEnabled defaults to false); any LLM
   // failure degrades inside the extractor to { ok:false }, never a write error.
-  if (cfg.entityExtractionEnabled && ctx.llm) {
-    const streamEntityText = async (messages, options = {}) => {
-      let route = null;
-      if (options.model) {
-        route = { model: options.model };
-      } else {
-        try {
-          const sel = ctx.agentDefaultModel?.currentSelection?.();
-          if (sel?.provider && sel?.model) route = sel;
-        } catch { /* fall through to no route */ }
-      }
-      let text = "";
-      for await (const chunk of ctx.llm.stream({
-        ...(route ?? {}),
-        purpose: "entity-extract",
-        maxTokens: 4096,
-        messages
-      })) {
-        if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
-        if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
-      }
-      return text;
-    };
-    service.setEntityExtractor((memory) =>
-      extractEntities(memory, { store, config: cfg, callLLM: streamEntityText, logger: ctx.logger })
-        .catch((err) => {
-          ctx.logger?.warn?.(`[dsh-mneme] entity extraction failed: ${String(err)}`);
-          return { ok: false, error: String(err) };
-        })
-    );
+  if (cfg.entityExtractionEnabled) {
+    if (!ctx.llm) {
+      // Issue #108: an enabled-but-unwired extractor failed silently before —
+      // zero entities, zero llm_audit_logs, no log line anywhere. Make the
+      // missing dependency visible so a user can tell "extractor not installed"
+      // from "extraction failed".
+      ctx.logger?.warn?.("[dsh-mneme] entityExtractionEnabled=true but ctx.llm unavailable — entity extractor NOT installed");
+    } else {
+      const streamEntityText = async (messages, options = {}) => {
+        // Issue #109: explicit provider/model from the panel win; otherwise
+        // fall back to the caller's current default model. Either way the
+        // request always carries a real provider/model route (dsh-llm
+        // GenerateOptions requires both) — never a bare stream.
+        let route = {};
+        if (options.provider) route.provider = options.provider;
+        if (options.model) route.model = options.model;
+        if (!route.provider || !route.model) {
+          try {
+            const sel = ctx.agentDefaultModel?.currentSelection?.();
+            if (sel?.provider && sel?.model) {
+              route.provider ??= sel.provider;
+              route.model ??= sel.model;
+            }
+          } catch { /* fall through to whatever route we already have */ }
+        }
+        const effort = options.reasoningEffort;
+        const tryStream = (withEffort) => {
+          let text = "";
+          return (async () => {
+            for await (const chunk of ctx.llm.stream({
+              ...route,
+              maxTokens: 4096,
+              ...(withEffort && effort ? { reasoningEffort: effort } : {}),
+              messages
+            })) {
+              if (chunk.type === "text-delta" && typeof chunk.text === "string") text += chunk.text;
+              if (chunk.type === "finish" && (chunk.reason?.kind === "error" || chunk.reason?.kind === "aborted")) return undefined;
+            }
+            return text;
+          })().catch((err) => {
+            ctx.logger?.warn?.(`[dsh-mneme] entity extraction llm stream failed: ${String(err)}`);
+            return undefined;
+          });
+        };
+        let text = await tryStream(true);
+        if (text === undefined && effort) {
+          // Mirror dream's effort fallback: a provider rejecting the reasoning
+          // effort must not sink the whole extraction — retry once without it.
+          ctx.logger?.warn?.(`[dsh-mneme] entity extraction: reasoningEffort "${effort}" rejected, retrying without it`);
+          text = await tryStream(false);
+        }
+        return text;
+      };
+      service.setEntityExtractor((memory) =>
+        extractEntities(memory, { store, config: cfg, callLLM: streamEntityText, logger: ctx.logger })
+          .catch((err) => {
+            ctx.logger?.warn?.(`[dsh-mneme] entity extraction failed: ${String(err)}`);
+            return { ok: false, error: String(err) };
+          })
+      );
+    }
   }
 
   const disposers = [];

--- a/dsh-mneme/src/settings.js
+++ b/dsh-mneme/src/settings.js
@@ -89,6 +89,10 @@ const FEATURE_FLAG_STRINGS = [
   // /llm-providers 端点一起提供，留空 = 用巩固模型或当前模型。
   "sleepProvider",
   "sleepModel",
+  // 实体抽取侧专用路由（issue #109）：provider/model 显式指定，
+  // 留空 = 用当前默认模型。
+  "entityExtractionProvider",
+  "entityExtractionModel",
   "localEmbedModel",
   "ollamaModel"
 ];
@@ -100,7 +104,9 @@ const FEATURE_FLAG_ENUMS = {
   embedProvider: ["openai", "local", "ollama"],
   // Plan #1: recall fusion recipe. blend = legacy (default); rrf / minmax are
   // rank/scale-aware alternatives selected by the panel.
-  recallFusion: ["blend", "rrf", "minmax"]
+  recallFusion: ["blend", "rrf", "minmax"],
+  // 实体抽取思考强度（issue #109）：与 dreamReasoningEffort 枚举对齐。
+  entityExtractionReasoning: ["low", "medium", "high", "none"]
 };
 const FEATURE_FLAG_STRING_MAX = 200;
 

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
 import { createStore } from "../src/store.js";
 import { createService } from "../src/service.js";
 import { createApi } from "../src/api.js";
@@ -515,6 +516,20 @@ test("Bug10: vector-reindex with an embed-only OpenAI-compatible embedder return
   assert.equal(vectorIndex.modelHash(), "text-embedding-3#abc", "model_hash written to vector_meta");
   assert.equal(vectorIndex.dimension(), 3, "dimension written to vector_meta");
   assert.equal(vectorIndex.getEmbedding(service.all()[0].id).length, 3, "embedding persisted");
+});
+
+// --- /info（反馈预填的插件版本）-----------------------------------------------
+
+test("GET /api/dsh-mneme/info returns the package version for feedback prefills", async () => {
+  const { routes } = setup(undefined);
+  const route = routes.find((r) => r.path === "/api/dsh-mneme/info");
+  const res = new FakeRes();
+  await route.handler(req("/api/dsh-mneme/info"), res);
+  assert.equal(res.statusCode, 200);
+  const data = JSON.parse(res.body);
+  // 与插件根 package.json 的版本一致（反馈 issue/邮件的预填环境信息依赖它）。
+  const expected = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+  assert.equal(data.version, expected);
 });
 
 // --- feature flags（/features：overrides + effective）------------------------

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -527,13 +527,15 @@ test("GET /api/dsh-mneme/features returns empty overrides and effective config d
   assert.equal(res.statusCode, 200);
   const data = JSON.parse(res.body);
   assert.deepEqual(data.overrides, {});
-  // effective 覆盖全部 39 个白名单键（含 v0.7.20 heatEnabled、Issue #89 新增
+  // effective 覆盖全部 42 个白名单键（含 v0.7.20 heatEnabled、Issue #89 新增
   // dreamSkipInvalid/allowCrossTypeMerge/dreamMinIntervalMinutes、面板可调的
-  // dreamMaxTokens、睡眠路由 sleepProvider/sleepModel，以及 PR1 新增的
-  // recallFusion/signalTransparency），未覆盖时取 bundle 配置的解析默认值；
+  // dreamMaxTokens、睡眠路由 sleepProvider/sleepModel、PR1 新增的
+  // recallFusion/signalTransparency，以及 issue #109 新增的实体抽取路由
+  // entityExtractionProvider/entityExtractionModel/entityExtractionReasoning），
+  // 未覆盖时取 bundle 配置的解析默认值；
   // dreamProvider/dreamModel 无 schema 默认值（Config({}) 解析为 undefined），
-  // 不编造给前端 → 39 - 2 = 37
-  assert.equal(Object.keys(data.effective).length, 37);
+  // 不编造给前端 → 42 - 2 = 40
+  assert.equal(Object.keys(data.effective).length, 40);
   assert.equal(data.effective.dreamSkipInvalid, true);
   assert.equal(data.effective.allowCrossTypeMerge, false);
   assert.equal(data.effective.dreamMinIntervalMinutes, 0);
@@ -559,6 +561,10 @@ test("GET /api/dsh-mneme/features returns empty overrides and effective config d
   // PR1：融合配方枚举 + 信号透明布尔（均有默认值，故计入 effective 计数）
   assert.equal(data.effective.recallFusion, "blend");
   assert.equal(data.effective.signalTransparency, false);
+  // issue #109：实体抽取路由三键（均有默认值，故计入 effective 计数）
+  assert.equal(data.effective.entityExtractionProvider, "");
+  assert.equal(data.effective.entityExtractionModel, "");
+  assert.equal(data.effective.entityExtractionReasoning, "none");
 });
 
 test("PUT /api/dsh-mneme/features round-trips, overrides effective and persists", async () => {

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -554,3 +554,42 @@ test("consolidation/sleep model routing: provider dropdowns from /llm-providers,
     "the route selects must share the string-input width budget"
   );
 });
+
+// 帮助与反馈入口（v0.8）：设置页底部三个反馈链接——GitHub 新建 issue 预填
+// （环境信息）、邮件反馈、浏览已知问题。纯前端链接零后端成本；插件版本从
+// /info 拉取（version 只读，不铺任何 token/凭据）。公开链接不得带个人邮箱。
+test("settings feedback card: prefilled issue + mailto + browse, version from /info", () => {
+  // 1. 版本预填端点
+  assert.ok(
+    clientSource.includes('apiFetch("/api/dsh-mneme/info")'),
+    "the feedback card must fetch the plugin version from /info"
+  );
+  assert.ok(
+    clientSource.includes("setPkgVersion"),
+    "the fetched version must land in component state"
+  );
+  // 2. GitHub 新建 issue：issues/new?title=&body= 预填环境信息（当前仓库无模板）
+  assert.ok(
+    clientSource.includes("https://github.com/modusensus/dsh-mneme/issues/new?title="),
+    "the issue link must prefill title+body on issues/new"
+  );
+  assert.ok(
+    clientSource.includes("**插件版本**") && clientSource.includes("**平台**"),
+    "the prefill body must carry plugin version and platform"
+  );
+  // 3. 邮件反馈：官方邮箱（对外不写个人邮箱），mailto 预填 subject+body
+  assert.ok(
+    clientSource.includes("mailto:work@modusensus.space?subject="),
+    "the mailto link must point at the public support address"
+  );
+  // 4. 浏览已知问题：跳仓库 issues 列表页（去重前置步骤）
+  assert.ok(
+    clientSource.includes('href: "https://github.com/modusensus/dsh-mneme/issues"'),
+    "the browse link must open the repo issues list"
+  );
+  // 5. 双语 i18n
+  for (const key of ["feedback.title", "feedback.newIssue", "feedback.email", "feedback.browse", "feedback.hint"]) {
+    const occurrences = clientSource.split(`"memory.settings.${key}"`).length - 1;
+    assert.ok(occurrences >= 2, `i18n key memory.settings.${key} must exist in both zh and en (got ${occurrences})`);
+  }
+});

--- a/dsh-mneme/test/entities.test.js
+++ b/dsh-mneme/test/entities.test.js
@@ -520,3 +520,28 @@ test("extractor fails safe when callLLM rejects → {ok:false}", async () => {
   assert.ok(result.error);
   store.close();
 });
+
+// --- issue #109: provider/model override + reasoning effort pass-through -----
+
+test("extractor passes provider/model/reasoningEffort through to callLLM options", async () => {
+  const store = openStore();
+  let captured = null;
+  const callLLM = async (_messages, options) => {
+    captured = options;
+    return JSON.stringify({ entities: [{ name: "Vite", type: "technology", attrs: [] }], relations: [] });
+  };
+  const config = { entityExtractionProvider: "openai", entityExtractionModel: "gpt-x", entityExtractionReasoning: "high" };
+  const result = await extractEntities({ id: "m1", content: "Vite 是前端构建工具" }, { store, config, callLLM });
+  assert.equal(result.ok, true);
+  assert.deepEqual(captured, { provider: "openai", model: "gpt-x", reasoningEffort: "high" });
+  store.close();
+});
+
+test("extractor omits empty provider/model and 'none' reasoning from options", async () => {
+  const store = openStore();
+  let captured = "unset";
+  const callLLM = async (_m, options) => { captured = options; return JSON.stringify({ entities: [], relations: [] }); };
+  await extractEntities({ id: "m2", content: "空文本" }, { store, config: {}, callLLM });
+  assert.deepEqual(captured, {}, "no provider/model/reasoning keys when unset");
+  store.close();
+});

--- a/dsh-mneme/test/reasoning-effort.test.js
+++ b/dsh-mneme/test/reasoning-effort.test.js
@@ -13,6 +13,7 @@ import { runSleep } from "../src/dream/sleep.js";
 import { createStore } from "../src/store.js";
 import { createService } from "../src/service.js";
 import { createVectorIndex } from "../src/vector-index.js";
+import { createEntityStreamAdapter } from "../src/index.js";
 
 const embedder = {
   embedSingle: async () => [1, 0, 0],
@@ -575,4 +576,80 @@ test("defaultEffort trap: sleep conflict pass remaps a poison effort too", async
     assert.equal(options.reasoningEffort, "medium", "poison 'low' remapped on sleep passes too");
   }
   store.close();
+});
+
+// ------------------------------------------------- entity extraction adapter (issue #108/#109)
+// The streamEntityText adapter lives in index.js; it maps the extractor's
+// options onto a dsh-llm stream route and retries once without the effort
+// when the first attempt is rejected. These tests drive the real exported
+// factory, not a mock of it.
+
+test("issue#109: entity extraction effort rejection retries once without the effort", async () => {
+  const calls = [];
+  const warnings = [];
+  const streamEntityText = createEntityStreamAdapter({
+    llm: {
+      async *stream(options) {
+        calls.push(options);
+        // First attempt carries the effort: the provider rejects it via an
+        // error finish chunk (the realistic stream-level rejection).
+        if (options.reasoningEffort) {
+          yield { type: "finish", reason: { kind: "error", message: "UNSUPPORTED_REASONING_EFFORT" } };
+          return;
+        }
+        yield { type: "text-delta", index: 0, text: "{\"entities\":[{\"name\":\"张三\",\"type\":\"person\",\"attrs\":[{\"key\":\"职业\",\"value\":\"工程师\",\"confidence\":0.9}]}],\"relations\":[]}" };
+        yield { type: "finish", reason: { kind: "stop" } };
+      }
+    },
+    agentDefaultModel: { currentSelection: () => ({ provider: "mock", model: "mock-model" }) },
+    logger: { warn: (m) => warnings.push(String(m)) }
+  });
+  const text = await streamEntityText(
+    [{ role: "user", content: [{ type: "text", text: "记忆内容" }] }],
+    { reasoningEffort: "low" }
+  );
+  assert.equal(calls.length, 2, "attempt (rejected) + retry without effort");
+  assert.equal(calls[0].reasoningEffort, "low", "first attempt forwards the effort");
+  assert.equal("reasoningEffort" in calls[1], false, "retry omits the rejected effort field");
+  assert.equal(calls[0].provider, "mock", "route resolved from agentDefaultModel");
+  assert.equal(calls[0].model, "mock-model", "route model from agentDefaultModel");
+  assert.equal(calls[0].maxTokens, 4096, "extraction caps its output");
+  assert.ok(text.includes("张三"), "retry stream text is returned");
+  assert.ok(warnings.some((w) => w.includes("rejected, retrying without it")), "rejection is logged");
+});
+
+test("issue#109: entity extraction never retries blindly without an effort configured", async () => {
+  const calls = [];
+  const streamEntityText = createEntityStreamAdapter({
+    llm: {
+      async *stream(options) {
+        calls.push(options);
+        yield { type: "finish", reason: { kind: "error", message: "overloaded" } };
+      }
+    },
+    agentDefaultModel: { currentSelection: () => ({ provider: "mock", model: "mock-model" }) },
+    logger: { warn: () => {} }
+  });
+  const text = await streamEntityText([{ role: "user", content: [] }], {});
+  assert.equal(text, undefined, "failure yields no text");
+  assert.equal(calls.length, 1, "no blind retry when no effort was requested");
+});
+
+test("issue#109: entity extraction explicit provider/model win over the default route", async () => {
+  const calls = [];
+  const streamEntityText = createEntityStreamAdapter({
+    llm: {
+      async *stream(options) {
+        calls.push(options);
+        yield { type: "text-delta", index: 0, text: "{}" };
+        yield { type: "finish", reason: { kind: "stop" } };
+      }
+    },
+    agentDefaultModel: { currentSelection: () => ({ provider: "default", model: "default-model" }) },
+    logger: { warn: () => {} }
+  });
+  await streamEntityText([{ role: "user", content: [] }], { provider: "volcano", model: "deepseek-v3" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].provider, "volcano", "explicit provider beats the default");
+  assert.equal(calls[0].model, "deepseek-v3", "explicit model beats the default");
 });


### PR DESCRIPTION
## 修复实体抽取静默失败（#108 #109）

实体抽取路由契约修复：provider/model 显式配置优先，兜底读默认路由选择；reasoningEffort 支持并带拒绝重试兜底（部分模型不支持思考强度参数时自动降级）。

## 变更

- `src/index.js`：`streamEntityText` 抽取为可测试导出的 `createEntityStreamAdapter` 工厂
- `src/api.js`：新增 `GET /api/dsh-mneme/info`（返回插件版本，供面板展示）
- 面板新增实体抽取 provider/model/思考强度三个控件（`lib/client.js`）
- 面板底部新增「帮助与反馈」卡片：GitHub issue 预填 + `mailto:work@modusensus.space` + 浏览已知问题入口

## 测试

- 新增 effort 拒绝重试 / 显式路由优先 / /info 版本一致性 / 反馈卡片源码断言 用例
- 744/744 全绿；src ↔ lib 同步检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a plugin information endpoint that reports the installed version.
  - Added a bilingual “Help & feedback” section with prefilled issue and email links, known-issues access, and environment details.
  - Expanded entity extraction settings with provider, model, and reasoning-effort controls.
  - Added entity-extraction connectivity testing with provider and model selection.
  - Improved compatibility by retrying entity extraction without reasoning when unsupported.

- **Tests**
  - Added coverage for version reporting, feedback links, configuration, and entity-extraction routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->