### PR TITLE
fix(ci): 工作流去除个人署名（对外内容不署名）

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -66,8 +66,6 @@ jobs:
           { echo "chore: v${{ inputs.version }} 发布准备（版本号 + 测试徽章 + CHANGELOG/路线图占位行）"
             echo
             echo "请在 CHANGELOG 与两个 README 的占位行补描述后再合并。"
-            echo
-            echo "Co-Authored-By: Anans-Ivresse <Anans-Ivresse@users.noreply.github.com>"
           } > commit-msg.txt
           git commit -F commit-msg.txt
           git push origin "release-prep/${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.verify.outputs.version }}
         run: |
-          # 标题统一纯版本号（v0.7.9 基准，桉桉 9/8 拍板）；Release 正文由
+          # 标题统一纯版本号（v0.7.9 基准，9/8 决定）；Release 正文由
           # 上方抽取的 CHANGELOG 分类小节提供（## 🆕 新功能 / 🐛 修复 / 🏗️ 工程 / 📦 升级提示）
           if gh release view "v${VERSION}" >/dev/null 2>&1; then
             gh release edit "v${VERSION}" --title "v${VERSION}" --notes-file notes/body.md


### PR DESCRIPTION
发布准备/发布工作流中残留的个人署名已去除：
- `release-prep.yml`：生成的发布准备提交去掉 Co-Authored-By 个人署名（否则每次自动 PR 的提交都会带名字）
- `release.yml`：注释中的名字改为中性表述
- 按对外内容不署名原则清理（9/10 反馈）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release automation messaging for clearer release title decisions.
  - Removed an unnecessary attribution trailer from release commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->