### PR TITLE
fix: 声明宿主版本要求，覆盖 dsh 0.1.x 当前全部版本

### DIFF
--- a/dsh-mneme/package-lock.json
+++ b/dsh-mneme/package-lock.json
@@ -27,10 +27,10 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-host-webserver": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
+        "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
+        "@deepseek-ai/dsh-system-prompt": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
+        "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
         "@deepseek-ai/schemastery": "^3.18.1",
         "dsh-better-sidebar": "^0.18.0"
       },

--- a/dsh-mneme/package.json
+++ b/dsh-mneme/package.json
@@ -47,10 +47,10 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-host-webserver": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
+    "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
+    "@deepseek-ai/dsh-system-prompt": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
+    "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0",
     "@deepseek-ai/schemastery": "^3.18.1",
     "dsh-better-sidebar": "^0.18.0"
   },


### PR DESCRIPTION
## 变更

修 `peerDependencies` 宿主版本声明：原 `^0.1.0-rc.6` 按 node-semver 元组规则**不匹配** `0.1.5-rc.1` 等中间预发布版本（当前 dsh 用户安装会 ERESOLVE），也违反 awesome-dsh-plugin 的 peer-range 预发布分支规范。

改为显式预发布分支三段式：

```
>=0.1.0-rc.6 <0.2.0 || >=0.1.5-rc.0 <0.3.0 || >=0.2.0-rc.0 <0.3.0
```

- 覆盖当前全部已发布 0.1.x（含 `0.1.5-rc.1`）
- 未来 0.2 预发布留显式分支，不静默排除
- 0.3 以上待验证后另行放开

## 验证

- 745 测试全绿
- 新 peer 范围实测匹配 dsh `0.1.5-rc.1`、`0.1.0-rc.6`、`0.2.0-rc.x`

## 变更文件

- `package.json` / `package-lock.json`：4 个 `@deepseek-ai/dsh-*` peer 范围更新


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated compatibility requirements for the DeepSeek AI packages used by the application.
  - Supports a broader range of compatible package versions across the 0.1.x and 0.2.x release lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->