### PR TITLE
feat(ci): release-prep 工作流（发布准备自动化）

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,76 @@
+name: Release Prep
+
+# 发布准备自动化：bump 版本号（package.json + package-lock）+ 同步双 README 测试徽章
+# + CHANGELOG 顶部空节 + 双 README 版本历史/路线图占位行，推 release-prep/<版本> 分支并自动开 PR。
+# CHANGELOG/路线图的描述文字仍需人工在 PR 里补（机器写不了内容）。
+# 使用：手动触发填目标版本号 → 合并 PR → 推 v<版本> tag 即自动发布（release.yml）。
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '目标版本号（如 0.7.30，不带 v）'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          V="${{ inputs.version }}"
+          if ! [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::版本号格式应为 0.X.Y（如 0.7.30），当前: $V"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: dsh-mneme/package-lock.json
+
+      - name: Install dependencies
+        working-directory: dsh-mneme
+        run: npm ci
+
+      - name: Count passing tests
+        id: tests
+        working-directory: dsh-mneme
+        run: |
+          COUNT=$(node --test test/*.test.js 2>&1 | tail -10 | grep -oE 'pass [0-9]+' | grep -oE '[0-9]+')
+          echo "count=$COUNT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Run release-prep (version bump + badge + placeholder rows)
+        run: node scripts/release-prep.mjs "${{ inputs.version }}" "${{ steps.tests.outputs.count }}"
+
+      - name: Create release-prep branch + PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "modusensus"
+          git config user.email "modusensus@users.noreply.github.com"
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::warning::无改动（版本号/占位行已存在）——跳过提交与 PR"
+            exit 0
+          fi
+          git checkout -b "release-prep/${{ inputs.version }}"
+          git add dsh-mneme/package.json dsh-mneme/package-lock.json dsh-mneme/CHANGELOG.md README.md dsh-mneme/README.md
+          { echo "chore: v${{ inputs.version }} 发布准备（版本号 + 测试徽章 + CHANGELOG/路线图占位行）"
+            echo
+            echo "请在 CHANGELOG 与两个 README 的占位行补描述后再合并。"
+            echo
+            echo "Co-Authored-By: Anans-Ivresse <Anans-Ivresse@users.noreply.github.com>"
+          } > commit-msg.txt
+          git commit -F commit-msg.txt
+          git push origin "release-prep/${{ inputs.version }}"
+          gh pr create --base main --head "release-prep/${{ inputs.version }}" \
+            --title "release: v${{ inputs.version }} 发布准备" \
+            --body "由 Release Prep 工作流生成：版本号（package.json + package-lock）、测试徽章（自动取当前测试数）已同步，CHANGELOG/路线图已加占位行。请在 CHANGELOG 与两个 README 的占位行补描述后再合并。合并后推 v${{ inputs.version }} tag 即自动发布。"

--- a/scripts/release-prep.mjs
+++ b/scripts/release-prep.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// 发布准备自动化：bump 版本号（dsh-mneme/package.json + package-lock 两处）+ 同步双 README 测试徽章
+// + CHANGELOG 顶部空节 + 双 README 版本历史/路线图占位行（描述留空待人工填写）。
+// 用法: node scripts/release-prep.mjs <版本号，如 0.7.30> [测试数，如 744]
+"use strict";
+
+import fs from "node:fs";
+
+const version = (process.argv[2] || "").replace(/^v/, "");
+const testCount = process.argv[3];
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error("用法: node scripts/release-prep.js <版本号> [测试数]");
+  process.exit(1);
+}
+
+const PKG = "dsh-mneme/package.json";
+const LOCK = "dsh-mneme/package-lock.json";
+const CHANGELOG = "dsh-mneme/CHANGELOG.md";
+const READMES = ["README.md", "dsh-mneme/README.md"];
+
+// ── 1. 版本号同步：package.json 1 处 + package-lock 顶层/包根两处 ──
+for (const f of [PKG, LOCK]) {
+  if (!fs.existsSync(f)) {
+    console.error(`缺少 ${f}`);
+    process.exit(1);
+  }
+  const p = JSON.parse(fs.readFileSync(f, "utf8"));
+  p.version = version;
+  if (p.packages && p.packages[""]) p.packages[""].version = version;
+  fs.writeFileSync(f, JSON.stringify(p, null, 2) + "\n");
+  console.log(`✓ ${f} → ${version}`);
+}
+
+// ── 2. 测试徽章同步（两个 README）──
+if (testCount && /^\d+$/.test(testCount)) {
+  for (const f of READMES) {
+    const t = fs.readFileSync(f, "utf8");
+    const n = t.replace(/tests-\d+%20passed/g, `tests-${testCount}%20passed`);
+    if (n !== t) {
+      fs.writeFileSync(f, n);
+      console.log(`✓ ${f} 测试徽章 → ${testCount}`);
+    }
+  }
+}
+
+// ── 3. CHANGELOG 顶部空节（满足 release.yml verify 的 ^## [V] 检查）──
+{
+  const t = fs.readFileSync(CHANGELOG, "utf8");
+  if (!t.includes(`## [${version}]`)) {
+    // 按东八区取日期（与历史 CHANGELOG 日期惯例一致）
+    const date = new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+    const head = `## [${version}] - ${date}\n\n## 🐛 修复\n\n- （待填）\n\n`;
+    fs.writeFileSync(CHANGELOG, t.replace(/^(# Changelog\n\n)/, "$1" + head));
+    console.log(`✓ ${CHANGELOG} 占位节`);
+  } else {
+    console.log(`- ${CHANGELOG} 已含 ${version}，跳过`);
+  }
+}
+
+// ── 4. 双 README 版本历史/路线图占位行（插在最新版本行之后；幂等）──
+{
+  const cellCount = (line) => line.split("|").filter((c) => c.trim()).length;
+  const hasCJK = (s) => /[一-鿿]/.test(s);
+  // 按表格列数生成占位行：2 列=版本历史，3 列=root 路线图（按语言），4 列=dsh-mneme 路线图
+  const rowFor = (line, v) => {
+    const n = cellCount(line);
+    if (n <= 2) return `| **v${v}** | （待填） |`;
+    if (n === 3)
+      return hasCJK(line) ? `| **v${v}** | （待填） | 🚧 准备中 |` : `| **v${v}** | TBD | 🚧 In prep |`;
+    return `| **v${v}** | 🚧 准备中 | （待填） | （待填） |`;
+  };
+  const semverGt = (a, b) => {
+    const pa = a.split(".").map(Number);
+    const pb = b.split(".").map(Number);
+    return pa[0] > pb[0] || (pa[0] === pb[0] && (pa[1] > pb[1] || (pa[1] === pb[1] && pa[2] > pb[2])));
+  };
+  const semverLt = (a, b) => semverGt(b, a);
+
+  for (const f of READMES) {
+    const t = fs.readFileSync(f, "utf8");
+    if (t.includes(`**v${version}**`)) {
+      console.log(`- ${f} 已含 v${version}，跳过占位行`);
+      continue;
+    }
+    const rows = [];
+    for (const line of t.split("\n")) {
+      const m = line.match(/^\|\s*\*\*v(\d+\.\d+\.\d+)\*\*/);
+      if (m) rows.push({ line, ver: m[1] });
+    }
+    if (!rows.length) {
+      console.log(`- ${f} 无版本表格行，跳过`);
+      continue;
+    }
+    // 取「小于目标版本」的最新版本行（路线图表可能已含 v0.8.0 这类计划行，不能插到它后面）
+    const lower = rows.filter((r) => semverLt(r.ver, version));
+    const pool = lower.length ? lower : rows;
+    const maxVer = pool.reduce((a, b) => (semverGt(b.ver, a.ver) ? b : a)).ver;
+    const out = [];
+    for (const line of t.split("\n")) {
+      out.push(line);
+      if (line.includes(`**v${maxVer}**`) && cellCount(line) >= 2) out.push(rowFor(line, version));
+    }
+    fs.writeFileSync(f, out.join("\n"));
+    console.log(`✓ ${f} 占位行 v${version}`);
+  }
+}
+
+console.log("完成。请 git diff 检查后提交。");


### PR DESCRIPTION
## 发布准备自动化（对应需求：Action 补上版本号 + README/徽章自动改）

新增手动触发的 `release-prep` 工作流（填目标版本号），自动完成发布前机械活：

1. **版本号**：`scripts/release-prep.mjs` bump `dsh-mneme/package.json` + `package-lock.json`（两处，根治落后两版问题）
2. **测试徽章**：跑 `npm test` 取真实测试数，自动改两个 README 徽章
3. **占位行**：CHANGELOG 顶部空节 + 两个 README 版本历史/路线图占位行（插在小于目标版本的最新版本行后，避开 v0.8.0 计划行；中文/英文/版本历史/路线图四种表格格式自适应）
4. **自动开 PR**：推 `release-prep/<版本>` 分支 + 建 PR

人工只需在 PR 补 CHANGELOG/路线图描述 → 合并 → 推 tag 自动发布。

已本地实测 0.7.30：4 处占位行位置/格式全部正确。CHANGELOG/路线图描述文字仍人工写（机器写不了内容）。

Closes: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a manually triggered release-preparation workflow.
  - Added semantic-version validation and automated updates to package metadata, changelog entries, roadmap placeholders, and test-count badges.
  - Release preparation now creates a dedicated branch and pull request when changes are detected.
  - Prevents unnecessary commits and pull requests when no files require updating.
  - Reports missing files, existing entries, skipped updates, and completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->