### PR TITLE
fix(e2e): 硬编码 7工具/14路由 改下限检查

### DIFF
--- a/dsh-mneme/scripts/e2e-dsh.js
+++ b/dsh-mneme/scripts/e2e-dsh.js
@@ -104,14 +104,16 @@ console.log(`记忆目录：${memDir}\n`);
 // 1. 装载检查
 console.log("【1】插件装载");
 const checks = [];
-checks.push(["注册 7 个模型工具", registeredTools.length === 7]);
+// 硬编码精确数会随插件演进过时（v0.7 起已有 8 工具 / 26+ 路由，早期写死的
+// 7/14 导致新旧 dsh 上 e2e 都误报失败）；改用「下限」检查 + 打印实际数量。
+checks.push(["注册 ≥7 个模型工具", registeredTools.length >= 7]);
 checks.push(["注册 2 个注入上下文", injectContexts.length === 2 && injectContexts[0].name === "memory"]);
-// 契约是 14 条 exact 路由（v0.3 实体清单接口后由 13 条扩到 14 条）；
 // prefix fallback（/api/dsh-mneme → 404）是兜底，不计入路由数。
-checks.push(["注册 14 条 API 路由", apiRoutes.filter((r) => r.kind === "exact").length === 14]);
+checks.push(["注册 ≥14 条 API 路由", apiRoutes.filter((r) => r.kind === "exact").length >= 14]);
 for (const [label, ok] of checks) console.log(`  ${ok ? "✅" : "❌"} ${label}`);
 if (!checks.every(([, ok]) => ok)) { console.log("\n装载检查失败，中止。"); process.exit(1); }
-console.log(`  工具：${registeredTools.map((t) => t.name).join(", ")}\n`);
+console.log(`  工具（${registeredTools.length}）：${registeredTools.map((t) => t.name).join(", ")}`);
+console.log(`  exact 路由：${apiRoutes.filter((r) => r.kind === "exact").length} 条\n`);
 
 // 2. 保存记忆（工具执行）
 console.log("【2】memory_save 保存记忆");


### PR DESCRIPTION
修复 e2e-dsh.js 中随插件扩容而过时的硬编码数量检查（7 模型工具 → 现 8；14 exact 路由 → 现 26+），改为 `>=` 下限检查并打印实际数量，作为长期兼容性回归测试。已在 dsh 0.1.0-rc.8 与 0.1.5-rc.1 双环境验证通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end validation to support expanded tool and route registrations.
  - Validation now reports the actual number of registered tools and routes, making test results clearer.
  - Existing injection-context checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->