### PR TITLE
feat(runtime): 自管本地推理运行时（PR-A，issue #131）

### DIFF
--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -153,8 +153,17 @@ v0.2 起新增**完全离线的语义记忆引擎**（本地模型 + 精排 + �
 - **Rerank 精排**：`Xenova/bge-reranker-base` 对召回候选交叉编码精排，提升 Top-K 准确率
 - **autoDream 语义增强**：对记忆向量聚类（`clusterMemories`），自动发现主题相近 / 疑似矛盾的记忆，巩固更精准
 - **搜索流水线**：混合召回（关键词 + 向量）→ Rerank → Top-K
+- **自管运行时**：本地推理的依赖闭包（`@huggingface/transformers` + `onnxruntime-node` + `sharp`，本机实测 49 个包 / 约 393MB）可收编到 `~/.dsh/mneme/runtime/`，与 profile 的依赖图解耦——由于 profile 是所有插件共用的依赖图，这份闭包留在此前的位置会让「安装任何插件」都替它重走一遍整条依赖链；收编优先硬链接，同盘时几乎不额外占盘
 
 配置只需在 `cordis.patch.yml` 里设置 `embedProvider`（默认 `openai`，保持 v0.1 行为；改为 `local` 即离线）。升级无需迁移数据。
+
+```bash
+node scripts/mneme-runtime.mjs status    # 运行时在哪、来源、结构是否完整（不加载模型）
+node scripts/mneme-runtime.mjs adopt --from ~/.dsh/profiles/<profile>/node_modules
+node scripts/mneme-runtime.mjs verify    # 真加载运行时并跑一次推理
+```
+
+> 三个命令的退出码为 `0` 健康 / `1` 不健康 / `2` 用法错误，便于脚本 gate；`--json` 输出机器可读结果。运行时不可用时不会崩——检索降级为关键词/BM25，读写不受影响。详见 [本地模型部署指南 §2.5](docs/LOCAL_MODEL.md)。
 
 ### 实体结构化记忆（Entity Gene）🧬
 

--- a/dsh-mneme/docs/LOCAL_MODEL.md
+++ b/dsh-mneme/docs/LOCAL_MODEL.md
@@ -13,7 +13,11 @@
 | GPU（可选） | 显存 ≥ 2GB | 开启 `localEmbedDevice: "gpu"`（onnxruntime 需要额外安装 cuda 后端） |
 | 网络 | 仅首次下载模型需要 | 已下载后可完全离线（默认走 Hugging Face，可换镜像源） |
 
-> 依赖：`@huggingface/transformers`（transformers.js）已声明在插件 `package.json` 的 `dependencies`；`onnxruntime-node` 作为可选原生后端列在 `allowScripts`（首次安装需确认脚本），无需手动额外安装。
+> 依赖解析分三层：① **插件自管运行时目录**（`~/.dsh/mneme/runtime/`，见 §2.5，优先）；② 宿主 profile 里已装的 `@huggingface/transformers`；③ 都没有则本地推理不可用，检索自动降级为关键词/BM25（读写在任何情况下都不受影响）。
+>
+> 目前插件仍把 `@huggingface/transformers` 声明在 `dependencies`，所以第 ② 层恒可用；后续版本会摘掉该声明、改由自管运行时承接。**建议提前按 §2.5 收编一份**，否则升级后本地嵌入会不可用。
+>
+> `onnxruntime-node` 作为可选原生后端列在 `allowScripts`（首次安装需确认脚本），无需手动额外安装。
 
 ## 2. 模型安装 / 下载
 
@@ -30,6 +34,8 @@ node scripts/benchmark-embed.js --provider local --model Xenova/bge-small-zh-v1.
 
 - Linux/macOS：`~/.dsh/mneme/models/`
 - Windows：`%USERPROFILE%\.dsh\mneme\models\`
+
+> 实测 transformers.js 4.2.0 在离线加载（`allowRemoteModels=false`）时按 `<cacheDir>/<org>/<model>/` 解析模型文件，例如 `<cacheDir>/Xenova/bge-small-zh-v1.5/config.json`。与本段上面描述的 `hub/models--…` 布局不一致时，以实际报错里给出的路径为准；缓存不在默认位置时按 §2.5 用 `--cache-dir` 指过去。
 
 ### 2.2 手动指定缓存目录
 
@@ -60,6 +66,32 @@ Ollama Embedder 走 `/api/embeddings`，**不下载任何文件到插件缓存**
 ```bash
 rm -rf ~/.dsh/mneme/models/hub/models--Xenova--bge-small-zh-v1.5
 ```
+
+### 2.5 自管运行时（收编 / 校验 / 排查）
+
+本地推理真正要用的是一整套依赖闭包：`@huggingface/transformers` + `onnxruntime-node` + `sharp`（本机实测 49 个包、3203 个文件、约 393MB）。插件支持把它收编到自管目录 `~/.dsh/mneme/runtime/`，与宿主 profile 的依赖图解耦；收编**优先使用硬链接**，同盘时几乎不额外占盘。
+
+**为什么值得提前做**：这份闭包此前留在插件 `dependencies` 里，而 profile 是所有插件共用的依赖图，于是「装任何插件」都要替它重走一遍整条链，弱网下极慢。摘掉该声明后，运行时由自管目录承接——所以要**先收编、再升级**，否则升级后本地嵌入不可用。
+
+```bash
+# 在插件目录下运行（例如 node_modules/@modusensus/dsh-mneme）
+
+# 1) 看状态：在哪、来源、结构完不完整（不加载模型，秒回）
+node scripts/mneme-runtime.mjs status
+
+# 2) 收编宿主里已有的那份（只读源、只写自管目录，不安装任何东西）
+node scripts/mneme-runtime.mjs adopt --from ~/.dsh/profiles/<profile>/node_modules
+
+# 3) 真加载运行时并跑一次推理，确认可用
+node scripts/mneme-runtime.mjs verify --cache-dir ~/.dsh/mneme/models
+```
+
+- 退出码：`0` 健康 / `1` 不健康或失败 / `2` 用法错误（便于脚本直接 gate，区分「没装」和「装坏了」看输出里的 `status`）。加 `--json` 得到机器可读结果。
+- `verify` 的功能验证**不触网**（`allowRemoteModels=false`）：模型必须已在缓存目录里，否则会明确失败——这是有意的，验证不该偷偷触网。缓存不在默认位置时用 `--cache-dir` 指到与 `embedModelCacheDir` 一致的位置。
+- 收编来的目录没有可比对的原始产物，完整性如实标 `unverified`，不假装验过；结构检查通过 ≠ 功能可用，两者分开报。
+- `status` 只做结构检查，所以 `functional` 恒为 `unknown`——要看真实推理结果就跑 `verify`。
+- 运行时不可用时插件不会崩：检索降级为关键词/BM25，读写在任何情况下都不受影响；错误信息会带上 `adopt` 的具体命令。
+- 同一份状态也能从 `GET /api/dsh-mneme/semantic` 的 `localRuntime` 字段读到（面板与 CLI 同源）。
 
 ## 3. 配置
 

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -5,6 +5,7 @@ import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
 import { describeStreamFailure, resolveRoute } from "./dream.js";
+import { describeLocalRuntime } from "./runtime/loader.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -615,7 +616,11 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           modelHash: embedder?.modelHash ?? null,
           dimension: embedder?.dimension ?? null,
           reranker: semantic?.reranker ? "ready" : null,
-          index: stats
+          index: stats,
+          // issue #131 / PR-A：自管运行时的状态。无论当前 provider 是不是 local
+          // 都报 —— 面板需要区分「已收编但没启用」和「要用本地却没收编」。
+          // 这里只做结构检查（不跑推理），失败降级成状态对象，不会让本端点 500。
+          localRuntime: describeLocalRuntime({ runtimeDir: config?.runtimeDir ?? "" })
         });
       } catch {
         sendJson(res, 500, { error: "internal" });

--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -5,7 +5,7 @@ import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
 import { describeStreamFailure, resolveRoute } from "./dream.js";
-import { describeLocalRuntime } from "./runtime/loader.js";
+import { describeLocalRuntime, publicRuntimeStatus } from "./runtime/loader.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -620,7 +620,9 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           // issue #131 / PR-A：自管运行时的状态。无论当前 provider 是不是 local
           // 都报 —— 面板需要区分「已收编但没启用」和「要用本地却没收编」。
           // 这里只做结构检查（不跑推理），失败降级成状态对象，不会让本端点 500。
-          localRuntime: describeLocalRuntime({ runtimeDir: config?.runtimeDir ?? "" })
+          // 必须经 publicRuntimeStatus 投影：本端点是免鉴权的，绝对路径与原始错误
+          // 文本不能出去（CWE-200）。完整诊断走本机 CLI 的 status。
+          localRuntime: publicRuntimeStatus(describeLocalRuntime({ runtimeDir: config?.runtimeDir ?? "" }))
         });
       } catch {
         sendJson(res, 500, { error: "internal" });

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -134,6 +134,12 @@ export const Config = z.object({
   embedModelCacheDir: z.string().default(""),
   embedModelMirror: z.string().default("https://hf-mirror.com"),
 
+  // 自管运行时目录（issue #131）。空 = ~/.dsh/mneme/runtime：里面放收编或下载来的
+  // transformers + onnxruntime 闭包，插件经 src/runtime/loader.js 的三层解析加载它。
+  // 目的就是让这条重依赖不必留在宿主 profile 的依赖图里——profile 是所有插件共用的
+  // 依赖图，留在里面会让「装任何插件都要替它重走一遍这条链」。
+  runtimeDir: z.string().default(""),
+
   // Vector search tuning.
   vectorSearchTopK: z.natural().min(1).max(100).default(20),
   vectorSearchThreshold: z.number().min(0).max(1).default(0.65),

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -222,6 +222,7 @@ export const apply = (ctx, config) => {
         device: cfg.localEmbedDevice,
         batchSize: cfg.localEmbedBatchSize,
         cacheDir: cfg.embedModelCacheDir,
+        runtimeDir: cfg.runtimeDir,
         baseUrl: cfg.ollamaBaseUrl,
         logger: ctx.logger
       });
@@ -273,6 +274,7 @@ export const apply = (ctx, config) => {
         scoreThreshold: cfg.rerankScoreThreshold,
         device: cfg.localEmbedDevice,
         cacheDir: cfg.embedModelCacheDir,
+        runtimeDir: cfg.runtimeDir,
         logger: ctx.logger
       });
       service.setReranker(reranker);

--- a/dsh-mneme/lib/local-embedder.js
+++ b/dsh-mneme/lib/local-embedder.js
@@ -3,9 +3,7 @@
 // old embedding.js logic). All classes share one interface so the orchestrator
 // can pick a backend by provider name and degrade gracefully on failure.
 // Methods throw on error — the caller decides the fallback chain.
-import os from "node:os";
-import path from "node:path";
-import { defaultRuntimeDir } from "./runtime/layout.js";
+import { defaultModelCacheDir, defaultRuntimeDir } from "./runtime/layout.js";
 import { loadTransformers } from "./runtime/loader.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -70,9 +68,7 @@ export class LocalEmbedder {
     this._dimension = opts.dimension || 512;
     this.device = opts.device || "cpu";
     this.batchSize = opts.batchSize || 8;
-    this.cacheDir =
-      String(opts.cacheDir ?? "").trim() ||
-      path.join(os.homedir(), ".dsh", "mneme", "models");
+    this.cacheDir = String(opts.cacheDir ?? "").trim() || defaultModelCacheDir();
     // 自管运行时根目录（issue #131）：空表示用默认位置，具体解析交给 loader。
     this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.useDtype = opts.useDtype || "q8";

--- a/dsh-mneme/lib/local-embedder.js
+++ b/dsh-mneme/lib/local-embedder.js
@@ -5,6 +5,8 @@
 // Methods throw on error — the caller decides the fallback chain.
 import os from "node:os";
 import path from "node:path";
+import { defaultRuntimeDir } from "./runtime/layout.js";
+import { loadTransformers } from "./runtime/loader.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
 
@@ -20,16 +22,28 @@ function modelHash(model) {
   return `${model}#${hashString(model)}`;
 }
 
-/** Lazy default loader: dynamic import keeps module load cheap. */
+/**
+ * Lazy default loader: dynamic import keeps module load cheap.
+ *
+ * 经 runtime/loader.js 的三层解析取运行时（自管 payload 优先，其次宿主裸 specifier）：
+ * 这样 PR-B 把 @huggingface/transformers 从 dependencies 摘掉、pnpm 把宿主那份 prune
+ * 掉之后，本地嵌入仍然可用；而在那之前，宿主那份照样能被第 ② 层兜住。
+ * runtimeDir 从 options 里取走后再传 pipeline，免得把插件自己的配置项混进
+ * transformers 的选项里。
+ */
 async function defaultPipelineLoader(task, model, options) {
-  const { env, pipeline } = await import("@huggingface/transformers");
+  const { runtimeDir, ...pipelineOptions } = options ?? {};
+  const { module } = await loadTransformers({
+    runtimeDir: runtimeDir || defaultRuntimeDir()
+  });
+  const { env, pipeline } = module;
   // issue #13: transformers.js's get_tokenizer_files() drops the caller's
   // cache_dir when it pre-checks tokenizer_config.json metadata, so the HEAD
   // request falls back to env.cacheDir and hits the network even when the
   // model is fully cached locally. Mirroring the cache_dir onto env.cacheDir
   // makes that pre-check resolve locally too — fully offline loading.
-  if (options?.cache_dir) env.cacheDir = options.cache_dir;
-  return pipeline(task, model, options);
+  if (pipelineOptions.cache_dir) env.cacheDir = pipelineOptions.cache_dir;
+  return pipeline(task, model, pipelineOptions);
 }
 
 /** Flatten a transformers.js Tensor [batch, dim] into number[][]. */
@@ -59,6 +73,8 @@ export class LocalEmbedder {
     this.cacheDir =
       String(opts.cacheDir ?? "").trim() ||
       path.join(os.homedir(), ".dsh", "mneme", "models");
+    // 自管运行时根目录（issue #131）：空表示用默认位置，具体解析交给 loader。
+    this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.useDtype = opts.useDtype || "q8";
     this.logger = opts.logger ?? null;
     // Test hook: replace the pipeline factory without touching modules.
@@ -77,6 +93,8 @@ export class LocalEmbedder {
       device: this.device
     };
     if (this.cacheDir) options.cache_dir = this.cacheDir;
+    // 传给注入的 engineFactory，由 defaultPipelineLoader 取走后交给三层解析。
+    if (this.runtimeDir) options.runtimeDir = this.runtimeDir;
     this.extractor = await this.engineFactory("feature-extraction", this.model, options);
     this.ready = true; // service reads this to flush queued re-embeds
     this.logger?.info?.(

--- a/dsh-mneme/lib/reranker.js
+++ b/dsh-mneme/lib/reranker.js
@@ -1,6 +1,4 @@
-import os from "node:os";
-import path from "node:path";
-import { defaultRuntimeDir } from "./runtime/layout.js";
+import { defaultModelCacheDir, defaultRuntimeDir } from "./runtime/layout.js";
 import { loadTransformers } from "./runtime/loader.js";
 
 // Cross-encoder re-ranker for dsh-mneme recall candidates. Uses
@@ -79,9 +77,7 @@ export class LocalReranker {
     this.maxCandidates = opts.maxCandidates || 30;
     this.scoreThreshold = opts.scoreThreshold ?? 0.1;
     this.device = opts.device || "cpu";
-    this.cacheDir =
-      String(opts.cacheDir ?? "").trim() ||
-      path.join(os.homedir(), ".dsh", "mneme", "models");
+    this.cacheDir = String(opts.cacheDir ?? "").trim() || defaultModelCacheDir();
     // 自管运行时根目录（issue #131）：空表示用默认位置，解析交给 loader。
     this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.logger = opts.logger ?? null;

--- a/dsh-mneme/lib/reranker.js
+++ b/dsh-mneme/lib/reranker.js
@@ -1,5 +1,7 @@
 import os from "node:os";
 import path from "node:path";
+import { defaultRuntimeDir } from "./runtime/layout.js";
+import { loadTransformers } from "./runtime/loader.js";
 
 // Cross-encoder re-ranker for dsh-mneme recall candidates. Uses
 // bge-reranker-base through transformers.js: tries the native `rerank` task
@@ -19,10 +21,19 @@ function modelHash(model) {
   return `${model}#${hashString(model)}`;
 }
 
-/** Lazy default pipeline factory: dynamic import keeps module load cheap. */
+/**
+ * Lazy default pipeline factory: dynamic import keeps module load cheap.
+ *
+ * 与 local-embedder 一样经 runtime/loader.js 的三层解析取运行时（自管 payload 优先，
+ * 其次宿主裸 specifier），这样 PR-B 把依赖从 profile 摘掉后 rerank 也还能用。
+ * runtimeDir 取走后不混进 transformers 的选项。
+ */
 async function defaultPipelineLoader(task, model, options) {
-  const { pipeline } = await import("@huggingface/transformers");
-  return pipeline(task, model, options);
+  const { runtimeDir, ...pipelineOptions } = options ?? {};
+  const { module } = await loadTransformers({
+    runtimeDir: runtimeDir || defaultRuntimeDir()
+  });
+  return module.pipeline(task, model, pipelineOptions);
 }
 
 /** Flatten a transformers.js Tensor [batch, seq, dim] into number[][] rows. */
@@ -71,6 +82,8 @@ export class LocalReranker {
     this.cacheDir =
       String(opts.cacheDir ?? "").trim() ||
       path.join(os.homedir(), ".dsh", "mneme", "models");
+    // 自管运行时根目录（issue #131）：空表示用默认位置，解析交给 loader。
+    this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.logger = opts.logger ?? null;
     this.engineFactory = opts.engineFactory || defaultPipelineLoader;
     // Injectable seam: async (query, passage) => number. When set, init()
@@ -107,6 +120,7 @@ export class LocalReranker {
   _engineOptions() {
     const options = { device: this.device };
     if (this.cacheDir) options.cache_dir = this.cacheDir;
+    if (this.runtimeDir) options.runtimeDir = this.runtimeDir;
     return options;
   }
 

--- a/dsh-mneme/lib/reranker.js
+++ b/dsh-mneme/lib/reranker.js
@@ -31,7 +31,12 @@ async function defaultPipelineLoader(task, model, options) {
   const { module } = await loadTransformers({
     runtimeDir: runtimeDir || defaultRuntimeDir()
   });
-  return module.pipeline(task, model, pipelineOptions);
+  const { env, pipeline } = module;
+  // issue #13 同款处理：transformers.js 在预检 tokenizer_config.json 元数据时会丢掉调用方
+  // 的 cache_dir，回退到 env.cacheDir —— 即使模型已完全缓存在本地也会去请求网络。
+  // embedder 侧早就镜像了，reranker 侧一直漏着，于是「已缓存 + 离线」时重排初始化会失败。
+  if (pipelineOptions.cache_dir) env.cacheDir = pipelineOptions.cache_dir;
+  return pipeline(task, model, pipelineOptions);
 }
 
 /** Flatten a transformers.js Tensor [batch, seq, dim] into number[][] rows. */

--- a/dsh-mneme/lib/runtime/adopt.js
+++ b/dsh-mneme/lib/runtime/adopt.js
@@ -14,9 +14,9 @@
 //    warnings，让上层的验证去发现「收编不完整」，而不是悄悄产出一份半对的运行时。
 //
 // @module dsh-mneme/runtime/adopt
-import { copyFileSync, existsSync, linkSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, linkSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { planClosure } from "./closure.js";
+import { DEFAULT_MAX_PACKAGES, planClosure } from "./closure.js";
 import { defaultRuntimeDir, nodeModulesDir, payloadDir, payloadId, runtimeManifestPath } from "./layout.js";
 
 /** 清单版本：将来字段变化时用来判断怎么读。 */
@@ -111,6 +111,24 @@ export function adoptRuntime({
   if (existsSync(dir) && !overwrite) {
     return { ok: false, reason: `目标已存在：${dir}（需要覆盖请传 overwrite: true）`, payloadDir: dir, payloadId: id, plan };
   }
+
+  // 截断的闭包必须拒绝。maxPackages 截断会静默丢掉传递依赖，而结构检查（describePayload）
+  // 只看必需包、版本和入口文件 —— 于是一份残缺的 payload 会被判为可用、被 loader 选中，
+  // 直到 import 原生模块时才炸，且错误现场离真正的原因很远。宁可在物化前明确失败。
+  if (plan.truncated) {
+    return {
+      ok: false,
+      reason: `依赖闭包被截断（上限 ${maxPackages ?? DEFAULT_MAX_PACKAGES} 个包），拒绝收编；请提高 maxPackages 后重试`,
+      payloadDir: dir,
+      payloadId: id,
+      plan
+    };
+  }
+
+  // 覆盖前必须先清空目标目录。不清的话，linkSync 对已存在的目标路径抛 EEXIST，
+  // 于是每个文件都落到复制分支：物化方式会假报成 "copy"、警告会错说「硬链接不可用」、
+  // 整份闭包真实占盘，而且上一次闭包留下的残留文件永远不会被清掉。
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 
   const warnings = [];
   const totals = { files: 0, bytes: 0, linked: 0, copied: 0, symlinks: 0 };

--- a/dsh-mneme/lib/runtime/adopt.js
+++ b/dsh-mneme/lib/runtime/adopt.js
@@ -1,0 +1,151 @@
+// 收编宿主已有的运行时（issue #131 / PR-A）
+//
+// 场景：老用户（以及本机）profile 里已经装好了整套 transformers + onnxruntime，
+// 而且它就是能跑的。删依赖之前先把这套「收编」进插件自管的目录，老用户的本地
+// 嵌入就不会因为后续的 prune 而断掉——这是分两步发版里第一步的全部意义。
+//
+// 两条实现约束：
+//
+// 1) 同卷硬链接、跨卷回退复制。收编的源和目标通常都在用户家目录（同卷），
+//    硬链接是瞬时的、不额外占盘；一旦跨卷 linkSync 会抛 EXDEV，则逐个文件回退复制。
+//
+// 2) 不跟随符号链接。pnpm 的 isolated 布局用符号链接指向虚拟store，跟随它会把
+//    宿主 store 里的东西拖进来、还会让目录层级失真。这里选择跳过并如实记进
+//    warnings，让上层的验证去发现「收编不完整」，而不是悄悄产出一份半对的运行时。
+//
+// @module dsh-mneme/runtime/adopt
+import { copyFileSync, existsSync, linkSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { planClosure } from "./closure.js";
+import { defaultRuntimeDir, nodeModulesDir, payloadDir, payloadId, runtimeManifestPath } from "./layout.js";
+
+/** 清单版本：将来字段变化时用来判断怎么读。 */
+export const RUNTIME_MANIFEST_VERSION = 1;
+
+/**
+ * 把一个包目录物化到目标位置。跳过嵌套的 `node_modules`——那些包在闭包计划里
+ * 是独立条目，会各自落到自己的相对位置；不跳就会重复搬一遍。
+ * @param {object} opts - 选项。
+ * @param {Function} [opts.link] - 硬链接实现，默认 fs.linkSync；测试用来注入失败。
+ * @returns {{files: number, bytes: number, linked: number, copied: number, symlinks: number, linkError: string|null}}
+ */
+export function materializePackage({ srcDir, destDir, warnings = [], link = linkSync }) {
+  const stats = { files: 0, bytes: 0, linked: 0, copied: 0, symlinks: 0, linkError: null };
+
+  const walk = (src) => {
+    for (const entry of readdirSync(src, { withFileTypes: true })) {
+      // 嵌套 node_modules 由闭包计划单独负责；跳过以免重复搬运。
+      if (entry.isDirectory() && entry.name === "node_modules") continue;
+      const full = join(src, entry.name);
+      const dest = join(destDir, full.slice(srcDir.length + 1));
+      if (entry.isSymbolicLink()) {
+        stats.symlinks++;
+        warnings.push(`跳过符号链接：${full}`);
+        continue;
+      }
+      if (entry.isDirectory()) {
+        mkdirSync(dest, { recursive: true });
+        walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      mkdirSync(join(dest, ".."), { recursive: true });
+      try {
+        link(full, dest);
+        stats.linked++;
+      } catch (error) {
+        // 跨卷（EXDEV）、权限、文件系统不支持硬链接：逐个文件回退复制。
+        // 这里只记录原因（返回给调用方），不往 warnings 里塞——warnings 是「按文件」
+        // 的事件（例如跳过符号链接），而「为什么整体变成复制」是「按整次收编」的事实，
+        // 去重与呈现由 adoptRuntime 负责，否则每个包都会重复记一条。
+        if (stats.linkError === null) {
+          stats.linkError = `${error?.code ?? ""} ${error?.message ?? error}`.trim();
+        }
+        copyFileSync(full, dest);
+        stats.copied++;
+      }
+      stats.files++;
+      stats.bytes += statSync(full).size;
+    }
+  };
+
+  mkdirSync(destDir, { recursive: true });
+  walk(srcDir);
+  return stats;
+}
+
+/**
+ * 从一份现成的 `node_modules` 收编出一份自管运行时，并写下清单。
+ * @param {object} opts - 选项。
+ * @param {string} opts.fromModulesDir - 源 node_modules（通常是宿主的）。
+ * @param {string} [opts.runtimeDir] - 运行时根目录。
+ * @param {string} [opts.platform] - 目标平台。
+ * @param {string} [opts.arch] - 目标架构。
+ * @param {string} [opts.procedure] - 来源标记（adopted / downloaded / manual）。
+ * @param {boolean} [opts.overwrite] - 目标已存在时是否覆盖。
+ * @param {number} [opts.maxPackages] - 闭包条目上限。
+ * @param {Function} [opts.link] - 硬链接实现，默认 fs.linkSync；测试用来注入失败以覆盖回退分支
+ *   （与 src/local-embedder.js 的 engineFactory 同一思路：把不可复现的环境差异变成可注入的依赖）。
+ * @returns {object} 结果；失败时 ok=false 且带 reason，不抛异常。
+ */
+export function adoptRuntime({
+  fromModulesDir,
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform,
+  arch = process.arch,
+  procedure = "adopted",
+  overwrite = false,
+  maxPackages,
+  link
+}) {
+  const plan = planClosure({ rootModulesDir: fromModulesDir, platform, arch, maxPackages });
+  const entryPackage = plan.packages[0];
+  if (entryPackage === undefined) {
+    return { ok: false, reason: plan.gaps[0]?.reason ?? "入口包未解析到", plan };
+  }
+
+  const version = entryPackage.version ?? "unknown";
+  const id = payloadId({ version, platform, arch });
+  const dir = payloadDir(runtimeDir, id);
+
+  if (existsSync(dir) && !overwrite) {
+    return { ok: false, reason: `目标已存在：${dir}（需要覆盖请传 overwrite: true）`, payloadDir: dir, payloadId: id, plan };
+  }
+
+  const warnings = [];
+  const totals = { files: 0, bytes: 0, linked: 0, copied: 0, symlinks: 0 };
+  let linkError = null;
+  for (const pkg of plan.packages) {
+    const stats = materializePackage({
+      srcDir: pkg.srcDir,
+      destDir: join(nodeModulesDir(dir), pkg.rel),
+      warnings,
+      link
+    });
+    for (const key of Object.keys(totals)) totals[key] += stats[key];
+    if (linkError === null && stats.linkError !== null) linkError = stats.linkError;
+  }
+  // 物化方式如实记进清单：收编「本该不占盘却占了盘」时，用户和面板都能看到原因。
+  const mode = totals.copied === 0 ? "hardlink" : totals.linked === 0 ? "copy" : "mixed";
+  if (linkError !== null) warnings.push(`硬链接不可用，已回退为复制：${linkError}`);
+
+  const manifest = {
+    manifestVersion: RUNTIME_MANIFEST_VERSION,
+    payloadId: id,
+    entry: plan.entry,
+    version,
+    platform,
+    arch,
+    procedure,
+    createdAt: new Date().toISOString(),
+    materialize: { mode, linkError },
+    packages: plan.packages.map((p) => ({ name: p.name, version: p.version, rel: p.rel, optional: p.optional })),
+    gaps: plan.gaps,
+    skipped: plan.skipped,
+    warnings
+  };
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(runtimeManifestPath(dir), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  return { ok: true, payloadDir: dir, payloadId: id, version, plan, manifest, totals };
+}

--- a/dsh-mneme/lib/runtime/closure.js
+++ b/dsh-mneme/lib/runtime/closure.js
@@ -1,0 +1,164 @@
+// 依赖闭包遍历 + 平台过滤（issue #131 / PR-A）
+//
+// 用途：adopt（从宿主 node_modules 收编）与 export（导出给别的机器）要回答的是
+// 同一个问题——「一份能跑的运行时，到底需要哪些包，各自该落到哪个位置」。
+//
+// 两个刻意的设计：
+//
+// 1) 按源布局镜像，不压平。入口 transformers.node.mjs 内部是裸导入
+//    （`import sharp from "sharp"`、`import * as ONNX_NODE from "onnxruntime-node"`），
+//    靠 Node 逐级向上查找解析。只要目标目录的嵌套结构与源一致，解析行为就一致；
+//    压平会把「同一个包的两个版本分别落在不同层」这类情形悄悄改成另一种结果。
+//    所以 rel 保留 `a/node_modules/b` 这种层级。
+//
+// 2) 跳过 peerDependencies。peer 由宿主提供（例如 @deepseek-ai/* 那些服务），
+//    插件自管的运行时不该把宿主的实现复制进来——复制了反而会和宿主的实例分叉。
+//
+// @module dsh-mneme/runtime/closure
+import { existsSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { readJsonSafe } from "./layout.js";
+
+/** 闭包条目数上限：纯属防呆，命中即截断并如实上报，不静默丢包。 */
+export const DEFAULT_MAX_PACKAGES = 400;
+
+/**
+ * 包是否匹配当前平台。npm 用 package.json 的 os / cpu 字段声明平台，
+ * 支持 `["win32"]` 正向匹配与 `["!darwin"]` 反向排除两种写法。
+ * 字段缺省表示「不限平台」。
+ * @param {any} manifest - 包的 package.json。
+ * @param {string} platform - process.platform 取值。
+ * @param {string} arch - process.arch 取值。
+ * @returns {boolean} 是否匹配。
+ */
+export function matchesPlatform(manifest, platform, arch) {
+  const check = (values, actual) => {
+    if (!Array.isArray(values) || values.length === 0) return true;
+    const negated = values.filter((v) => typeof v === "string" && v.startsWith("!"));
+    const positive = values.filter((v) => typeof v === "string" && !v.startsWith("!"));
+    // 反向排除优先：命中任一 `!x` 即不匹配（与 npm 的语义一致）。
+    if (negated.some((v) => v.slice(1) === actual)) return false;
+    if (positive.length === 0) return true;
+    return positive.includes(actual);
+  };
+  return check(manifest?.os, platform) && check(manifest?.cpu, arch);
+}
+
+/**
+ * 按 Node 的解析规则，从 fromDir 出发找 name 的包目录，但**不越出 rootModulesDir**。
+ *
+ * Node 的规则是：从所在目录逐级向上，每级查 `<级>/node_modules/<name>`。所以对
+ * `root/@scope/pkg` 而言，候选依次是 `root/@scope/pkg/node_modules/...`、
+ * `root/@scope/node_modules/...`、`root/node_modules/...`（这一级是
+ * node_modules 套 node_modules，通常不存在），最后到 `dirname(root)/node_modules/...`
+ * ——正好就是 `root/<name>`。因此循环要允许走到 root 的上一级再停。
+ * @param {string} fromDir - 从哪个包目录出发解析。
+ * @param {string} name - 依赖名。
+ * @param {string} rootModulesDir - 允许查找的边界 node_modules 目录。
+ * @returns {string|null} 包目录绝对路径，找不到返回 null。
+ */
+export function resolvePackageDir(fromDir, name, rootModulesDir) {
+  const limit = dirname(rootModulesDir);
+  let dir = fromDir;
+  for (;;) {
+    const candidate = join(dir, "node_modules", name);
+    if (existsSync(join(candidate, "package.json"))) return candidate;
+    if (dir === limit || dir === dirname(dir)) return null;
+    dir = dirname(dir);
+  }
+}
+
+/** 转成 manifest 里使用的、与平台无关的相对路径（始终用 `/`）。 */
+function toRel(root, dir) {
+  return relative(root, dir).split(sep).join("/");
+}
+
+/**
+ * 计算一份运行时的依赖闭包。
+ *
+ * 只走 dependencies 与 optionalDependencies：
+ * - 必需依赖缺失 → 记进 gaps（让调用方能如实报「这份闭包不完整」）；
+ * - 可选依赖缺失 → 静默跳过（这正是平台分片包在别的平台上的正常形态）；
+ * - 平台不匹配的包 → 记进 skipped（导出给别的机器时，跨平台的残留不会被带走）。
+ * @param {object} opts - 选项。
+ * @param {string} opts.rootModulesDir - 源 node_modules 目录。
+ * @param {string} [opts.entry] - 入口包名。
+ * @param {string} [opts.platform] - 目标平台。
+ * @param {string} [opts.arch] - 目标架构。
+ * @param {number} [opts.maxPackages] - 条目上限。
+ * @returns {{rootModulesDir: string, entry: string, platform: string, arch: string,
+ *   packages: {name: string, version: string|null, rel: string, srcDir: string, optional: boolean}[],
+ *   gaps: {name: string, from: string, reason: string}[],
+ *   skipped: {name: string, rel: string, reason: string}[], truncated: boolean}}
+ */
+export function planClosure({
+  rootModulesDir,
+  entry = "@huggingface/transformers",
+  platform = process.platform,
+  arch = process.arch,
+  maxPackages = DEFAULT_MAX_PACKAGES
+} = {}) {
+  const packages = [];
+  const gaps = [];
+  const skipped = [];
+  const seen = new Set();
+
+  const entryDir = resolvePackageDir(rootModulesDir, entry, rootModulesDir);
+  if (entryDir === null) {
+    gaps.push({ name: entry, from: ".", reason: "入口包不存在" });
+    return { rootModulesDir, entry, platform, arch, packages, gaps, skipped, truncated: false };
+  }
+
+  // BFS：队列里放已被解析出来的包目录。用真实目录去重，避免软链接/重复边导致来回走。
+  const queue = [{ dir: entryDir, rel: toRel(rootModulesDir, entryDir), optional: false }];
+  let truncated = false;
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (seen.has(current.dir)) continue;
+    seen.add(current.dir);
+
+    const manifest = readJsonSafe(join(current.dir, "package.json"));
+    if (manifest === undefined) {
+      gaps.push({ name: current.rel, from: current.rel, reason: "package.json 读不到" });
+      continue;
+    }
+    // 入口包本身不做平台过滤：它是用户明确要的那一个。
+    if (current.rel !== toRel(rootModulesDir, entryDir) && !matchesPlatform(manifest, platform, arch)) {
+      skipped.push({ name: manifest.name ?? current.rel, rel: current.rel, reason: "平台不匹配" });
+      continue;
+    }
+    if (packages.length >= maxPackages) {
+      truncated = true;
+      break;
+    }
+    packages.push({
+      name: manifest.name ?? current.rel,
+      version: manifest.version ?? null,
+      rel: current.rel,
+      srcDir: current.dir,
+      optional: current.optional
+    });
+
+    const required = Object.keys(manifest.dependencies ?? {});
+    const optional = Object.keys(manifest.optionalDependencies ?? {});
+    for (const name of [...required, ...optional]) {
+      const isOptional = optional.includes(name);
+      const dir = resolvePackageDir(current.dir, name, rootModulesDir);
+      if (dir === null) {
+        // 可选依赖缺失是正常形态（平台分片包在别的平台就是这样），不报警。
+        if (!isOptional) gaps.push({ name, from: current.rel, reason: "必需依赖未找到" });
+        continue;
+      }
+      const rel = toRel(rootModulesDir, dir);
+      // 不允许越出源树：越出说明解析跑到了宿主其它位置，这份闭包就不是自包含的。
+      if (rel.startsWith("..")) {
+        gaps.push({ name, from: current.rel, reason: "解析结果越出源 node_modules" });
+        continue;
+      }
+      queue.push({ dir, rel, optional: isOptional });
+    }
+  }
+
+  return { rootModulesDir, entry, platform, arch, packages, gaps, skipped, truncated };
+}

--- a/dsh-mneme/lib/runtime/layout.js
+++ b/dsh-mneme/lib/runtime/layout.js
@@ -161,7 +161,7 @@ export function listPayloadDirs(runtimeDir) {
  * @param {{platform?: string, arch?: string}} [opts] - 目标平台。
  * @returns {{dir: string, ok: boolean, version: string|null, manifest: any, missing: string[], reasons: string[]}}
  */
-export function describePayload(dir, { platform = process.platform } = {}) {
+export function describePayload(dir, { platform = process.platform, arch = process.arch } = {}) {
   const report = {
     dir,
     ok: false,
@@ -194,15 +194,14 @@ export function describePayload(dir, { platform = process.platform } = {}) {
   // 3) 入口文件本身（前面只确认了包目录在）。
   if (!existsSync(join(dir, TRANSFORMERS_ENTRY))) report.missing.push(TRANSFORMERS_ENTRY);
 
-  // 4) onnxruntime-node 一个包内含三平台二进制，裁剪或跨机搬运时最容易只留下
-  //    别的平台；只检查「当前平台的子树在不在」，不检查具体架构目录，
-  //    免得绑定到包内部的路径细节。
-  if (
-    existsSync(join(nm, "onnxruntime-node")) &&
-    !existsSync(join(nm, "onnxruntime-node", "bin", "napi-v6", platform))
-  ) {
+  // 4) onnxruntime-node 一个包内含多平台 × 多架构的二进制，裁剪或跨机搬运时最容易只留下
+  //    别的平台/架构。必须点名到**平台 + 架构**：真实包结构是
+  //    bin/napi-v6/{darwin,linux,win32}/{arm64,x64}，只查平台的话 linux-arm64 的 payload
+  //    在 linux-x64 上也会通过结构检查，被 loader 选中后才在 import 原生模块时失败。
+  const nativeDir = join(nm, "onnxruntime-node", "bin", "napi-v6", platform, arch);
+  if (existsSync(join(nm, "onnxruntime-node")) && !existsSync(nativeDir)) {
     report.reasons.push(
-      `onnxruntime-node 缺少 ${platform} 平台的二进制子树（bin/napi-v6/${platform}）`
+      `onnxruntime-node 缺少 ${platform}/${arch} 的二进制子树（bin/napi-v6/${platform}/${arch}）`
     );
   }
 

--- a/dsh-mneme/lib/runtime/layout.js
+++ b/dsh-mneme/lib/runtime/layout.js
@@ -1,0 +1,199 @@
+// 运行时目录契约（issue #131 / PR-A）
+//
+// 背景：@huggingface/transformers 及其原生闭包（onnxruntime-node 解包 210 MB、
+// onnxruntime-web 128 MB、sharp 19 MB）只要留在插件的 dependencies 里，就会进
+// 宿主 profile 的安装图。profile 是所有插件共用的依赖图，于是「装任何插件都要替
+// 它重走一遍这条链」，弱网下直接把安装卡死。本模块定义插件自管运行时的落地契约，
+// 让这份运行时与宿主依赖图解耦。
+//
+// 只有三件事是稳定契约，其余实现都可以换：
+//
+//   <runtimeDir>/<payloadId>/mneme-runtime.json   来源与版本清单
+//   <runtimeDir>/<payloadId>/node_modules/        扁平依赖闭包（与 hoisted 同形）
+//   <runtimeDir>/<payloadId>/node_modules/@huggingface/transformers/dist/transformers.node.mjs
+//
+// 为什么必须是「扁平 node_modules」：transformers.node.mjs 内部全是裸导入
+// （`import sharp from "sharp"`、`import * as ONNX_NODE from "onnxruntime-node"`），
+// 它们相对该文件自身位置解析。所以只要把闭包按扁平结构放好，再用绝对 file URL
+// import 入口，整套就能跑起来——不需要动宿主的 node_modules，也不需要 overrides。
+//
+// @module dsh-mneme/runtime/layout
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** 运行时清单文件名，与 payload 目录同级。 */
+export const RUNTIME_MANIFEST = "mneme-runtime.json";
+/** 唯一会被本插件 import 的入口：transformers 的 Node 构建。 */
+export const TRANSFORMERS_ENTRY =
+  "node_modules/@huggingface/transformers/dist/transformers.node.mjs";
+/**
+ * 结构检查要求的包。三个都是硬要求：
+ * - @huggingface/transformers 是入口本身；
+ * - onnxruntime-node 被 Node 构建顶层 import；
+ * - sharp 也被 Node 构建顶层 `import sharp from "sharp"`，缺了入口 import 就抛。
+ */
+export const REQUIRED_PACKAGES = ["@huggingface/transformers", "onnxruntime-node", "sharp"];
+/** 认可的 transformers 版本区间：peer 提案的 >=4.2.0 <5（见 issue #131）。 */
+export const TRANSFORMERS_MIN = [4, 2, 0];
+export const TRANSFORMERS_MAX_MAJOR = 5;
+
+/**
+ * 解析 major.minor.patch。解析不出来返回 null —— 这里刻意不抛错，
+ * 让调用方把「版本读不懂」当成一条可报告的失败，而不是异常。
+ * @param {unknown} value - 版本字符串。
+ * @returns {number[]|null} [major, minor, patch] 或 null。
+ */
+function parseVersion(value) {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(value ?? ""));
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** 三元版本比较：a < b 返回负数。 */
+function compareVersion(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * 版本是否落在认可区间内。
+ *
+ * 刻意只实现「>=TRANSFORMERS_MIN <TRANSFORMERS_MAX_MAJOR」这一条区间，
+ * 不是通用 semver —— 运行时要认的只有 transformers 一个包，写通用实现
+ * 反而引入没被使用、也没被测试的分支。
+ * @param {unknown} version - 待检查版本。
+ * @returns {boolean} 是否认可。
+ */
+export function transformersVersionOk(version) {
+  const v = parseVersion(version);
+  if (v === null) return false;
+  if (v[0] >= TRANSFORMERS_MAX_MAJOR) return false;
+  return compareVersion(v, TRANSFORMERS_MIN) >= 0;
+}
+
+/**
+ * 运行时根目录的默认位置。与 embedModelCacheDir 的既有约定保持一致
+ * （都挂在 ~/.dsh/mneme/ 下，便于用户整个删掉重来）。
+ * @param {string} [home] - 家目录，测试时可注入。
+ * @returns {string} 运行时根目录。
+ */
+export function defaultRuntimeDir(home = homedir()) {
+  return join(home, ".dsh", "mneme", "runtime");
+}
+
+/**
+ * 一个 payload 的目录名。带平台与架构，因此多份可以共存，
+ * 加载器按平台挑一份可用的即可。
+ * @param {{version: string, platform?: string, arch?: string}} opts - 版本与平台。
+ * @returns {string} 形如 transformers-4.2.0-node-win32-x64。
+ */
+export function payloadId({ version, platform = process.platform, arch = process.arch }) {
+  return `transformers-${version}-node-${platform}-${arch}`;
+}
+
+/** payload 目录。@param {string} runtimeDir @param {string} id @returns {string} */
+export function payloadDir(runtimeDir, id) {
+  return join(runtimeDir, id);
+}
+
+/** payload 内的扁平依赖目录。@param {string} dir @returns {string} */
+export function nodeModulesDir(dir) {
+  return join(dir, "node_modules");
+}
+
+/** 清单文件路径。@param {string} dir @returns {string} */
+export function runtimeManifestPath(dir) {
+  return join(dir, RUNTIME_MANIFEST);
+}
+
+/**
+ * 读取 JSON，读不到或解析失败都返回 undefined（结构检查不应因缺文件而抛错）。
+ * @param {string} file - 文件路径。
+ * @returns {any|undefined} 解析结果。
+ */
+export function readJsonSafe(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * 列出运行时根目录下所有 payload 目录（名称排序）。目录不存在返回空数组。
+ * 加载器用它挑候选，再逐个 describePayload 判断可用性。
+ * @param {string} runtimeDir - 运行时根目录。
+ * @returns {string[]} payload 目录名。
+ */
+export function listPayloadDirs(runtimeDir) {
+  try {
+    return readdirSync(runtimeDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 结构检查：这份 payload 是否至少「该有的文件都在」。
+ *
+ * 它故意不做功能验证（真 import 并跑一次推理）——那一步要看运行环境，
+ * 由 verify 模块负责。这里只回答「解压完整没有、版本对不对、平台对不对」，
+ * 用来在下载/搬运之后立刻发现缺件。
+ * @param {string} dir - payload 目录。
+ * @param {{platform?: string, arch?: string}} [opts] - 目标平台。
+ * @returns {{dir: string, ok: boolean, version: string|null, manifest: any, missing: string[], reasons: string[]}}
+ */
+export function describePayload(dir, { platform = process.platform } = {}) {
+  const report = {
+    dir,
+    ok: false,
+    version: null,
+    manifest: readJsonSafe(runtimeManifestPath(dir)),
+    missing: [],
+    reasons: []
+  };
+
+  const nm = nodeModulesDir(dir);
+  if (!existsSync(nm)) {
+    report.reasons.push(`node_modules 不存在：${nm}`);
+    return report;
+  }
+
+  // 1) 必需包逐个点名 —— 缺哪个报哪个，用户能照着单子手工补。
+  for (const name of REQUIRED_PACKAGES) {
+    if (!existsSync(join(nm, name, "package.json"))) report.missing.push(name);
+  }
+
+  // 2) 版本必须落在认可区间（装了别的 major 的闭包，行为不可预期）。
+  const transformers = readJsonSafe(join(nm, "@huggingface/transformers", "package.json"));
+  report.version = transformers?.version ?? null;
+  if (transformers !== undefined && !transformersVersionOk(transformers.version)) {
+    report.reasons.push(
+      `@huggingface/transformers@${transformers.version} 不在认可区间（>=${TRANSFORMERS_MIN.join(".")} <${TRANSFORMERS_MAX_MAJOR}）`
+    );
+  }
+
+  // 3) 入口文件本身（前面只确认了包目录在）。
+  if (!existsSync(join(dir, TRANSFORMERS_ENTRY))) report.missing.push(TRANSFORMERS_ENTRY);
+
+  // 4) onnxruntime-node 一个包内含三平台二进制，裁剪或跨机搬运时最容易只留下
+  //    别的平台；只检查「当前平台的子树在不在」，不检查具体架构目录，
+  //    免得绑定到包内部的路径细节。
+  if (
+    existsSync(join(nm, "onnxruntime-node")) &&
+    !existsSync(join(nm, "onnxruntime-node", "bin", "napi-v6", platform))
+  ) {
+    report.reasons.push(
+      `onnxruntime-node 缺少 ${platform} 平台的二进制子树（bin/napi-v6/${platform}）`
+    );
+  }
+
+  report.ok = report.missing.length === 0 && report.reasons.length === 0;
+  return report;
+}

--- a/dsh-mneme/lib/runtime/layout.js
+++ b/dsh-mneme/lib/runtime/layout.js
@@ -85,6 +85,18 @@ export function defaultRuntimeDir(home = homedir()) {
 }
 
 /**
+ * 本地模型的默认缓存目录。
+ *
+ * 收在这里是因为它必须**唯一**：embedder、reranker、verify 三方若各写一份字面量，
+ * 一旦漂移，verify 就会拿另一份模型去验证，验证结果不再是运行时的真实证据。
+ * @param {string} [home] - 家目录，测试时可注入。
+ * @returns {string} 模型缓存目录。
+ */
+export function defaultModelCacheDir(home = homedir()) {
+  return join(home, ".dsh", "mneme", "models");
+}
+
+/**
  * 一个 payload 的目录名。带平台与架构，因此多份可以共存，
  * 加载器按平台挑一份可用的即可。
  * @param {{version: string, platform?: string, arch?: string}} opts - 版本与平台。

--- a/dsh-mneme/lib/runtime/loader.js
+++ b/dsh-mneme/lib/runtime/loader.js
@@ -17,7 +17,7 @@
 // 那条错误要带出来——它是「这份 payload 坏了」和「本机根本没有」的区别。
 //
 // @module dsh-mneme/runtime/loader
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { join } from "node:path";
 import {
   TRANSFORMERS_ENTRY,
@@ -31,6 +31,27 @@ import {
 const defaultImport = (specifier) => import(specifier);
 
 /**
+ * 给用户看的可操作提示。用插件自身的相对位置推出绝对路径 —— src/ 与 lib/ 都在
+ * 包根下一层，所以 `../../scripts` 在两处都解析到同一个文件，提示不会因为跑源码
+ * 还是跑构建产物而指错。
+ */
+const RUNTIME_HINT =
+  "本地推理运行时不可用。查看状态：" +
+  `node "${fileURLToPath(new URL("../../scripts/mneme-runtime.mjs", import.meta.url))}" status` +
+  "；宿主里已有这份依赖时可用 `adopt --from <宿主 node_modules 目录>` 收编，再用 `verify` 验证。" +
+  "检索会自动降级为关键词/BM25，不影响记忆读写。";
+
+/**
+ * 空/空白 runtimeDir 视为「用默认目录」。配置项 runtimeDir 的默认值就是空串，
+ * 原样传下去会变成相对路径（`readdirSync("")` 直接失败），把「没配」误报成「坏了」。
+ * 收在这一处，省得每个调用方各写一遍 `|| defaultRuntimeDir()`。
+ */
+function effectiveRuntimeDir(runtimeDir) {
+  const value = String(runtimeDir ?? "").trim();
+  return value === "" ? defaultRuntimeDir() : value;
+}
+
+/**
  * 在运行时根目录里挑一份可用的 payload。
  *
  * 多份并存时取目录名倒序的第一个通过结构检查的（同平台通常只会有一份；
@@ -40,19 +61,87 @@ const defaultImport = (specifier) => import(specifier);
  *   没有可用 payload 时返回 null（不是错误——第 ② 层还有机会）。
  */
 export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform = process.platform } = {}) {
-  for (const id of listPayloadDirs(runtimeDir).reverse()) {
-    const dir = payloadDir(runtimeDir, id);
-    const report = describePayload(dir, { platform });
+  const dir = effectiveRuntimeDir(runtimeDir);
+  for (const id of listPayloadDirs(dir).reverse()) {
+    const payload = payloadDir(dir, id);
+    const report = describePayload(payload, { platform });
     if (!report.ok) continue;
     return {
-      dir,
+      dir: payload,
       payloadId: id,
-      entryUrl: pathToFileURL(join(dir, TRANSFORMERS_ENTRY)).href,
+      entryUrl: pathToFileURL(join(payload, TRANSFORMERS_ENTRY)).href,
       version: report.version,
       manifest: report.manifest
     };
   }
   return null;
+}
+
+/**
+ * 只读地报告自管运行时的当前状态，供状态接口 / 面板 / CLI 展示。
+ *
+ * 刻意只做结构检查，不做功能验证：这是被 GET 端点按次调用的探针，而真跑一次
+ * 推理要加载原生模块、还会碰模型缓存。所以 `functional` 如实返回 "unknown"，
+ * 并给出去哪验证的提示 —— 宁可说「没验过」，也不假装验过。
+ *
+ * 挑选口径直接复用 resolveRuntimeEntry，避免出现「状态接口报的那份」和
+ * 「真正加载的那份」不是同一个。
+ * @param {{runtimeDir?: string, platform?: string}} [opts] - 选项。
+ * @returns {{status: string, runtimeDir: string, hint: string}} 状态；任何异常都降级成状态对象，不抛。
+ */
+export function describeLocalRuntime({
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform
+} = {}) {
+  let candidate = null;
+  const dir = effectiveRuntimeDir(runtimeDir);
+  try {
+    candidate = resolveRuntimeEntry({ runtimeDir: dir, platform });
+  } catch (error) {
+    // 配置里的 runtimeDir 是用户输入（可能是离奇的字符串让 pathToFileURL 抛错），
+    // 这里是唯一的边界，收在这里比每个调用方各包一层稳。
+    return {
+      status: "unreadable",
+      runtimeDir: dir,
+      reason: String(error?.message ?? error),
+      functional: "unknown",
+      hint: RUNTIME_HINT
+    };
+  }
+
+  if (candidate !== null) {
+    return {
+      status: "available",
+      runtimeDir: dir,
+      payloadId: candidate.payloadId,
+      version: candidate.version,
+      procedure: candidate.manifest?.procedure ?? null,
+      materialize: candidate.manifest?.materialize?.mode ?? null,
+      // 历史 payload（收编来的）清单里没有 integrity 字段，如实报 unverified；
+      // 下载通道会把校验结果写进清单，这里不改代码就能读到。
+      integrity: candidate.manifest?.integrity ?? "unverified",
+      functional: "unknown",
+      hint: RUNTIME_HINT
+    };
+  }
+
+  const ids = listPayloadDirs(dir);
+  if (ids.length === 0) {
+    return { status: "missing", runtimeDir: dir, functional: "unknown", hint: RUNTIME_HINT };
+  }
+  // 有目录但一份都没通过结构检查：把最新那份的缺件和原因带出来，别只说「坏了」。
+  const id = ids[ids.length - 1];
+  const report = describePayload(payloadDir(dir, id), { platform });
+  return {
+    status: "broken",
+    runtimeDir: dir,
+    payloadId: id,
+    version: report.version,
+    missing: report.missing,
+    reasons: report.reasons,
+    functional: "unknown",
+    hint: RUNTIME_HINT
+  };
 }
 
 /**
@@ -105,10 +194,7 @@ export async function loadTransformers({
   }
 
   // ③ 都没有：给出可操作的下一步，而不是一句 module not found
-  const hint =
-    "本地推理运行时不可用。可在设置面板「本地推理运行时」里安装，或把已有的运行时收编：" +
-    "dsh-mneme runtime adopt --from <node_modules 目录>。检索会自动降级为关键词/BM25，不影响记忆读写。";
-  const error = new Error(`${hint}\n${failures.map((f) => `  - ${f}`).join("\n")}`);
+  const error = new Error(`${RUNTIME_HINT}\n${failures.map((f) => `  - ${f}`).join("\n")}`);
   error.code = "MNEME_RUNTIME_UNAVAILABLE";
   error.failures = failures;
   throw error;

--- a/dsh-mneme/lib/runtime/loader.js
+++ b/dsh-mneme/lib/runtime/loader.js
@@ -60,11 +60,15 @@ function effectiveRuntimeDir(runtimeDir) {
  * @returns {{dir: string, payloadId: string, entryUrl: string, version: string|null, manifest: any}|null}
  *   没有可用 payload 时返回 null（不是错误——第 ② 层还有机会）。
  */
-export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform = process.platform } = {}) {
+export function resolveRuntimeEntry({
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform,
+  arch = process.arch
+} = {}) {
   const dir = effectiveRuntimeDir(runtimeDir);
   for (const id of listPayloadDirs(dir).reverse()) {
     const payload = payloadDir(dir, id);
-    const report = describePayload(payload, { platform });
+    const report = describePayload(payload, { platform, arch });
     if (!report.ok) continue;
     return {
       dir: payload,
@@ -91,12 +95,13 @@ export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform
  */
 export function describeLocalRuntime({
   runtimeDir = defaultRuntimeDir(),
-  platform = process.platform
+  platform = process.platform,
+  arch = process.arch
 } = {}) {
   let candidate = null;
   const dir = effectiveRuntimeDir(runtimeDir);
   try {
-    candidate = resolveRuntimeEntry({ runtimeDir: dir, platform });
+    candidate = resolveRuntimeEntry({ runtimeDir: dir, platform, arch });
   } catch (error) {
     // 配置里的 runtimeDir 是用户输入（可能是离奇的字符串让 pathToFileURL 抛错），
     // 这里是唯一的边界，收在这里比每个调用方各包一层稳。
@@ -131,7 +136,7 @@ export function describeLocalRuntime({
   }
   // 有目录但一份都没通过结构检查：把最新那份的缺件和原因带出来，别只说「坏了」。
   const id = ids[ids.length - 1];
-  const report = describePayload(payloadDir(dir, id), { platform });
+  const report = describePayload(payloadDir(dir, id), { platform, arch });
   return {
     status: "broken",
     runtimeDir: dir,
@@ -141,6 +146,31 @@ export function describeLocalRuntime({
     reasons: report.reasons,
     functional: "unknown",
     hint: RUNTIME_HINT
+  };
+}
+
+/**
+ * 把 describeLocalRuntime 的结果投影成「允许出现在免鉴权 HTTP 端点里」的形状。
+ *
+ * 为什么必须投影：`/api/dsh-mneme/semantic` 是刻意不鉴权的只读端点（与 list/search 同列），
+ * 而完整状态里有**绝对路径**（`runtimeDir`、`hint` 里嵌的脚本路径）和**原始错误文本**
+ * （`reason`/`reasons` 会带上完整文件路径，例如「node_modules 不存在：C:\...」）。
+ * 把它们发给任何能连上该端口的人，属于信息泄漏（CWE-200）。
+ *
+ * 完整诊断留给本机的 CLI（`status`）——那里本来就有文件系统权限，也才是真正需要这些细节的场景。
+ * 面板侧不需要这些：它只需要 status，其余文案用本地 i18n。
+ * @param {object} report - describeLocalRuntime 的返回值。
+ * @returns {{status: string, payloadId: string|null, version: string|null, procedure: string|null, materialize: string|null, integrity: string|null, functional: string|null}}
+ */
+export function publicRuntimeStatus(report) {
+  return {
+    status: report?.status ?? "unknown",
+    payloadId: report?.payloadId ?? null,
+    version: report?.version ?? null,
+    procedure: report?.procedure ?? null,
+    materialize: report?.materialize ?? null,
+    integrity: report?.integrity ?? null,
+    functional: report?.functional ?? null
   };
 }
 

--- a/dsh-mneme/lib/runtime/loader.js
+++ b/dsh-mneme/lib/runtime/loader.js
@@ -1,0 +1,115 @@
+// 运行时加载器：三层解析（issue #131 / PR-A）
+//
+//   ① 插件自管目录 ~/.dsh/mneme/runtime/<payloadId>/ —— 收编来的或下载来的
+//   ② 宿主裸 specifier —— 用户自己装的、或别的插件带进来的
+//   ③ 都没有 —— 抛出带可操作提示的错误，由调用方降级
+//
+// 为什么第 ② 层不能省：PR-A 只是「先建基础设施」，依赖声明不动，所以老用户
+// 升级后宿主那份还在。第 ② 层保证他们在收编完成前照常可用；等 PR-B 真的把依赖
+// 摘掉、pnpm 把宿主那份 prune 掉之后，第 ① 层顶上，本地嵌入不断。
+//
+// 为什么第 ① 层要 import 绝对 file URL 而不是改 node_modules：入口内部全是裸导入
+// （`import sharp from "sharp"`、`import * as ONNX_NODE from "onnxruntime-node"`），
+// 按自身位置解析。把闭包按扁平结构放在 payload 里、用绝对 URL import 入口，
+// 整套就自洽了——不需要动宿主的 node_modules，也不需要 overrides。
+//
+// 失败必须可见：第 ① 层如果「找到了但加载不起来」，不能静默滑到第 ② 层就完事，
+// 那条错误要带出来——它是「这份 payload 坏了」和「本机根本没有」的区别。
+//
+// @module dsh-mneme/runtime/loader
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
+import {
+  TRANSFORMERS_ENTRY,
+  defaultRuntimeDir,
+  describePayload,
+  listPayloadDirs,
+  payloadDir
+} from "./layout.js";
+
+/** 默认 import 实现；测试用来注入，避免真的加载原生模块。 */
+const defaultImport = (specifier) => import(specifier);
+
+/**
+ * 在运行时根目录里挑一份可用的 payload。
+ *
+ * 多份并存时取目录名倒序的第一个通过结构检查的（同平台通常只会有一份；
+ * 需要严格挑版本时由调用方先自己筛 runtimeDir）。
+ * @param {object} [opts] - 选项。
+ * @returns {{dir: string, payloadId: string, entryUrl: string, version: string|null, manifest: any}|null}
+ *   没有可用 payload 时返回 null（不是错误——第 ② 层还有机会）。
+ */
+export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform = process.platform } = {}) {
+  for (const id of listPayloadDirs(runtimeDir).reverse()) {
+    const dir = payloadDir(runtimeDir, id);
+    const report = describePayload(dir, { platform });
+    if (!report.ok) continue;
+    return {
+      dir,
+      payloadId: id,
+      entryUrl: pathToFileURL(join(dir, TRANSFORMERS_ENTRY)).href,
+      version: report.version,
+      manifest: report.manifest
+    };
+  }
+  return null;
+}
+
+/**
+ * 按三层解析加载 transformers。任何一层失败都不抛给调用方之外的语义：
+ * 全部失败时抛一个带「试过哪些、各自为什么失败」的错误，便于面板/状态接口直接展示。
+ * @param {object} [opts] - 选项。
+ * @param {string} [opts.runtimeDir] - 运行时根目录。
+ * @param {string} [opts.platform] - 平台。
+ * @param {Function} [opts.importModule] - import 实现（测试注入）。
+ * @param {(message: string) => void} [opts.onFailure] - 每次降级/失败的回调：
+ *   第 ① 层坏了却退到第 ② 层时，调用方（面板/日志）要能看见，不能静默。
+ * @returns {Promise<{module: any, source: "runtime"|"host", payloadId?: string, version?: string, entryUrl?: string}>}
+ */
+export async function loadTransformers({
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform,
+  importModule = defaultImport,
+  onFailure = null
+} = {}) {
+  const failures = [];
+  const note = (message) => {
+    failures.push(message);
+    onFailure?.(message);
+  };
+
+  // ① 自管运行时
+  const candidate = resolveRuntimeEntry({ runtimeDir, platform });
+  if (candidate !== null) {
+    try {
+      const module = await importModule(candidate.entryUrl);
+      return {
+        module,
+        source: "runtime",
+        payloadId: candidate.payloadId,
+        version: candidate.version,
+        entryUrl: candidate.entryUrl
+      };
+    } catch (error) {
+      // 找到了却加载不起来 —— 这条必须带出去，「坏了」和「没有」不是一回事。
+      note(`自管运行时 ${candidate.payloadId} 加载失败：${error?.message ?? error}`);
+    }
+  }
+
+  // ② 宿主（用户自己装的 / 别的插件带进来的）
+  try {
+    const module = await importModule("@huggingface/transformers");
+    return { module, source: "host" };
+  } catch (error) {
+    note(`宿主未提供 @huggingface/transformers：${error?.message ?? error}`);
+  }
+
+  // ③ 都没有：给出可操作的下一步，而不是一句 module not found
+  const hint =
+    "本地推理运行时不可用。可在设置面板「本地推理运行时」里安装，或把已有的运行时收编：" +
+    "dsh-mneme runtime adopt --from <node_modules 目录>。检索会自动降级为关键词/BM25，不影响记忆读写。";
+  const error = new Error(`${hint}\n${failures.map((f) => `  - ${f}`).join("\n")}`);
+  error.code = "MNEME_RUNTIME_UNAVAILABLE";
+  error.failures = failures;
+  throw error;
+}

--- a/dsh-mneme/lib/runtime/verify.js
+++ b/dsh-mneme/lib/runtime/verify.js
@@ -121,7 +121,16 @@ export async function verifyFunctional(dir, {
   if (!Array.isArray(rows) || rows.length !== probeTexts.length) {
     return fail(`返回行数不符：期望 ${probeTexts.length}，实际 ${Array.isArray(rows) ? rows.length : typeof rows}`);
   }
-  const dim = rows[0]?.length ?? 0;
+  // 先逐行确认「是数组」且「全是有限数」。这一步不能省：non-finite（NaN/Infinity）会让
+  // 下面所有比较恒为 false —— `Math.abs(NaN - 1) > tol` 是 false，`Math.abs(NaN) > 阈值`
+  // 也是 false —— 于是一份坏掉的运行时会被判成「验证通过」。这是本模块最危险的失败模式
+  // （假通过），比抛异常糟得多。行不是数组时同样要先拦住，否则 .length 直接抛，
+  // 违背「任何失败都返回结果对象，不抛异常」的契约。
+  for (let i = 0; i < rows.length; i++) {
+    if (!Array.isArray(rows[i])) return fail(`第 ${i} 行不是数组（${typeof rows[i]}）`);
+    if (rows[i].some((v) => !Number.isFinite(v))) return fail(`第 ${i} 行含有非有限数值`);
+  }
+  const dim = rows[0].length;
   if (dim === 0) return fail("返回了空向量");
   if (rows.some((row) => row.length !== dim)) return fail("各行维度不一致");
 

--- a/dsh-mneme/lib/runtime/verify.js
+++ b/dsh-mneme/lib/runtime/verify.js
@@ -1,0 +1,177 @@
+// 运行时验证三件套（issue #131 / PR-A）
+//
+// 为什么要分三层，而不是「能 import 就算通过」：
+//
+//   结构   —— 入口在不在、版本对不对、平台子树对不对、闭包有没有缺口。
+//              便宜、确定，能立刻发现「解压到一半」。
+//   功能   —— 真的 import 入口并跑一次推理。这是唯一能证明「这份运行时在这个
+//              环境里真的算得出来」的一层；结构全对但原生二进制与本机 ABI 不
+//              匹配时，只有它能发现。
+//   完整性 —— 只对「有原始产物可比对」的来源做（下载的 tarball、本地 tarball）。
+//              收编来的目录没有原始 tarball，如实标 unverified，不假装验过。
+//
+// 功能验证复用 src/local-embedder.js 的 engineFactory 思路：真正干活的是注入进来
+// 的 engine，默认实现才去 import 真实运行时。这样测试不需要网络、不需要模型，
+// 也能把「返回了非归一化向量」「只返回一行」这类问题钉住。
+//
+// 默认 engine 会强制 env.allowRemoteModels = false：验证过程绝不能偷偷下载模型，
+// 否则「验证」本身就成了一个新的网络依赖点。
+//
+// @module dsh-mneme/runtime/verify
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
+import { TRANSFORMERS_ENTRY, describePayload } from "./layout.js";
+
+/** 默认探针文本：中英各一条，避免只覆盖单字节语种。 */
+export const DEFAULT_PROBE_TEXTS = ["猫咪喜欢晒太阳", "the quick brown fox"];
+/** 默认模型，与 src/config.js 的 localEmbedModel 默认值一致。 */
+export const DEFAULT_PROBE_MODEL = "Xenova/bge-small-zh-v1.5";
+/** L2 归一化的容忍度（我们显式请求了 normalize: true）。 */
+const NORM_TOLERANCE = 0.01;
+/** 判定「退化向量」的余弦上限：两条毫不相干的文本不该几乎同向。 */
+const DEGENERATE_COS = 0.999;
+
+/**
+ * 默认 engine：真的去 import 运行时并建一个 feature-extraction 管道。
+ *
+ * 返回一个 `embed(texts) => number[][]`。之所以不返回 transformers 的 tensor，
+ * 是为了把「Tensor 形状怎么读」这种细节留在实现里，验证逻辑只看数字。
+ * @param {string} entryUrl - 入口文件的 file URL。
+ * @param {{cacheDir?: string, model?: string, dtype?: string, device?: string}} opts - 选项。
+ * @returns {Promise<(texts: string[]) => Promise<number[][]>>} 嵌入函数。
+ */
+export async function defaultEngine(entryUrl, { cacheDir, model = DEFAULT_PROBE_MODEL, dtype = "q8", device = "cpu" } = {}) {
+  const mod = await import(entryUrl);
+  const { env, pipeline } = mod;
+  if (cacheDir) {
+    try {
+      env.cacheDir = cacheDir;
+    } catch {
+      /* 老版本可能没有这个字段：忽略，交给下面 pipeline 自己找缓存 */
+    }
+  }
+  // 验证不允许触网：缓存命中就本地加载，命中不了就明确失败。
+  try {
+    env.allowRemoteModels = false;
+  } catch {
+    /* 同上 */
+  }
+  const extractor = await pipeline("feature-extraction", model, { dtype, device, cache_dir: cacheDir });
+  return async (texts) => {
+    const tensor = await extractor(texts, { pooling: "mean", normalize: true });
+    const dims = Array.from(tensor.dims ?? []);
+    const width = dims[dims.length - 1] || 0;
+    const rows = [];
+    for (let i = 0; i < tensor.data.length; i += width) {
+      rows.push(Array.from(tensor.data.subarray(i, i + width)));
+    }
+    return rows;
+  };
+}
+
+/** 向量模长。 */
+function norm(row) {
+  let sum = 0;
+  for (const value of row) sum += value * value;
+  return Math.sqrt(sum);
+}
+
+/** 两行向量的余弦。 */
+function cosine(a, b) {
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+/**
+ * 跑功能验证：真的 import 并嵌入探针文本，然后检查结果的形状与数值性质。
+ *
+ * 任何失败都返回结果对象，不抛异常——验证本身必须是 fail-safe 的，
+ * 否则一条坏运行时会把调用方（面板、状态接口）也带崩。
+ * @param {string} dir - payload 目录。
+ * @param {object} [opts] - 选项。
+ * @returns {Promise<{ok: boolean, reason: string|null, dim: number|null, rows: number, elapsedMs: number}>}
+ */
+export async function verifyFunctional(dir, {
+  engine = defaultEngine,
+  probeTexts = DEFAULT_PROBE_TEXTS,
+  cacheDir,
+  model,
+  dtype,
+  device
+} = {}) {
+  const startedAt = Date.now();
+  const fail = (reason) => ({ ok: false, reason, dim: null, rows: 0, elapsedMs: Date.now() - startedAt });
+
+  const entry = join(dir, TRANSFORMERS_ENTRY);
+  let embed;
+  try {
+    embed = await engine(pathToFileURL(entry).href, { cacheDir, model, dtype, device });
+  } catch (error) {
+    return fail(`加载运行时失败：${error?.message ?? error}`);
+  }
+
+  let rows;
+  try {
+    rows = await embed(probeTexts);
+  } catch (error) {
+    return fail(`推理失败：${error?.message ?? error}`);
+  }
+
+  if (!Array.isArray(rows) || rows.length !== probeTexts.length) {
+    return fail(`返回行数不符：期望 ${probeTexts.length}，实际 ${Array.isArray(rows) ? rows.length : typeof rows}`);
+  }
+  const dim = rows[0]?.length ?? 0;
+  if (dim === 0) return fail("返回了空向量");
+  if (rows.some((row) => row.length !== dim)) return fail("各行维度不一致");
+
+  for (let i = 0; i < rows.length; i++) {
+    const length = norm(rows[i]);
+    if (Math.abs(length - 1) > NORM_TOLERANCE) {
+      return fail(`第 ${i} 行不是 L2 归一化向量（模长 ${length.toFixed(4)}）`);
+    }
+  }
+  if (rows.length >= 2 && Math.abs(cosine(rows[0], rows[1])) > DEGENERATE_COS) {
+    return fail(`嵌入退化：两条不相干文本的余弦为 ${cosine(rows[0], rows[1]).toFixed(4)}`);
+  }
+
+  return { ok: true, reason: null, dim, rows: rows.length, elapsedMs: Date.now() - startedAt };
+}
+
+/**
+ * 三层验证，任何一层失败都如实记录；结构不过就不再做功能验证（省掉一次无谓的加载）。
+ * @param {string} dir - payload 目录。
+ * @param {object} [opts] - 选项。
+ * @param {{status: string, detail?: string}} [opts.integrity] - 调用方算好的完整性结论
+ *   （下载/本地 tarball 路径在解包前比对过 sha512，把结果传进来；收编路径没有可比对
+ *   的原始产物，默认 unverified）。
+ * @returns {Promise<object>} 三件套结果 + 总判定。
+ */
+export async function verifyPayload(dir, {
+  platform = process.platform,
+  engine,
+  probeTexts,
+  cacheDir,
+  model,
+  dtype,
+  device,
+  integrity
+} = {}) {
+  const structural = describePayload(dir, { platform });
+  const integrityResult = integrity
+    ? { ok: integrity.status === "sha512-matched", status: integrity.status, detail: integrity.detail ?? null }
+    : { ok: true, status: "unverified", detail: "该来源没有可比对的原始产物（收编）；如需强校验请用 --strict 走 tarball 通道" };
+
+  const functional = structural.ok
+    ? await verifyFunctional(dir, { engine, probeTexts, cacheDir, model, dtype, device })
+    : { ok: false, reason: "结构检查未通过，跳过功能验证", dim: null, rows: 0, elapsedMs: 0 };
+
+  return {
+    dir,
+    version: structural.version,
+    ok: structural.ok && functional.ok && integrityResult.ok,
+    structural,
+    functional,
+    integrity: integrityResult
+  };
+}

--- a/dsh-mneme/scripts/mneme-runtime.mjs
+++ b/dsh-mneme/scripts/mneme-runtime.mjs
@@ -22,6 +22,9 @@ import { describeLocalRuntime, resolveRuntimeEntry } from "../lib/runtime/loader
 import { defaultModelCacheDir, defaultRuntimeDir, describePayload } from "../lib/runtime/layout.js";
 import { verifyPayload } from "../lib/runtime/verify.js";
 
+// 注意：下面是模板字面量，帮助正文里**不能出现反引号** —— 会把字面量提前截断。
+// 这个坑踩过一次，而且因为本文件原本不在任何测试覆盖里，CI 完全没抓到；
+// 现在由 test/runtime-cli.test.js 动态 import 本文件来兜底（语法错会在测试里直接炸）。
 const USAGE = `本地推理运行时管理（dsh-mneme / issue #131）
 
 用法：
@@ -44,23 +47,43 @@ const USAGE = `本地推理运行时管理（dsh-mneme / issue #131）
 
 class UsageError extends Error {}
 
+/** 必须带值的选项；缺值时是用法错误，不能把 "true" 当成路径用下去。 */
+const VALUE_OPTIONS = new Set(["runtime", "from", "cache-dir"]);
+/** 纯开关。 */
+const FLAG_OPTIONS = new Set(["json", "overwrite"]);
+
 /**
  * 参数解析：只支持 `--key value` 与 `--flag`。
  * 够用就不引库 —— 这个脚本要在「插件装不上」的场景下还能跑，依赖越少越好。
+ *
+ * 两个刻意的严格行为：
+ * - 缺值的 `--runtime` / `--from` / `--cache-dir` 直接报用法错误（exit 2）。宽松处理会让
+ *   它们变成 `true`，再被当作一个叫 "true" 的路径用下去，最后以 exit 1 收场 ——
+ *   真正的「你少打了一个值」被伪装成「运行时坏了」。
+ * - 未知选项也报用法错误，而不是静默忽略：打错字应当立刻可见。
  */
 function parseArgs(argv) {
   const options = {};
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i];
-    if (!token.startsWith("--")) throw new UsageError(`无法识别的参数：${token}`);
-    const key = token.slice(2);
-    const next = argv[i + 1];
-    if (next !== undefined && !next.startsWith("--")) {
-      options[key] = next;
-      i++;
-    } else {
-      options[key] = true;
+    const key = token.startsWith("--") ? token.slice(2) : null;
+    if (key === null || (!VALUE_OPTIONS.has(key) && !FLAG_OPTIONS.has(key))) {
+      const accepted = [
+        ...[...VALUE_OPTIONS].map((k) => `--${k} <值>`),
+        ...[...FLAG_OPTIONS].map((k) => `--${k}`)
+      ].join("、");
+      throw new UsageError(`无法识别的参数：${token}（可用：${accepted}）`);
     }
+    if (FLAG_OPTIONS.has(key)) {
+      options[key] = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new UsageError(`--${key} 需要带一个值`);
+    }
+    options[key] = value;
+    i++;
   }
   return options;
 }
@@ -205,16 +228,28 @@ async function main() {
   throw new UsageError(`未知命令：${command}\n\n${USAGE}`);
 }
 
-try {
-  process.exitCode = await main();
-} catch (error) {
-  if (error instanceof UsageError) {
-    process.stderr.write(`${error.message}\n`);
-    process.exitCode = 2;
-  } else {
-    // 验证/收编本身是 fail-safe 的；能走到这里的多半是环境问题（磁盘、权限），
-    // 如实打出来，别吞。
-    process.stderr.write(`失败：${error?.stack ?? error}\n`);
-    process.exitCode = 1;
+/**
+ * 只有被直接执行时才跑 CLI。这样测试可以安全地 `import` 本文件来验证它能被解析并求值
+ * —— 脚本不在任何其它测试覆盖里，一个模板字面量里的反引号就足以让它整体坏掉而 CI 全绿。
+ * 与 scripts/benchmark-recall.js 的 invokedDirectly 同一套写法。
+ */
+const invokedDirectly =
+  process.argv[1] != null && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/").split("/").pop() ?? "");
+
+if (invokedDirectly) {
+  try {
+    process.exitCode = await main();
+  } catch (error) {
+    if (error instanceof UsageError) {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 2;
+    } else {
+      // 验证/收编本身是 fail-safe 的；能走到这里的多半是环境问题（磁盘、权限），
+      // 如实打出来，别吞。
+      process.stderr.write(`失败：${error?.stack ?? error}\n`);
+      process.exitCode = 1;
+    }
   }
 }
+
+export { main, parseArgs, UsageError };

--- a/dsh-mneme/scripts/mneme-runtime.mjs
+++ b/dsh-mneme/scripts/mneme-runtime.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * 本地推理运行时管理入口（issue #131 / PR-A）
+ *
+ * 为什么不在 bin/cli.mjs 里加子命令：那个 CLI 的契约是「外部 HTTP API 客户端」，
+ * 要求 dsh-mneme 服务正在运行。而收编/验证运行时恰恰发生在服务没起来、插件甚至
+ * 装不上的时候 —— 两者是相反的使用场景。scripts/ 是与 benchmark-embed.js 同类的
+ * 本地工具目录，放这里符合既有约定，也不用动物那个零依赖 CLI 的契约。
+ *
+ * 用法（在插件目录下运行）：
+ *   node scripts/mneme-runtime.mjs status  [--runtime <dir>] [--json]
+ *   node scripts/mneme-runtime.mjs adopt   --from <宿主 node_modules 目录> [--runtime <dir>] [--overwrite] [--json]
+ *   node scripts/mneme-runtime.mjs verify  [--runtime <dir>] [--cache-dir <dir>] [--json]
+ *
+ * 退出码：0 = 健康 / 1 = 不健康或失败 / 2 = 用法错误。
+ * 每一档都要能被脚本直接拿去 gate，所以「没装」和「装坏了」返回的都是 1，
+ * 具体区别看输出里的 status。
+ */
+import process from "node:process";
+import { adoptRuntime } from "../lib/runtime/adopt.js";
+import { describeLocalRuntime, resolveRuntimeEntry } from "../lib/runtime/loader.js";
+import { defaultModelCacheDir, defaultRuntimeDir, describePayload } from "../lib/runtime/layout.js";
+import { verifyPayload } from "../lib/runtime/verify.js";
+
+const USAGE = `本地推理运行时管理（dsh-mneme / issue #131）
+
+用法：
+  node scripts/mneme-runtime.mjs status  [--runtime <dir>] [--json]
+  node scripts/mneme-runtime.mjs adopt   --from <宿主 node_modules 目录> [--runtime <dir>] [--overwrite] [--json]
+  node scripts/mneme-runtime.mjs verify  [--runtime <dir>] [--cache-dir <dir>] [--json]
+
+说明：
+  status  只读探查：这份运行时在哪、来源是什么、结构完不完整。不加载模型。
+  adopt   把宿主 node_modules 里已有的那份依赖闭包收编进插件自管目录，
+          优先用硬链接（同盘时几乎不额外占盘）。收编后宿主那份可以随时被 pnpm 删掉。
+  verify  真加载运行时并跑一次推理，外加结构与完整性检查。
+          ⚠ 功能验证是离线的（allowRemoteModels=false）：模型必须已在缓存目录里，
+          否则会明确失败 —— 这是有意的，验证不该偷偷触网。
+          默认缓存目录若与你的 embedModelCacheDir 不一致，用 --cache-dir 指过去。
+
+默认运行时目录：${defaultRuntimeDir()}
+默认模型缓存目录：${defaultModelCacheDir()}
+`;
+
+class UsageError extends Error {}
+
+/**
+ * 参数解析：只支持 `--key value` 与 `--flag`。
+ * 够用就不引库 —— 这个脚本要在「插件装不上」的场景下还能跑，依赖越少越好。
+ */
+function parseArgs(argv) {
+  const options = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (!token.startsWith("--")) throw new UsageError(`无法识别的参数：${token}`);
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      options[key] = next;
+      i++;
+    } else {
+      options[key] = true;
+    }
+  }
+  return options;
+}
+
+const printJson = (value) => process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+
+/** payloadId → 人类可读的标签，纯展示。 */
+function describePayloadLabel(report) {
+  const parts = [];
+  if (report.version) parts.push(`transformers ${report.version}`);
+  if (report.procedure) parts.push(`来源 ${report.procedure}`);
+  if (report.materialize) parts.push(`物化 ${report.materialize}`);
+  return parts.join("，");
+}
+
+function runStatus({ runtimeDir, asJson }) {
+  const report = describeLocalRuntime({ runtimeDir });
+  const healthy = report.status === "available";
+  if (asJson) {
+    printJson(report);
+    return healthy ? 0 : 1;
+  }
+
+  const label = { available: "可用", missing: "未安装", broken: "损坏", unreadable: "读不到" }[report.status] ?? report.status;
+  console.log(`运行时目录：${report.runtimeDir}`);
+  console.log(`状态：${label}`);
+  if (report.payloadId) console.log(`payload：${report.payloadId}`);
+  const extra = describePayloadLabel(report);
+  if (extra) console.log(`       ${extra}`);
+  if (healthy) {
+    console.log(`完整性：${report.integrity}`);
+    // 明说「结构通过 ≠ 验过」，否则这个面板会给出虚假的安心感。
+    console.log(`功能：${report.functional}（状态探查不加载模型，跑 verify 才能确认真的能推理）`);
+  }
+  for (const item of report.missing ?? []) console.log(`缺失：${item}`);
+  for (const reason of report.reasons ?? []) console.log(`原因：${reason}`);
+  if (report.reason) console.log(`原因：${report.reason}`);
+  if (!healthy) console.log(`\n${report.hint}`);
+  return healthy ? 0 : 1;
+}
+
+async function runAdopt({ runtimeDir, asJson, options }) {
+  const from = String(options.from ?? "").trim();
+  if (!from) {
+    throw new UsageError(
+      "adopt 需要 --from <宿主 node_modules 目录>，例如：\n" +
+        "  .../profiles/<profile>/node_modules\n" +
+        "（就是当前装着 @huggingface/transformers 的那个 node_modules）"
+    );
+  }
+
+  const result = await adoptRuntime({
+    fromModulesDir: from,
+    runtimeDir,
+    overwrite: options.overwrite === true
+  });
+
+  // 搬运完立刻做结构检查：缺件现在就能发现，不必等到第一次推理才炸。
+  const structural = describePayload(result.payloadDir);
+
+  if (asJson) {
+    printJson({ ...result, structural });
+    return structural.ok ? 0 : 1;
+  }
+
+  console.log(`已收编到：${result.payloadDir}`);
+  console.log(`payload：${result.payloadId}`);
+  console.log(`包数：${result.plan.packages.length}    文件：${result.totals.files}    字节：${result.totals.bytes}`);
+  console.log(`物化方式：${result.manifest.materialize.mode}` + (result.manifest.materialize.linkError ? `（硬链接失败原因：${result.manifest.materialize.linkError}）` : ""));
+  if (result.plan.skipped.length) {
+    console.log(`跳过（平台不适用）：${result.plan.skipped.map((s) => s.name).join("、")}`);
+  }
+  for (const warning of result.manifest.warnings) console.log(`警告：${warning}`);
+  // 缺件是硬失败：闭包不完整的运行时，功能验证必然也过不了，不该报成功。
+  for (const gap of result.plan.gaps) {
+    console.log(`缺失依赖：${gap.name}（被 ${gap.from} 需要：${gap.reason}）`);
+  }
+  for (const item of structural.missing) console.log(`缺失文件：${item}`);
+  for (const reason of structural.reasons) console.log(`结构问题：${reason}`);
+  console.log(`结构检查：${structural.ok ? "通过" : "未通过"}`);
+  if (structural.ok) {
+    console.log(`\n下一步：node scripts/mneme-runtime.mjs verify   # 真跑一次推理确认可用`);
+  }
+  return structural.ok ? 0 : 1;
+}
+
+async function runVerify({ runtimeDir, asJson, options }) {
+  const candidate = resolveRuntimeEntry({ runtimeDir });
+  if (candidate === null) {
+    // 「没得验」不是用法错误，是不健康 —— 复用 status 的提示，别自己编一套说法。
+    const report = describeLocalRuntime({ runtimeDir });
+    if (asJson) printJson(report);
+    else console.log(`没有可用的运行时 payload。\n\n${report.hint}`);
+    return 1;
+  }
+
+  const cacheDir = String(options["cache-dir"] ?? "").trim() || defaultModelCacheDir();
+  if (!asJson) {
+    console.log(`验证 payload：${candidate.payloadId}`);
+    console.log(`模型缓存目录：${cacheDir}`);
+    console.log("正在加载运行时并推理（首次可能要几十秒）...");
+  }
+
+  const result = await verifyPayload(candidate.dir, { cacheDir });
+
+  if (asJson) {
+    printJson(result);
+    return result.ok ? 0 : 1;
+  }
+
+  console.log(`结构检查：${result.structural.ok ? "通过" : "未通过"}`);
+  for (const item of result.structural.missing) console.log(`  缺失：${item}`);
+  for (const reason of result.structural.reasons) console.log(`  原因：${reason}`);
+  const fn = result.functional;
+  console.log(`功能验证：${fn.ok ? `通过（维度 ${fn.dim}，${fn.rows} 行，${fn.elapsedMs}ms）` : "未通过"}`);
+  if (!fn.ok) {
+    console.log(`  原因：${fn.reason}`);
+    // 最常见的失败是模型不在这个目录 —— 注意这里的默认值不一定等于用户配置的
+    // embedModelCacheDir，所以要明确告诉他能改。
+    console.log(`  提示：功能验证不触网（allowRemoteModels=false），模型必须已在缓存目录里。`);
+    console.log(`        若模型在别处，用 --cache-dir <目录> 指过去（应与配置项 embedModelCacheDir 一致）；`);
+    console.log(`        或先用 embedProvider="local" 触发一次下载（走 embedModelMirror 镜像）。`);
+  }
+  console.log(`完整性：${result.integrity.status}${result.integrity.detail ? `（${result.integrity.detail}）` : ""}`);
+  console.log(`\n总判定：${result.ok ? "通过" : "未通过"}`);
+  return result.ok ? 0 : 1;
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    process.stdout.write(USAGE);
+    return command ? 0 : 2;
+  }
+  const options = parseArgs(rest);
+  const runtimeDir = String(options.runtime ?? "").trim() || defaultRuntimeDir();
+  const asJson = options.json === true;
+
+  if (command === "status") return runStatus({ runtimeDir, asJson });
+  if (command === "adopt") return runAdopt({ runtimeDir, asJson, options });
+  if (command === "verify") return runVerify({ runtimeDir, asJson, options });
+  throw new UsageError(`未知命令：${command}\n\n${USAGE}`);
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  if (error instanceof UsageError) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  } else {
+    // 验证/收编本身是 fail-safe 的；能走到这里的多半是环境问题（磁盘、权限），
+    // 如实打出来，别吞。
+    process.stderr.write(`失败：${error?.stack ?? error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/dsh-mneme/scripts/mneme-runtime.mjs
+++ b/dsh-mneme/scripts/mneme-runtime.mjs
@@ -141,12 +141,28 @@ async function runAdopt({ runtimeDir, asJson, options }) {
     overwrite: options.overwrite === true
   });
 
+  // 收编失败时 adoptRuntime **不带 payloadDir**（入口包解析不到就是这条路径）。
+  // 必须先处理，否则下面拿 undefined 当路径喂给 describePayload，用户看到的是
+  // `TypeError: The "path" argument must be of type string` 的堆栈，
+  // 而不是「入口包不存在 + 下一步该做什么」——而这是文档里给用户的第一条命令。
+  if (result.ok === false) {
+    if (asJson) printJson(result);
+    else console.log(`收编失败：${result.reason}`);
+    return 1;
+  }
+
   // 搬运完立刻做结构检查：缺件现在就能发现，不必等到第一次推理才炸。
   const structural = describePayload(result.payloadDir);
 
+  // 两条判据都要过：describePayload 只点三个必需包，**不看闭包计划里的必需依赖缺口**。
+  // 只认 structural.ok 的话，「缺传递依赖、入口一 import 就炸」的收编会报 exit 0，
+  // 脚本化的 gate 就在最需要它的时候误报健康。
+  const gaps = result.plan.gaps;
+  const healthy = structural.ok && gaps.length === 0;
+
   if (asJson) {
-    printJson({ ...result, structural });
-    return structural.ok ? 0 : 1;
+    printJson({ ...result, structural, healthy });
+    return healthy ? 0 : 1;
   }
 
   console.log(`已收编到：${result.payloadDir}`);
@@ -157,17 +173,19 @@ async function runAdopt({ runtimeDir, asJson, options }) {
     console.log(`跳过（平台不适用）：${result.plan.skipped.map((s) => s.name).join("、")}`);
   }
   for (const warning of result.manifest.warnings) console.log(`警告：${warning}`);
-  // 缺件是硬失败：闭包不完整的运行时，功能验证必然也过不了，不该报成功。
-  for (const gap of result.plan.gaps) {
+  for (const gap of gaps) {
     console.log(`缺失依赖：${gap.name}（被 ${gap.from} 需要：${gap.reason}）`);
   }
   for (const item of structural.missing) console.log(`缺失文件：${item}`);
   for (const reason of structural.reasons) console.log(`结构问题：${reason}`);
   console.log(`结构检查：${structural.ok ? "通过" : "未通过"}`);
-  if (structural.ok) {
+  if (gaps.length > 0) {
+    console.log(`闭包完整性：未通过（${gaps.length} 个必需依赖缺失，入口加载时会失败）`);
+  }
+  if (healthy) {
     console.log(`\n下一步：node scripts/mneme-runtime.mjs verify   # 真跑一次推理确认可用`);
   }
-  return structural.ok ? 0 : 1;
+  return healthy ? 0 : 1;
 }
 
 async function runVerify({ runtimeDir, asJson, options }) {
@@ -252,4 +270,4 @@ if (invokedDirectly) {
   }
 }
 
-export { main, parseArgs, UsageError };
+export { main, parseArgs, runAdopt, UsageError };

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -5,6 +5,7 @@ import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
 import { describeStreamFailure, resolveRoute } from "./dream.js";
+import { describeLocalRuntime } from "./runtime/loader.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -615,7 +616,11 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           modelHash: embedder?.modelHash ?? null,
           dimension: embedder?.dimension ?? null,
           reranker: semantic?.reranker ? "ready" : null,
-          index: stats
+          index: stats,
+          // issue #131 / PR-A：自管运行时的状态。无论当前 provider 是不是 local
+          // 都报 —— 面板需要区分「已收编但没启用」和「要用本地却没收编」。
+          // 这里只做结构检查（不跑推理），失败降级成状态对象，不会让本端点 500。
+          localRuntime: describeLocalRuntime({ runtimeDir: config?.runtimeDir ?? "" })
         });
       } catch {
         sendJson(res, 500, { error: "internal" });

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -5,7 +5,7 @@ import { FEATURE_FLAG_SPEC } from "./settings.js";
 import { TYPE_FILE, renderMirrorText, parseHumanEdits } from "./mirror.js";
 import { computeHeat } from "./heat.js";
 import { describeStreamFailure, resolveRoute } from "./dream.js";
-import { describeLocalRuntime } from "./runtime/loader.js";
+import { describeLocalRuntime, publicRuntimeStatus } from "./runtime/loader.js";
 
 // headers：少数端点（/export 附件下载）需要追加 Content-Disposition 等响应头。
 function sendJson(res, status, payload, headers = {}) {
@@ -620,7 +620,9 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
           // issue #131 / PR-A：自管运行时的状态。无论当前 provider 是不是 local
           // 都报 —— 面板需要区分「已收编但没启用」和「要用本地却没收编」。
           // 这里只做结构检查（不跑推理），失败降级成状态对象，不会让本端点 500。
-          localRuntime: describeLocalRuntime({ runtimeDir: config?.runtimeDir ?? "" })
+          // 必须经 publicRuntimeStatus 投影：本端点是免鉴权的，绝对路径与原始错误
+          // 文本不能出去（CWE-200）。完整诊断走本机 CLI 的 status。
+          localRuntime: publicRuntimeStatus(describeLocalRuntime({ runtimeDir: config?.runtimeDir ?? "" }))
         });
       } catch {
         sendJson(res, 500, { error: "internal" });

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -134,6 +134,12 @@ export const Config = z.object({
   embedModelCacheDir: z.string().default(""),
   embedModelMirror: z.string().default("https://hf-mirror.com"),
 
+  // 自管运行时目录（issue #131）。空 = ~/.dsh/mneme/runtime：里面放收编或下载来的
+  // transformers + onnxruntime 闭包，插件经 src/runtime/loader.js 的三层解析加载它。
+  // 目的就是让这条重依赖不必留在宿主 profile 的依赖图里——profile 是所有插件共用的
+  // 依赖图，留在里面会让「装任何插件都要替它重走一遍这条链」。
+  runtimeDir: z.string().default(""),
+
   // Vector search tuning.
   vectorSearchTopK: z.natural().min(1).max(100).default(20),
   vectorSearchThreshold: z.number().min(0).max(1).default(0.65),

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -222,6 +222,7 @@ export const apply = (ctx, config) => {
         device: cfg.localEmbedDevice,
         batchSize: cfg.localEmbedBatchSize,
         cacheDir: cfg.embedModelCacheDir,
+        runtimeDir: cfg.runtimeDir,
         baseUrl: cfg.ollamaBaseUrl,
         logger: ctx.logger
       });
@@ -273,6 +274,7 @@ export const apply = (ctx, config) => {
         scoreThreshold: cfg.rerankScoreThreshold,
         device: cfg.localEmbedDevice,
         cacheDir: cfg.embedModelCacheDir,
+        runtimeDir: cfg.runtimeDir,
         logger: ctx.logger
       });
       service.setReranker(reranker);

--- a/dsh-mneme/src/local-embedder.js
+++ b/dsh-mneme/src/local-embedder.js
@@ -3,9 +3,7 @@
 // old embedding.js logic). All classes share one interface so the orchestrator
 // can pick a backend by provider name and degrade gracefully on failure.
 // Methods throw on error — the caller decides the fallback chain.
-import os from "node:os";
-import path from "node:path";
-import { defaultRuntimeDir } from "./runtime/layout.js";
+import { defaultModelCacheDir, defaultRuntimeDir } from "./runtime/layout.js";
 import { loadTransformers } from "./runtime/loader.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -70,9 +68,7 @@ export class LocalEmbedder {
     this._dimension = opts.dimension || 512;
     this.device = opts.device || "cpu";
     this.batchSize = opts.batchSize || 8;
-    this.cacheDir =
-      String(opts.cacheDir ?? "").trim() ||
-      path.join(os.homedir(), ".dsh", "mneme", "models");
+    this.cacheDir = String(opts.cacheDir ?? "").trim() || defaultModelCacheDir();
     // 自管运行时根目录（issue #131）：空表示用默认位置，具体解析交给 loader。
     this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.useDtype = opts.useDtype || "q8";

--- a/dsh-mneme/src/local-embedder.js
+++ b/dsh-mneme/src/local-embedder.js
@@ -5,6 +5,8 @@
 // Methods throw on error — the caller decides the fallback chain.
 import os from "node:os";
 import path from "node:path";
+import { defaultRuntimeDir } from "./runtime/layout.js";
+import { loadTransformers } from "./runtime/loader.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
 
@@ -20,16 +22,28 @@ function modelHash(model) {
   return `${model}#${hashString(model)}`;
 }
 
-/** Lazy default loader: dynamic import keeps module load cheap. */
+/**
+ * Lazy default loader: dynamic import keeps module load cheap.
+ *
+ * 经 runtime/loader.js 的三层解析取运行时（自管 payload 优先，其次宿主裸 specifier）：
+ * 这样 PR-B 把 @huggingface/transformers 从 dependencies 摘掉、pnpm 把宿主那份 prune
+ * 掉之后，本地嵌入仍然可用；而在那之前，宿主那份照样能被第 ② 层兜住。
+ * runtimeDir 从 options 里取走后再传 pipeline，免得把插件自己的配置项混进
+ * transformers 的选项里。
+ */
 async function defaultPipelineLoader(task, model, options) {
-  const { env, pipeline } = await import("@huggingface/transformers");
+  const { runtimeDir, ...pipelineOptions } = options ?? {};
+  const { module } = await loadTransformers({
+    runtimeDir: runtimeDir || defaultRuntimeDir()
+  });
+  const { env, pipeline } = module;
   // issue #13: transformers.js's get_tokenizer_files() drops the caller's
   // cache_dir when it pre-checks tokenizer_config.json metadata, so the HEAD
   // request falls back to env.cacheDir and hits the network even when the
   // model is fully cached locally. Mirroring the cache_dir onto env.cacheDir
   // makes that pre-check resolve locally too — fully offline loading.
-  if (options?.cache_dir) env.cacheDir = options.cache_dir;
-  return pipeline(task, model, options);
+  if (pipelineOptions.cache_dir) env.cacheDir = pipelineOptions.cache_dir;
+  return pipeline(task, model, pipelineOptions);
 }
 
 /** Flatten a transformers.js Tensor [batch, dim] into number[][]. */
@@ -59,6 +73,8 @@ export class LocalEmbedder {
     this.cacheDir =
       String(opts.cacheDir ?? "").trim() ||
       path.join(os.homedir(), ".dsh", "mneme", "models");
+    // 自管运行时根目录（issue #131）：空表示用默认位置，具体解析交给 loader。
+    this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.useDtype = opts.useDtype || "q8";
     this.logger = opts.logger ?? null;
     // Test hook: replace the pipeline factory without touching modules.
@@ -77,6 +93,8 @@ export class LocalEmbedder {
       device: this.device
     };
     if (this.cacheDir) options.cache_dir = this.cacheDir;
+    // 传给注入的 engineFactory，由 defaultPipelineLoader 取走后交给三层解析。
+    if (this.runtimeDir) options.runtimeDir = this.runtimeDir;
     this.extractor = await this.engineFactory("feature-extraction", this.model, options);
     this.ready = true; // service reads this to flush queued re-embeds
     this.logger?.info?.(

--- a/dsh-mneme/src/reranker.js
+++ b/dsh-mneme/src/reranker.js
@@ -1,6 +1,4 @@
-import os from "node:os";
-import path from "node:path";
-import { defaultRuntimeDir } from "./runtime/layout.js";
+import { defaultModelCacheDir, defaultRuntimeDir } from "./runtime/layout.js";
 import { loadTransformers } from "./runtime/loader.js";
 
 // Cross-encoder re-ranker for dsh-mneme recall candidates. Uses
@@ -79,9 +77,7 @@ export class LocalReranker {
     this.maxCandidates = opts.maxCandidates || 30;
     this.scoreThreshold = opts.scoreThreshold ?? 0.1;
     this.device = opts.device || "cpu";
-    this.cacheDir =
-      String(opts.cacheDir ?? "").trim() ||
-      path.join(os.homedir(), ".dsh", "mneme", "models");
+    this.cacheDir = String(opts.cacheDir ?? "").trim() || defaultModelCacheDir();
     // 自管运行时根目录（issue #131）：空表示用默认位置，解析交给 loader。
     this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.logger = opts.logger ?? null;

--- a/dsh-mneme/src/reranker.js
+++ b/dsh-mneme/src/reranker.js
@@ -1,5 +1,7 @@
 import os from "node:os";
 import path from "node:path";
+import { defaultRuntimeDir } from "./runtime/layout.js";
+import { loadTransformers } from "./runtime/loader.js";
 
 // Cross-encoder re-ranker for dsh-mneme recall candidates. Uses
 // bge-reranker-base through transformers.js: tries the native `rerank` task
@@ -19,10 +21,19 @@ function modelHash(model) {
   return `${model}#${hashString(model)}`;
 }
 
-/** Lazy default pipeline factory: dynamic import keeps module load cheap. */
+/**
+ * Lazy default pipeline factory: dynamic import keeps module load cheap.
+ *
+ * 与 local-embedder 一样经 runtime/loader.js 的三层解析取运行时（自管 payload 优先，
+ * 其次宿主裸 specifier），这样 PR-B 把依赖从 profile 摘掉后 rerank 也还能用。
+ * runtimeDir 取走后不混进 transformers 的选项。
+ */
 async function defaultPipelineLoader(task, model, options) {
-  const { pipeline } = await import("@huggingface/transformers");
-  return pipeline(task, model, options);
+  const { runtimeDir, ...pipelineOptions } = options ?? {};
+  const { module } = await loadTransformers({
+    runtimeDir: runtimeDir || defaultRuntimeDir()
+  });
+  return module.pipeline(task, model, pipelineOptions);
 }
 
 /** Flatten a transformers.js Tensor [batch, seq, dim] into number[][] rows. */
@@ -71,6 +82,8 @@ export class LocalReranker {
     this.cacheDir =
       String(opts.cacheDir ?? "").trim() ||
       path.join(os.homedir(), ".dsh", "mneme", "models");
+    // 自管运行时根目录（issue #131）：空表示用默认位置，解析交给 loader。
+    this.runtimeDir = String(opts.runtimeDir ?? "").trim();
     this.logger = opts.logger ?? null;
     this.engineFactory = opts.engineFactory || defaultPipelineLoader;
     // Injectable seam: async (query, passage) => number. When set, init()
@@ -107,6 +120,7 @@ export class LocalReranker {
   _engineOptions() {
     const options = { device: this.device };
     if (this.cacheDir) options.cache_dir = this.cacheDir;
+    if (this.runtimeDir) options.runtimeDir = this.runtimeDir;
     return options;
   }
 

--- a/dsh-mneme/src/reranker.js
+++ b/dsh-mneme/src/reranker.js
@@ -31,7 +31,12 @@ async function defaultPipelineLoader(task, model, options) {
   const { module } = await loadTransformers({
     runtimeDir: runtimeDir || defaultRuntimeDir()
   });
-  return module.pipeline(task, model, pipelineOptions);
+  const { env, pipeline } = module;
+  // issue #13 同款处理：transformers.js 在预检 tokenizer_config.json 元数据时会丢掉调用方
+  // 的 cache_dir，回退到 env.cacheDir —— 即使模型已完全缓存在本地也会去请求网络。
+  // embedder 侧早就镜像了，reranker 侧一直漏着，于是「已缓存 + 离线」时重排初始化会失败。
+  if (pipelineOptions.cache_dir) env.cacheDir = pipelineOptions.cache_dir;
+  return pipeline(task, model, pipelineOptions);
 }
 
 /** Flatten a transformers.js Tensor [batch, seq, dim] into number[][] rows. */

--- a/dsh-mneme/src/runtime/adopt.js
+++ b/dsh-mneme/src/runtime/adopt.js
@@ -14,9 +14,9 @@
 //    warnings，让上层的验证去发现「收编不完整」，而不是悄悄产出一份半对的运行时。
 //
 // @module dsh-mneme/runtime/adopt
-import { copyFileSync, existsSync, linkSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, linkSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { planClosure } from "./closure.js";
+import { DEFAULT_MAX_PACKAGES, planClosure } from "./closure.js";
 import { defaultRuntimeDir, nodeModulesDir, payloadDir, payloadId, runtimeManifestPath } from "./layout.js";
 
 /** 清单版本：将来字段变化时用来判断怎么读。 */
@@ -111,6 +111,24 @@ export function adoptRuntime({
   if (existsSync(dir) && !overwrite) {
     return { ok: false, reason: `目标已存在：${dir}（需要覆盖请传 overwrite: true）`, payloadDir: dir, payloadId: id, plan };
   }
+
+  // 截断的闭包必须拒绝。maxPackages 截断会静默丢掉传递依赖，而结构检查（describePayload）
+  // 只看必需包、版本和入口文件 —— 于是一份残缺的 payload 会被判为可用、被 loader 选中，
+  // 直到 import 原生模块时才炸，且错误现场离真正的原因很远。宁可在物化前明确失败。
+  if (plan.truncated) {
+    return {
+      ok: false,
+      reason: `依赖闭包被截断（上限 ${maxPackages ?? DEFAULT_MAX_PACKAGES} 个包），拒绝收编；请提高 maxPackages 后重试`,
+      payloadDir: dir,
+      payloadId: id,
+      plan
+    };
+  }
+
+  // 覆盖前必须先清空目标目录。不清的话，linkSync 对已存在的目标路径抛 EEXIST，
+  // 于是每个文件都落到复制分支：物化方式会假报成 "copy"、警告会错说「硬链接不可用」、
+  // 整份闭包真实占盘，而且上一次闭包留下的残留文件永远不会被清掉。
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 
   const warnings = [];
   const totals = { files: 0, bytes: 0, linked: 0, copied: 0, symlinks: 0 };

--- a/dsh-mneme/src/runtime/adopt.js
+++ b/dsh-mneme/src/runtime/adopt.js
@@ -1,0 +1,151 @@
+// 收编宿主已有的运行时（issue #131 / PR-A）
+//
+// 场景：老用户（以及本机）profile 里已经装好了整套 transformers + onnxruntime，
+// 而且它就是能跑的。删依赖之前先把这套「收编」进插件自管的目录，老用户的本地
+// 嵌入就不会因为后续的 prune 而断掉——这是分两步发版里第一步的全部意义。
+//
+// 两条实现约束：
+//
+// 1) 同卷硬链接、跨卷回退复制。收编的源和目标通常都在用户家目录（同卷），
+//    硬链接是瞬时的、不额外占盘；一旦跨卷 linkSync 会抛 EXDEV，则逐个文件回退复制。
+//
+// 2) 不跟随符号链接。pnpm 的 isolated 布局用符号链接指向虚拟store，跟随它会把
+//    宿主 store 里的东西拖进来、还会让目录层级失真。这里选择跳过并如实记进
+//    warnings，让上层的验证去发现「收编不完整」，而不是悄悄产出一份半对的运行时。
+//
+// @module dsh-mneme/runtime/adopt
+import { copyFileSync, existsSync, linkSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { planClosure } from "./closure.js";
+import { defaultRuntimeDir, nodeModulesDir, payloadDir, payloadId, runtimeManifestPath } from "./layout.js";
+
+/** 清单版本：将来字段变化时用来判断怎么读。 */
+export const RUNTIME_MANIFEST_VERSION = 1;
+
+/**
+ * 把一个包目录物化到目标位置。跳过嵌套的 `node_modules`——那些包在闭包计划里
+ * 是独立条目，会各自落到自己的相对位置；不跳就会重复搬一遍。
+ * @param {object} opts - 选项。
+ * @param {Function} [opts.link] - 硬链接实现，默认 fs.linkSync；测试用来注入失败。
+ * @returns {{files: number, bytes: number, linked: number, copied: number, symlinks: number, linkError: string|null}}
+ */
+export function materializePackage({ srcDir, destDir, warnings = [], link = linkSync }) {
+  const stats = { files: 0, bytes: 0, linked: 0, copied: 0, symlinks: 0, linkError: null };
+
+  const walk = (src) => {
+    for (const entry of readdirSync(src, { withFileTypes: true })) {
+      // 嵌套 node_modules 由闭包计划单独负责；跳过以免重复搬运。
+      if (entry.isDirectory() && entry.name === "node_modules") continue;
+      const full = join(src, entry.name);
+      const dest = join(destDir, full.slice(srcDir.length + 1));
+      if (entry.isSymbolicLink()) {
+        stats.symlinks++;
+        warnings.push(`跳过符号链接：${full}`);
+        continue;
+      }
+      if (entry.isDirectory()) {
+        mkdirSync(dest, { recursive: true });
+        walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      mkdirSync(join(dest, ".."), { recursive: true });
+      try {
+        link(full, dest);
+        stats.linked++;
+      } catch (error) {
+        // 跨卷（EXDEV）、权限、文件系统不支持硬链接：逐个文件回退复制。
+        // 这里只记录原因（返回给调用方），不往 warnings 里塞——warnings 是「按文件」
+        // 的事件（例如跳过符号链接），而「为什么整体变成复制」是「按整次收编」的事实，
+        // 去重与呈现由 adoptRuntime 负责，否则每个包都会重复记一条。
+        if (stats.linkError === null) {
+          stats.linkError = `${error?.code ?? ""} ${error?.message ?? error}`.trim();
+        }
+        copyFileSync(full, dest);
+        stats.copied++;
+      }
+      stats.files++;
+      stats.bytes += statSync(full).size;
+    }
+  };
+
+  mkdirSync(destDir, { recursive: true });
+  walk(srcDir);
+  return stats;
+}
+
+/**
+ * 从一份现成的 `node_modules` 收编出一份自管运行时，并写下清单。
+ * @param {object} opts - 选项。
+ * @param {string} opts.fromModulesDir - 源 node_modules（通常是宿主的）。
+ * @param {string} [opts.runtimeDir] - 运行时根目录。
+ * @param {string} [opts.platform] - 目标平台。
+ * @param {string} [opts.arch] - 目标架构。
+ * @param {string} [opts.procedure] - 来源标记（adopted / downloaded / manual）。
+ * @param {boolean} [opts.overwrite] - 目标已存在时是否覆盖。
+ * @param {number} [opts.maxPackages] - 闭包条目上限。
+ * @param {Function} [opts.link] - 硬链接实现，默认 fs.linkSync；测试用来注入失败以覆盖回退分支
+ *   （与 src/local-embedder.js 的 engineFactory 同一思路：把不可复现的环境差异变成可注入的依赖）。
+ * @returns {object} 结果；失败时 ok=false 且带 reason，不抛异常。
+ */
+export function adoptRuntime({
+  fromModulesDir,
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform,
+  arch = process.arch,
+  procedure = "adopted",
+  overwrite = false,
+  maxPackages,
+  link
+}) {
+  const plan = planClosure({ rootModulesDir: fromModulesDir, platform, arch, maxPackages });
+  const entryPackage = plan.packages[0];
+  if (entryPackage === undefined) {
+    return { ok: false, reason: plan.gaps[0]?.reason ?? "入口包未解析到", plan };
+  }
+
+  const version = entryPackage.version ?? "unknown";
+  const id = payloadId({ version, platform, arch });
+  const dir = payloadDir(runtimeDir, id);
+
+  if (existsSync(dir) && !overwrite) {
+    return { ok: false, reason: `目标已存在：${dir}（需要覆盖请传 overwrite: true）`, payloadDir: dir, payloadId: id, plan };
+  }
+
+  const warnings = [];
+  const totals = { files: 0, bytes: 0, linked: 0, copied: 0, symlinks: 0 };
+  let linkError = null;
+  for (const pkg of plan.packages) {
+    const stats = materializePackage({
+      srcDir: pkg.srcDir,
+      destDir: join(nodeModulesDir(dir), pkg.rel),
+      warnings,
+      link
+    });
+    for (const key of Object.keys(totals)) totals[key] += stats[key];
+    if (linkError === null && stats.linkError !== null) linkError = stats.linkError;
+  }
+  // 物化方式如实记进清单：收编「本该不占盘却占了盘」时，用户和面板都能看到原因。
+  const mode = totals.copied === 0 ? "hardlink" : totals.linked === 0 ? "copy" : "mixed";
+  if (linkError !== null) warnings.push(`硬链接不可用，已回退为复制：${linkError}`);
+
+  const manifest = {
+    manifestVersion: RUNTIME_MANIFEST_VERSION,
+    payloadId: id,
+    entry: plan.entry,
+    version,
+    platform,
+    arch,
+    procedure,
+    createdAt: new Date().toISOString(),
+    materialize: { mode, linkError },
+    packages: plan.packages.map((p) => ({ name: p.name, version: p.version, rel: p.rel, optional: p.optional })),
+    gaps: plan.gaps,
+    skipped: plan.skipped,
+    warnings
+  };
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(runtimeManifestPath(dir), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  return { ok: true, payloadDir: dir, payloadId: id, version, plan, manifest, totals };
+}

--- a/dsh-mneme/src/runtime/closure.js
+++ b/dsh-mneme/src/runtime/closure.js
@@ -1,0 +1,164 @@
+// 依赖闭包遍历 + 平台过滤（issue #131 / PR-A）
+//
+// 用途：adopt（从宿主 node_modules 收编）与 export（导出给别的机器）要回答的是
+// 同一个问题——「一份能跑的运行时，到底需要哪些包，各自该落到哪个位置」。
+//
+// 两个刻意的设计：
+//
+// 1) 按源布局镜像，不压平。入口 transformers.node.mjs 内部是裸导入
+//    （`import sharp from "sharp"`、`import * as ONNX_NODE from "onnxruntime-node"`），
+//    靠 Node 逐级向上查找解析。只要目标目录的嵌套结构与源一致，解析行为就一致；
+//    压平会把「同一个包的两个版本分别落在不同层」这类情形悄悄改成另一种结果。
+//    所以 rel 保留 `a/node_modules/b` 这种层级。
+//
+// 2) 跳过 peerDependencies。peer 由宿主提供（例如 @deepseek-ai/* 那些服务），
+//    插件自管的运行时不该把宿主的实现复制进来——复制了反而会和宿主的实例分叉。
+//
+// @module dsh-mneme/runtime/closure
+import { existsSync } from "node:fs";
+import { dirname, join, relative, sep } from "node:path";
+import { readJsonSafe } from "./layout.js";
+
+/** 闭包条目数上限：纯属防呆，命中即截断并如实上报，不静默丢包。 */
+export const DEFAULT_MAX_PACKAGES = 400;
+
+/**
+ * 包是否匹配当前平台。npm 用 package.json 的 os / cpu 字段声明平台，
+ * 支持 `["win32"]` 正向匹配与 `["!darwin"]` 反向排除两种写法。
+ * 字段缺省表示「不限平台」。
+ * @param {any} manifest - 包的 package.json。
+ * @param {string} platform - process.platform 取值。
+ * @param {string} arch - process.arch 取值。
+ * @returns {boolean} 是否匹配。
+ */
+export function matchesPlatform(manifest, platform, arch) {
+  const check = (values, actual) => {
+    if (!Array.isArray(values) || values.length === 0) return true;
+    const negated = values.filter((v) => typeof v === "string" && v.startsWith("!"));
+    const positive = values.filter((v) => typeof v === "string" && !v.startsWith("!"));
+    // 反向排除优先：命中任一 `!x` 即不匹配（与 npm 的语义一致）。
+    if (negated.some((v) => v.slice(1) === actual)) return false;
+    if (positive.length === 0) return true;
+    return positive.includes(actual);
+  };
+  return check(manifest?.os, platform) && check(manifest?.cpu, arch);
+}
+
+/**
+ * 按 Node 的解析规则，从 fromDir 出发找 name 的包目录，但**不越出 rootModulesDir**。
+ *
+ * Node 的规则是：从所在目录逐级向上，每级查 `<级>/node_modules/<name>`。所以对
+ * `root/@scope/pkg` 而言，候选依次是 `root/@scope/pkg/node_modules/...`、
+ * `root/@scope/node_modules/...`、`root/node_modules/...`（这一级是
+ * node_modules 套 node_modules，通常不存在），最后到 `dirname(root)/node_modules/...`
+ * ——正好就是 `root/<name>`。因此循环要允许走到 root 的上一级再停。
+ * @param {string} fromDir - 从哪个包目录出发解析。
+ * @param {string} name - 依赖名。
+ * @param {string} rootModulesDir - 允许查找的边界 node_modules 目录。
+ * @returns {string|null} 包目录绝对路径，找不到返回 null。
+ */
+export function resolvePackageDir(fromDir, name, rootModulesDir) {
+  const limit = dirname(rootModulesDir);
+  let dir = fromDir;
+  for (;;) {
+    const candidate = join(dir, "node_modules", name);
+    if (existsSync(join(candidate, "package.json"))) return candidate;
+    if (dir === limit || dir === dirname(dir)) return null;
+    dir = dirname(dir);
+  }
+}
+
+/** 转成 manifest 里使用的、与平台无关的相对路径（始终用 `/`）。 */
+function toRel(root, dir) {
+  return relative(root, dir).split(sep).join("/");
+}
+
+/**
+ * 计算一份运行时的依赖闭包。
+ *
+ * 只走 dependencies 与 optionalDependencies：
+ * - 必需依赖缺失 → 记进 gaps（让调用方能如实报「这份闭包不完整」）；
+ * - 可选依赖缺失 → 静默跳过（这正是平台分片包在别的平台上的正常形态）；
+ * - 平台不匹配的包 → 记进 skipped（导出给别的机器时，跨平台的残留不会被带走）。
+ * @param {object} opts - 选项。
+ * @param {string} opts.rootModulesDir - 源 node_modules 目录。
+ * @param {string} [opts.entry] - 入口包名。
+ * @param {string} [opts.platform] - 目标平台。
+ * @param {string} [opts.arch] - 目标架构。
+ * @param {number} [opts.maxPackages] - 条目上限。
+ * @returns {{rootModulesDir: string, entry: string, platform: string, arch: string,
+ *   packages: {name: string, version: string|null, rel: string, srcDir: string, optional: boolean}[],
+ *   gaps: {name: string, from: string, reason: string}[],
+ *   skipped: {name: string, rel: string, reason: string}[], truncated: boolean}}
+ */
+export function planClosure({
+  rootModulesDir,
+  entry = "@huggingface/transformers",
+  platform = process.platform,
+  arch = process.arch,
+  maxPackages = DEFAULT_MAX_PACKAGES
+} = {}) {
+  const packages = [];
+  const gaps = [];
+  const skipped = [];
+  const seen = new Set();
+
+  const entryDir = resolvePackageDir(rootModulesDir, entry, rootModulesDir);
+  if (entryDir === null) {
+    gaps.push({ name: entry, from: ".", reason: "入口包不存在" });
+    return { rootModulesDir, entry, platform, arch, packages, gaps, skipped, truncated: false };
+  }
+
+  // BFS：队列里放已被解析出来的包目录。用真实目录去重，避免软链接/重复边导致来回走。
+  const queue = [{ dir: entryDir, rel: toRel(rootModulesDir, entryDir), optional: false }];
+  let truncated = false;
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (seen.has(current.dir)) continue;
+    seen.add(current.dir);
+
+    const manifest = readJsonSafe(join(current.dir, "package.json"));
+    if (manifest === undefined) {
+      gaps.push({ name: current.rel, from: current.rel, reason: "package.json 读不到" });
+      continue;
+    }
+    // 入口包本身不做平台过滤：它是用户明确要的那一个。
+    if (current.rel !== toRel(rootModulesDir, entryDir) && !matchesPlatform(manifest, platform, arch)) {
+      skipped.push({ name: manifest.name ?? current.rel, rel: current.rel, reason: "平台不匹配" });
+      continue;
+    }
+    if (packages.length >= maxPackages) {
+      truncated = true;
+      break;
+    }
+    packages.push({
+      name: manifest.name ?? current.rel,
+      version: manifest.version ?? null,
+      rel: current.rel,
+      srcDir: current.dir,
+      optional: current.optional
+    });
+
+    const required = Object.keys(manifest.dependencies ?? {});
+    const optional = Object.keys(manifest.optionalDependencies ?? {});
+    for (const name of [...required, ...optional]) {
+      const isOptional = optional.includes(name);
+      const dir = resolvePackageDir(current.dir, name, rootModulesDir);
+      if (dir === null) {
+        // 可选依赖缺失是正常形态（平台分片包在别的平台就是这样），不报警。
+        if (!isOptional) gaps.push({ name, from: current.rel, reason: "必需依赖未找到" });
+        continue;
+      }
+      const rel = toRel(rootModulesDir, dir);
+      // 不允许越出源树：越出说明解析跑到了宿主其它位置，这份闭包就不是自包含的。
+      if (rel.startsWith("..")) {
+        gaps.push({ name, from: current.rel, reason: "解析结果越出源 node_modules" });
+        continue;
+      }
+      queue.push({ dir, rel, optional: isOptional });
+    }
+  }
+
+  return { rootModulesDir, entry, platform, arch, packages, gaps, skipped, truncated };
+}

--- a/dsh-mneme/src/runtime/layout.js
+++ b/dsh-mneme/src/runtime/layout.js
@@ -161,7 +161,7 @@ export function listPayloadDirs(runtimeDir) {
  * @param {{platform?: string, arch?: string}} [opts] - 目标平台。
  * @returns {{dir: string, ok: boolean, version: string|null, manifest: any, missing: string[], reasons: string[]}}
  */
-export function describePayload(dir, { platform = process.platform } = {}) {
+export function describePayload(dir, { platform = process.platform, arch = process.arch } = {}) {
   const report = {
     dir,
     ok: false,
@@ -194,15 +194,14 @@ export function describePayload(dir, { platform = process.platform } = {}) {
   // 3) 入口文件本身（前面只确认了包目录在）。
   if (!existsSync(join(dir, TRANSFORMERS_ENTRY))) report.missing.push(TRANSFORMERS_ENTRY);
 
-  // 4) onnxruntime-node 一个包内含三平台二进制，裁剪或跨机搬运时最容易只留下
-  //    别的平台；只检查「当前平台的子树在不在」，不检查具体架构目录，
-  //    免得绑定到包内部的路径细节。
-  if (
-    existsSync(join(nm, "onnxruntime-node")) &&
-    !existsSync(join(nm, "onnxruntime-node", "bin", "napi-v6", platform))
-  ) {
+  // 4) onnxruntime-node 一个包内含多平台 × 多架构的二进制，裁剪或跨机搬运时最容易只留下
+  //    别的平台/架构。必须点名到**平台 + 架构**：真实包结构是
+  //    bin/napi-v6/{darwin,linux,win32}/{arm64,x64}，只查平台的话 linux-arm64 的 payload
+  //    在 linux-x64 上也会通过结构检查，被 loader 选中后才在 import 原生模块时失败。
+  const nativeDir = join(nm, "onnxruntime-node", "bin", "napi-v6", platform, arch);
+  if (existsSync(join(nm, "onnxruntime-node")) && !existsSync(nativeDir)) {
     report.reasons.push(
-      `onnxruntime-node 缺少 ${platform} 平台的二进制子树（bin/napi-v6/${platform}）`
+      `onnxruntime-node 缺少 ${platform}/${arch} 的二进制子树（bin/napi-v6/${platform}/${arch}）`
     );
   }
 

--- a/dsh-mneme/src/runtime/layout.js
+++ b/dsh-mneme/src/runtime/layout.js
@@ -1,0 +1,199 @@
+// 运行时目录契约（issue #131 / PR-A）
+//
+// 背景：@huggingface/transformers 及其原生闭包（onnxruntime-node 解包 210 MB、
+// onnxruntime-web 128 MB、sharp 19 MB）只要留在插件的 dependencies 里，就会进
+// 宿主 profile 的安装图。profile 是所有插件共用的依赖图，于是「装任何插件都要替
+// 它重走一遍这条链」，弱网下直接把安装卡死。本模块定义插件自管运行时的落地契约，
+// 让这份运行时与宿主依赖图解耦。
+//
+// 只有三件事是稳定契约，其余实现都可以换：
+//
+//   <runtimeDir>/<payloadId>/mneme-runtime.json   来源与版本清单
+//   <runtimeDir>/<payloadId>/node_modules/        扁平依赖闭包（与 hoisted 同形）
+//   <runtimeDir>/<payloadId>/node_modules/@huggingface/transformers/dist/transformers.node.mjs
+//
+// 为什么必须是「扁平 node_modules」：transformers.node.mjs 内部全是裸导入
+// （`import sharp from "sharp"`、`import * as ONNX_NODE from "onnxruntime-node"`），
+// 它们相对该文件自身位置解析。所以只要把闭包按扁平结构放好，再用绝对 file URL
+// import 入口，整套就能跑起来——不需要动宿主的 node_modules，也不需要 overrides。
+//
+// @module dsh-mneme/runtime/layout
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** 运行时清单文件名，与 payload 目录同级。 */
+export const RUNTIME_MANIFEST = "mneme-runtime.json";
+/** 唯一会被本插件 import 的入口：transformers 的 Node 构建。 */
+export const TRANSFORMERS_ENTRY =
+  "node_modules/@huggingface/transformers/dist/transformers.node.mjs";
+/**
+ * 结构检查要求的包。三个都是硬要求：
+ * - @huggingface/transformers 是入口本身；
+ * - onnxruntime-node 被 Node 构建顶层 import；
+ * - sharp 也被 Node 构建顶层 `import sharp from "sharp"`，缺了入口 import 就抛。
+ */
+export const REQUIRED_PACKAGES = ["@huggingface/transformers", "onnxruntime-node", "sharp"];
+/** 认可的 transformers 版本区间：peer 提案的 >=4.2.0 <5（见 issue #131）。 */
+export const TRANSFORMERS_MIN = [4, 2, 0];
+export const TRANSFORMERS_MAX_MAJOR = 5;
+
+/**
+ * 解析 major.minor.patch。解析不出来返回 null —— 这里刻意不抛错，
+ * 让调用方把「版本读不懂」当成一条可报告的失败，而不是异常。
+ * @param {unknown} value - 版本字符串。
+ * @returns {number[]|null} [major, minor, patch] 或 null。
+ */
+function parseVersion(value) {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(value ?? ""));
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** 三元版本比较：a < b 返回负数。 */
+function compareVersion(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * 版本是否落在认可区间内。
+ *
+ * 刻意只实现「>=TRANSFORMERS_MIN <TRANSFORMERS_MAX_MAJOR」这一条区间，
+ * 不是通用 semver —— 运行时要认的只有 transformers 一个包，写通用实现
+ * 反而引入没被使用、也没被测试的分支。
+ * @param {unknown} version - 待检查版本。
+ * @returns {boolean} 是否认可。
+ */
+export function transformersVersionOk(version) {
+  const v = parseVersion(version);
+  if (v === null) return false;
+  if (v[0] >= TRANSFORMERS_MAX_MAJOR) return false;
+  return compareVersion(v, TRANSFORMERS_MIN) >= 0;
+}
+
+/**
+ * 运行时根目录的默认位置。与 embedModelCacheDir 的既有约定保持一致
+ * （都挂在 ~/.dsh/mneme/ 下，便于用户整个删掉重来）。
+ * @param {string} [home] - 家目录，测试时可注入。
+ * @returns {string} 运行时根目录。
+ */
+export function defaultRuntimeDir(home = homedir()) {
+  return join(home, ".dsh", "mneme", "runtime");
+}
+
+/**
+ * 一个 payload 的目录名。带平台与架构，因此多份可以共存，
+ * 加载器按平台挑一份可用的即可。
+ * @param {{version: string, platform?: string, arch?: string}} opts - 版本与平台。
+ * @returns {string} 形如 transformers-4.2.0-node-win32-x64。
+ */
+export function payloadId({ version, platform = process.platform, arch = process.arch }) {
+  return `transformers-${version}-node-${platform}-${arch}`;
+}
+
+/** payload 目录。@param {string} runtimeDir @param {string} id @returns {string} */
+export function payloadDir(runtimeDir, id) {
+  return join(runtimeDir, id);
+}
+
+/** payload 内的扁平依赖目录。@param {string} dir @returns {string} */
+export function nodeModulesDir(dir) {
+  return join(dir, "node_modules");
+}
+
+/** 清单文件路径。@param {string} dir @returns {string} */
+export function runtimeManifestPath(dir) {
+  return join(dir, RUNTIME_MANIFEST);
+}
+
+/**
+ * 读取 JSON，读不到或解析失败都返回 undefined（结构检查不应因缺文件而抛错）。
+ * @param {string} file - 文件路径。
+ * @returns {any|undefined} 解析结果。
+ */
+export function readJsonSafe(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * 列出运行时根目录下所有 payload 目录（名称排序）。目录不存在返回空数组。
+ * 加载器用它挑候选，再逐个 describePayload 判断可用性。
+ * @param {string} runtimeDir - 运行时根目录。
+ * @returns {string[]} payload 目录名。
+ */
+export function listPayloadDirs(runtimeDir) {
+  try {
+    return readdirSync(runtimeDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 结构检查：这份 payload 是否至少「该有的文件都在」。
+ *
+ * 它故意不做功能验证（真 import 并跑一次推理）——那一步要看运行环境，
+ * 由 verify 模块负责。这里只回答「解压完整没有、版本对不对、平台对不对」，
+ * 用来在下载/搬运之后立刻发现缺件。
+ * @param {string} dir - payload 目录。
+ * @param {{platform?: string, arch?: string}} [opts] - 目标平台。
+ * @returns {{dir: string, ok: boolean, version: string|null, manifest: any, missing: string[], reasons: string[]}}
+ */
+export function describePayload(dir, { platform = process.platform } = {}) {
+  const report = {
+    dir,
+    ok: false,
+    version: null,
+    manifest: readJsonSafe(runtimeManifestPath(dir)),
+    missing: [],
+    reasons: []
+  };
+
+  const nm = nodeModulesDir(dir);
+  if (!existsSync(nm)) {
+    report.reasons.push(`node_modules 不存在：${nm}`);
+    return report;
+  }
+
+  // 1) 必需包逐个点名 —— 缺哪个报哪个，用户能照着单子手工补。
+  for (const name of REQUIRED_PACKAGES) {
+    if (!existsSync(join(nm, name, "package.json"))) report.missing.push(name);
+  }
+
+  // 2) 版本必须落在认可区间（装了别的 major 的闭包，行为不可预期）。
+  const transformers = readJsonSafe(join(nm, "@huggingface/transformers", "package.json"));
+  report.version = transformers?.version ?? null;
+  if (transformers !== undefined && !transformersVersionOk(transformers.version)) {
+    report.reasons.push(
+      `@huggingface/transformers@${transformers.version} 不在认可区间（>=${TRANSFORMERS_MIN.join(".")} <${TRANSFORMERS_MAX_MAJOR}）`
+    );
+  }
+
+  // 3) 入口文件本身（前面只确认了包目录在）。
+  if (!existsSync(join(dir, TRANSFORMERS_ENTRY))) report.missing.push(TRANSFORMERS_ENTRY);
+
+  // 4) onnxruntime-node 一个包内含三平台二进制，裁剪或跨机搬运时最容易只留下
+  //    别的平台；只检查「当前平台的子树在不在」，不检查具体架构目录，
+  //    免得绑定到包内部的路径细节。
+  if (
+    existsSync(join(nm, "onnxruntime-node")) &&
+    !existsSync(join(nm, "onnxruntime-node", "bin", "napi-v6", platform))
+  ) {
+    report.reasons.push(
+      `onnxruntime-node 缺少 ${platform} 平台的二进制子树（bin/napi-v6/${platform}）`
+    );
+  }
+
+  report.ok = report.missing.length === 0 && report.reasons.length === 0;
+  return report;
+}

--- a/dsh-mneme/src/runtime/layout.js
+++ b/dsh-mneme/src/runtime/layout.js
@@ -85,6 +85,18 @@ export function defaultRuntimeDir(home = homedir()) {
 }
 
 /**
+ * 本地模型的默认缓存目录。
+ *
+ * 收在这里是因为它必须**唯一**：embedder、reranker、verify 三方若各写一份字面量，
+ * 一旦漂移，verify 就会拿另一份模型去验证，验证结果不再是运行时的真实证据。
+ * @param {string} [home] - 家目录，测试时可注入。
+ * @returns {string} 模型缓存目录。
+ */
+export function defaultModelCacheDir(home = homedir()) {
+  return join(home, ".dsh", "mneme", "models");
+}
+
+/**
  * 一个 payload 的目录名。带平台与架构，因此多份可以共存，
  * 加载器按平台挑一份可用的即可。
  * @param {{version: string, platform?: string, arch?: string}} opts - 版本与平台。

--- a/dsh-mneme/src/runtime/loader.js
+++ b/dsh-mneme/src/runtime/loader.js
@@ -17,7 +17,7 @@
 // 那条错误要带出来——它是「这份 payload 坏了」和「本机根本没有」的区别。
 //
 // @module dsh-mneme/runtime/loader
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { join } from "node:path";
 import {
   TRANSFORMERS_ENTRY,
@@ -31,6 +31,27 @@ import {
 const defaultImport = (specifier) => import(specifier);
 
 /**
+ * 给用户看的可操作提示。用插件自身的相对位置推出绝对路径 —— src/ 与 lib/ 都在
+ * 包根下一层，所以 `../../scripts` 在两处都解析到同一个文件，提示不会因为跑源码
+ * 还是跑构建产物而指错。
+ */
+const RUNTIME_HINT =
+  "本地推理运行时不可用。查看状态：" +
+  `node "${fileURLToPath(new URL("../../scripts/mneme-runtime.mjs", import.meta.url))}" status` +
+  "；宿主里已有这份依赖时可用 `adopt --from <宿主 node_modules 目录>` 收编，再用 `verify` 验证。" +
+  "检索会自动降级为关键词/BM25，不影响记忆读写。";
+
+/**
+ * 空/空白 runtimeDir 视为「用默认目录」。配置项 runtimeDir 的默认值就是空串，
+ * 原样传下去会变成相对路径（`readdirSync("")` 直接失败），把「没配」误报成「坏了」。
+ * 收在这一处，省得每个调用方各写一遍 `|| defaultRuntimeDir()`。
+ */
+function effectiveRuntimeDir(runtimeDir) {
+  const value = String(runtimeDir ?? "").trim();
+  return value === "" ? defaultRuntimeDir() : value;
+}
+
+/**
  * 在运行时根目录里挑一份可用的 payload。
  *
  * 多份并存时取目录名倒序的第一个通过结构检查的（同平台通常只会有一份；
@@ -40,19 +61,87 @@ const defaultImport = (specifier) => import(specifier);
  *   没有可用 payload 时返回 null（不是错误——第 ② 层还有机会）。
  */
 export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform = process.platform } = {}) {
-  for (const id of listPayloadDirs(runtimeDir).reverse()) {
-    const dir = payloadDir(runtimeDir, id);
-    const report = describePayload(dir, { platform });
+  const dir = effectiveRuntimeDir(runtimeDir);
+  for (const id of listPayloadDirs(dir).reverse()) {
+    const payload = payloadDir(dir, id);
+    const report = describePayload(payload, { platform });
     if (!report.ok) continue;
     return {
-      dir,
+      dir: payload,
       payloadId: id,
-      entryUrl: pathToFileURL(join(dir, TRANSFORMERS_ENTRY)).href,
+      entryUrl: pathToFileURL(join(payload, TRANSFORMERS_ENTRY)).href,
       version: report.version,
       manifest: report.manifest
     };
   }
   return null;
+}
+
+/**
+ * 只读地报告自管运行时的当前状态，供状态接口 / 面板 / CLI 展示。
+ *
+ * 刻意只做结构检查，不做功能验证：这是被 GET 端点按次调用的探针，而真跑一次
+ * 推理要加载原生模块、还会碰模型缓存。所以 `functional` 如实返回 "unknown"，
+ * 并给出去哪验证的提示 —— 宁可说「没验过」，也不假装验过。
+ *
+ * 挑选口径直接复用 resolveRuntimeEntry，避免出现「状态接口报的那份」和
+ * 「真正加载的那份」不是同一个。
+ * @param {{runtimeDir?: string, platform?: string}} [opts] - 选项。
+ * @returns {{status: string, runtimeDir: string, hint: string}} 状态；任何异常都降级成状态对象，不抛。
+ */
+export function describeLocalRuntime({
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform
+} = {}) {
+  let candidate = null;
+  const dir = effectiveRuntimeDir(runtimeDir);
+  try {
+    candidate = resolveRuntimeEntry({ runtimeDir: dir, platform });
+  } catch (error) {
+    // 配置里的 runtimeDir 是用户输入（可能是离奇的字符串让 pathToFileURL 抛错），
+    // 这里是唯一的边界，收在这里比每个调用方各包一层稳。
+    return {
+      status: "unreadable",
+      runtimeDir: dir,
+      reason: String(error?.message ?? error),
+      functional: "unknown",
+      hint: RUNTIME_HINT
+    };
+  }
+
+  if (candidate !== null) {
+    return {
+      status: "available",
+      runtimeDir: dir,
+      payloadId: candidate.payloadId,
+      version: candidate.version,
+      procedure: candidate.manifest?.procedure ?? null,
+      materialize: candidate.manifest?.materialize?.mode ?? null,
+      // 历史 payload（收编来的）清单里没有 integrity 字段，如实报 unverified；
+      // 下载通道会把校验结果写进清单，这里不改代码就能读到。
+      integrity: candidate.manifest?.integrity ?? "unverified",
+      functional: "unknown",
+      hint: RUNTIME_HINT
+    };
+  }
+
+  const ids = listPayloadDirs(dir);
+  if (ids.length === 0) {
+    return { status: "missing", runtimeDir: dir, functional: "unknown", hint: RUNTIME_HINT };
+  }
+  // 有目录但一份都没通过结构检查：把最新那份的缺件和原因带出来，别只说「坏了」。
+  const id = ids[ids.length - 1];
+  const report = describePayload(payloadDir(dir, id), { platform });
+  return {
+    status: "broken",
+    runtimeDir: dir,
+    payloadId: id,
+    version: report.version,
+    missing: report.missing,
+    reasons: report.reasons,
+    functional: "unknown",
+    hint: RUNTIME_HINT
+  };
 }
 
 /**
@@ -105,10 +194,7 @@ export async function loadTransformers({
   }
 
   // ③ 都没有：给出可操作的下一步，而不是一句 module not found
-  const hint =
-    "本地推理运行时不可用。可在设置面板「本地推理运行时」里安装，或把已有的运行时收编：" +
-    "dsh-mneme runtime adopt --from <node_modules 目录>。检索会自动降级为关键词/BM25，不影响记忆读写。";
-  const error = new Error(`${hint}\n${failures.map((f) => `  - ${f}`).join("\n")}`);
+  const error = new Error(`${RUNTIME_HINT}\n${failures.map((f) => `  - ${f}`).join("\n")}`);
   error.code = "MNEME_RUNTIME_UNAVAILABLE";
   error.failures = failures;
   throw error;

--- a/dsh-mneme/src/runtime/loader.js
+++ b/dsh-mneme/src/runtime/loader.js
@@ -60,11 +60,15 @@ function effectiveRuntimeDir(runtimeDir) {
  * @returns {{dir: string, payloadId: string, entryUrl: string, version: string|null, manifest: any}|null}
  *   没有可用 payload 时返回 null（不是错误——第 ② 层还有机会）。
  */
-export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform = process.platform } = {}) {
+export function resolveRuntimeEntry({
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform,
+  arch = process.arch
+} = {}) {
   const dir = effectiveRuntimeDir(runtimeDir);
   for (const id of listPayloadDirs(dir).reverse()) {
     const payload = payloadDir(dir, id);
-    const report = describePayload(payload, { platform });
+    const report = describePayload(payload, { platform, arch });
     if (!report.ok) continue;
     return {
       dir: payload,
@@ -91,12 +95,13 @@ export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform
  */
 export function describeLocalRuntime({
   runtimeDir = defaultRuntimeDir(),
-  platform = process.platform
+  platform = process.platform,
+  arch = process.arch
 } = {}) {
   let candidate = null;
   const dir = effectiveRuntimeDir(runtimeDir);
   try {
-    candidate = resolveRuntimeEntry({ runtimeDir: dir, platform });
+    candidate = resolveRuntimeEntry({ runtimeDir: dir, platform, arch });
   } catch (error) {
     // 配置里的 runtimeDir 是用户输入（可能是离奇的字符串让 pathToFileURL 抛错），
     // 这里是唯一的边界，收在这里比每个调用方各包一层稳。
@@ -131,7 +136,7 @@ export function describeLocalRuntime({
   }
   // 有目录但一份都没通过结构检查：把最新那份的缺件和原因带出来，别只说「坏了」。
   const id = ids[ids.length - 1];
-  const report = describePayload(payloadDir(dir, id), { platform });
+  const report = describePayload(payloadDir(dir, id), { platform, arch });
   return {
     status: "broken",
     runtimeDir: dir,
@@ -141,6 +146,31 @@ export function describeLocalRuntime({
     reasons: report.reasons,
     functional: "unknown",
     hint: RUNTIME_HINT
+  };
+}
+
+/**
+ * 把 describeLocalRuntime 的结果投影成「允许出现在免鉴权 HTTP 端点里」的形状。
+ *
+ * 为什么必须投影：`/api/dsh-mneme/semantic` 是刻意不鉴权的只读端点（与 list/search 同列），
+ * 而完整状态里有**绝对路径**（`runtimeDir`、`hint` 里嵌的脚本路径）和**原始错误文本**
+ * （`reason`/`reasons` 会带上完整文件路径，例如「node_modules 不存在：C:\...」）。
+ * 把它们发给任何能连上该端口的人，属于信息泄漏（CWE-200）。
+ *
+ * 完整诊断留给本机的 CLI（`status`）——那里本来就有文件系统权限，也才是真正需要这些细节的场景。
+ * 面板侧不需要这些：它只需要 status，其余文案用本地 i18n。
+ * @param {object} report - describeLocalRuntime 的返回值。
+ * @returns {{status: string, payloadId: string|null, version: string|null, procedure: string|null, materialize: string|null, integrity: string|null, functional: string|null}}
+ */
+export function publicRuntimeStatus(report) {
+  return {
+    status: report?.status ?? "unknown",
+    payloadId: report?.payloadId ?? null,
+    version: report?.version ?? null,
+    procedure: report?.procedure ?? null,
+    materialize: report?.materialize ?? null,
+    integrity: report?.integrity ?? null,
+    functional: report?.functional ?? null
   };
 }
 

--- a/dsh-mneme/src/runtime/loader.js
+++ b/dsh-mneme/src/runtime/loader.js
@@ -1,0 +1,115 @@
+// 运行时加载器：三层解析（issue #131 / PR-A）
+//
+//   ① 插件自管目录 ~/.dsh/mneme/runtime/<payloadId>/ —— 收编来的或下载来的
+//   ② 宿主裸 specifier —— 用户自己装的、或别的插件带进来的
+//   ③ 都没有 —— 抛出带可操作提示的错误，由调用方降级
+//
+// 为什么第 ② 层不能省：PR-A 只是「先建基础设施」，依赖声明不动，所以老用户
+// 升级后宿主那份还在。第 ② 层保证他们在收编完成前照常可用；等 PR-B 真的把依赖
+// 摘掉、pnpm 把宿主那份 prune 掉之后，第 ① 层顶上，本地嵌入不断。
+//
+// 为什么第 ① 层要 import 绝对 file URL 而不是改 node_modules：入口内部全是裸导入
+// （`import sharp from "sharp"`、`import * as ONNX_NODE from "onnxruntime-node"`），
+// 按自身位置解析。把闭包按扁平结构放在 payload 里、用绝对 URL import 入口，
+// 整套就自洽了——不需要动宿主的 node_modules，也不需要 overrides。
+//
+// 失败必须可见：第 ① 层如果「找到了但加载不起来」，不能静默滑到第 ② 层就完事，
+// 那条错误要带出来——它是「这份 payload 坏了」和「本机根本没有」的区别。
+//
+// @module dsh-mneme/runtime/loader
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
+import {
+  TRANSFORMERS_ENTRY,
+  defaultRuntimeDir,
+  describePayload,
+  listPayloadDirs,
+  payloadDir
+} from "./layout.js";
+
+/** 默认 import 实现；测试用来注入，避免真的加载原生模块。 */
+const defaultImport = (specifier) => import(specifier);
+
+/**
+ * 在运行时根目录里挑一份可用的 payload。
+ *
+ * 多份并存时取目录名倒序的第一个通过结构检查的（同平台通常只会有一份；
+ * 需要严格挑版本时由调用方先自己筛 runtimeDir）。
+ * @param {object} [opts] - 选项。
+ * @returns {{dir: string, payloadId: string, entryUrl: string, version: string|null, manifest: any}|null}
+ *   没有可用 payload 时返回 null（不是错误——第 ② 层还有机会）。
+ */
+export function resolveRuntimeEntry({ runtimeDir = defaultRuntimeDir(), platform = process.platform } = {}) {
+  for (const id of listPayloadDirs(runtimeDir).reverse()) {
+    const dir = payloadDir(runtimeDir, id);
+    const report = describePayload(dir, { platform });
+    if (!report.ok) continue;
+    return {
+      dir,
+      payloadId: id,
+      entryUrl: pathToFileURL(join(dir, TRANSFORMERS_ENTRY)).href,
+      version: report.version,
+      manifest: report.manifest
+    };
+  }
+  return null;
+}
+
+/**
+ * 按三层解析加载 transformers。任何一层失败都不抛给调用方之外的语义：
+ * 全部失败时抛一个带「试过哪些、各自为什么失败」的错误，便于面板/状态接口直接展示。
+ * @param {object} [opts] - 选项。
+ * @param {string} [opts.runtimeDir] - 运行时根目录。
+ * @param {string} [opts.platform] - 平台。
+ * @param {Function} [opts.importModule] - import 实现（测试注入）。
+ * @param {(message: string) => void} [opts.onFailure] - 每次降级/失败的回调：
+ *   第 ① 层坏了却退到第 ② 层时，调用方（面板/日志）要能看见，不能静默。
+ * @returns {Promise<{module: any, source: "runtime"|"host", payloadId?: string, version?: string, entryUrl?: string}>}
+ */
+export async function loadTransformers({
+  runtimeDir = defaultRuntimeDir(),
+  platform = process.platform,
+  importModule = defaultImport,
+  onFailure = null
+} = {}) {
+  const failures = [];
+  const note = (message) => {
+    failures.push(message);
+    onFailure?.(message);
+  };
+
+  // ① 自管运行时
+  const candidate = resolveRuntimeEntry({ runtimeDir, platform });
+  if (candidate !== null) {
+    try {
+      const module = await importModule(candidate.entryUrl);
+      return {
+        module,
+        source: "runtime",
+        payloadId: candidate.payloadId,
+        version: candidate.version,
+        entryUrl: candidate.entryUrl
+      };
+    } catch (error) {
+      // 找到了却加载不起来 —— 这条必须带出去，「坏了」和「没有」不是一回事。
+      note(`自管运行时 ${candidate.payloadId} 加载失败：${error?.message ?? error}`);
+    }
+  }
+
+  // ② 宿主（用户自己装的 / 别的插件带进来的）
+  try {
+    const module = await importModule("@huggingface/transformers");
+    return { module, source: "host" };
+  } catch (error) {
+    note(`宿主未提供 @huggingface/transformers：${error?.message ?? error}`);
+  }
+
+  // ③ 都没有：给出可操作的下一步，而不是一句 module not found
+  const hint =
+    "本地推理运行时不可用。可在设置面板「本地推理运行时」里安装，或把已有的运行时收编：" +
+    "dsh-mneme runtime adopt --from <node_modules 目录>。检索会自动降级为关键词/BM25，不影响记忆读写。";
+  const error = new Error(`${hint}\n${failures.map((f) => `  - ${f}`).join("\n")}`);
+  error.code = "MNEME_RUNTIME_UNAVAILABLE";
+  error.failures = failures;
+  throw error;
+}

--- a/dsh-mneme/src/runtime/verify.js
+++ b/dsh-mneme/src/runtime/verify.js
@@ -121,7 +121,16 @@ export async function verifyFunctional(dir, {
   if (!Array.isArray(rows) || rows.length !== probeTexts.length) {
     return fail(`返回行数不符：期望 ${probeTexts.length}，实际 ${Array.isArray(rows) ? rows.length : typeof rows}`);
   }
-  const dim = rows[0]?.length ?? 0;
+  // 先逐行确认「是数组」且「全是有限数」。这一步不能省：non-finite（NaN/Infinity）会让
+  // 下面所有比较恒为 false —— `Math.abs(NaN - 1) > tol` 是 false，`Math.abs(NaN) > 阈值`
+  // 也是 false —— 于是一份坏掉的运行时会被判成「验证通过」。这是本模块最危险的失败模式
+  // （假通过），比抛异常糟得多。行不是数组时同样要先拦住，否则 .length 直接抛，
+  // 违背「任何失败都返回结果对象，不抛异常」的契约。
+  for (let i = 0; i < rows.length; i++) {
+    if (!Array.isArray(rows[i])) return fail(`第 ${i} 行不是数组（${typeof rows[i]}）`);
+    if (rows[i].some((v) => !Number.isFinite(v))) return fail(`第 ${i} 行含有非有限数值`);
+  }
+  const dim = rows[0].length;
   if (dim === 0) return fail("返回了空向量");
   if (rows.some((row) => row.length !== dim)) return fail("各行维度不一致");
 

--- a/dsh-mneme/src/runtime/verify.js
+++ b/dsh-mneme/src/runtime/verify.js
@@ -1,0 +1,177 @@
+// 运行时验证三件套（issue #131 / PR-A）
+//
+// 为什么要分三层，而不是「能 import 就算通过」：
+//
+//   结构   —— 入口在不在、版本对不对、平台子树对不对、闭包有没有缺口。
+//              便宜、确定，能立刻发现「解压到一半」。
+//   功能   —— 真的 import 入口并跑一次推理。这是唯一能证明「这份运行时在这个
+//              环境里真的算得出来」的一层；结构全对但原生二进制与本机 ABI 不
+//              匹配时，只有它能发现。
+//   完整性 —— 只对「有原始产物可比对」的来源做（下载的 tarball、本地 tarball）。
+//              收编来的目录没有原始 tarball，如实标 unverified，不假装验过。
+//
+// 功能验证复用 src/local-embedder.js 的 engineFactory 思路：真正干活的是注入进来
+// 的 engine，默认实现才去 import 真实运行时。这样测试不需要网络、不需要模型，
+// 也能把「返回了非归一化向量」「只返回一行」这类问题钉住。
+//
+// 默认 engine 会强制 env.allowRemoteModels = false：验证过程绝不能偷偷下载模型，
+// 否则「验证」本身就成了一个新的网络依赖点。
+//
+// @module dsh-mneme/runtime/verify
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
+import { TRANSFORMERS_ENTRY, describePayload } from "./layout.js";
+
+/** 默认探针文本：中英各一条，避免只覆盖单字节语种。 */
+export const DEFAULT_PROBE_TEXTS = ["猫咪喜欢晒太阳", "the quick brown fox"];
+/** 默认模型，与 src/config.js 的 localEmbedModel 默认值一致。 */
+export const DEFAULT_PROBE_MODEL = "Xenova/bge-small-zh-v1.5";
+/** L2 归一化的容忍度（我们显式请求了 normalize: true）。 */
+const NORM_TOLERANCE = 0.01;
+/** 判定「退化向量」的余弦上限：两条毫不相干的文本不该几乎同向。 */
+const DEGENERATE_COS = 0.999;
+
+/**
+ * 默认 engine：真的去 import 运行时并建一个 feature-extraction 管道。
+ *
+ * 返回一个 `embed(texts) => number[][]`。之所以不返回 transformers 的 tensor，
+ * 是为了把「Tensor 形状怎么读」这种细节留在实现里，验证逻辑只看数字。
+ * @param {string} entryUrl - 入口文件的 file URL。
+ * @param {{cacheDir?: string, model?: string, dtype?: string, device?: string}} opts - 选项。
+ * @returns {Promise<(texts: string[]) => Promise<number[][]>>} 嵌入函数。
+ */
+export async function defaultEngine(entryUrl, { cacheDir, model = DEFAULT_PROBE_MODEL, dtype = "q8", device = "cpu" } = {}) {
+  const mod = await import(entryUrl);
+  const { env, pipeline } = mod;
+  if (cacheDir) {
+    try {
+      env.cacheDir = cacheDir;
+    } catch {
+      /* 老版本可能没有这个字段：忽略，交给下面 pipeline 自己找缓存 */
+    }
+  }
+  // 验证不允许触网：缓存命中就本地加载，命中不了就明确失败。
+  try {
+    env.allowRemoteModels = false;
+  } catch {
+    /* 同上 */
+  }
+  const extractor = await pipeline("feature-extraction", model, { dtype, device, cache_dir: cacheDir });
+  return async (texts) => {
+    const tensor = await extractor(texts, { pooling: "mean", normalize: true });
+    const dims = Array.from(tensor.dims ?? []);
+    const width = dims[dims.length - 1] || 0;
+    const rows = [];
+    for (let i = 0; i < tensor.data.length; i += width) {
+      rows.push(Array.from(tensor.data.subarray(i, i + width)));
+    }
+    return rows;
+  };
+}
+
+/** 向量模长。 */
+function norm(row) {
+  let sum = 0;
+  for (const value of row) sum += value * value;
+  return Math.sqrt(sum);
+}
+
+/** 两行向量的余弦。 */
+function cosine(a, b) {
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+/**
+ * 跑功能验证：真的 import 并嵌入探针文本，然后检查结果的形状与数值性质。
+ *
+ * 任何失败都返回结果对象，不抛异常——验证本身必须是 fail-safe 的，
+ * 否则一条坏运行时会把调用方（面板、状态接口）也带崩。
+ * @param {string} dir - payload 目录。
+ * @param {object} [opts] - 选项。
+ * @returns {Promise<{ok: boolean, reason: string|null, dim: number|null, rows: number, elapsedMs: number}>}
+ */
+export async function verifyFunctional(dir, {
+  engine = defaultEngine,
+  probeTexts = DEFAULT_PROBE_TEXTS,
+  cacheDir,
+  model,
+  dtype,
+  device
+} = {}) {
+  const startedAt = Date.now();
+  const fail = (reason) => ({ ok: false, reason, dim: null, rows: 0, elapsedMs: Date.now() - startedAt });
+
+  const entry = join(dir, TRANSFORMERS_ENTRY);
+  let embed;
+  try {
+    embed = await engine(pathToFileURL(entry).href, { cacheDir, model, dtype, device });
+  } catch (error) {
+    return fail(`加载运行时失败：${error?.message ?? error}`);
+  }
+
+  let rows;
+  try {
+    rows = await embed(probeTexts);
+  } catch (error) {
+    return fail(`推理失败：${error?.message ?? error}`);
+  }
+
+  if (!Array.isArray(rows) || rows.length !== probeTexts.length) {
+    return fail(`返回行数不符：期望 ${probeTexts.length}，实际 ${Array.isArray(rows) ? rows.length : typeof rows}`);
+  }
+  const dim = rows[0]?.length ?? 0;
+  if (dim === 0) return fail("返回了空向量");
+  if (rows.some((row) => row.length !== dim)) return fail("各行维度不一致");
+
+  for (let i = 0; i < rows.length; i++) {
+    const length = norm(rows[i]);
+    if (Math.abs(length - 1) > NORM_TOLERANCE) {
+      return fail(`第 ${i} 行不是 L2 归一化向量（模长 ${length.toFixed(4)}）`);
+    }
+  }
+  if (rows.length >= 2 && Math.abs(cosine(rows[0], rows[1])) > DEGENERATE_COS) {
+    return fail(`嵌入退化：两条不相干文本的余弦为 ${cosine(rows[0], rows[1]).toFixed(4)}`);
+  }
+
+  return { ok: true, reason: null, dim, rows: rows.length, elapsedMs: Date.now() - startedAt };
+}
+
+/**
+ * 三层验证，任何一层失败都如实记录；结构不过就不再做功能验证（省掉一次无谓的加载）。
+ * @param {string} dir - payload 目录。
+ * @param {object} [opts] - 选项。
+ * @param {{status: string, detail?: string}} [opts.integrity] - 调用方算好的完整性结论
+ *   （下载/本地 tarball 路径在解包前比对过 sha512，把结果传进来；收编路径没有可比对
+ *   的原始产物，默认 unverified）。
+ * @returns {Promise<object>} 三件套结果 + 总判定。
+ */
+export async function verifyPayload(dir, {
+  platform = process.platform,
+  engine,
+  probeTexts,
+  cacheDir,
+  model,
+  dtype,
+  device,
+  integrity
+} = {}) {
+  const structural = describePayload(dir, { platform });
+  const integrityResult = integrity
+    ? { ok: integrity.status === "sha512-matched", status: integrity.status, detail: integrity.detail ?? null }
+    : { ok: true, status: "unverified", detail: "该来源没有可比对的原始产物（收编）；如需强校验请用 --strict 走 tarball 通道" };
+
+  const functional = structural.ok
+    ? await verifyFunctional(dir, { engine, probeTexts, cacheDir, model, dtype, device })
+    : { ok: false, reason: "结构检查未通过，跳过功能验证", dim: null, rows: 0, elapsedMs: 0 };
+
+  return {
+    dir,
+    version: structural.version,
+    ok: structural.ok && functional.ok && integrityResult.ok,
+    structural,
+    functional,
+    integrity: integrityResult
+  };
+}

--- a/dsh-mneme/test/config.test.js
+++ b/dsh-mneme/test/config.test.js
@@ -46,5 +46,21 @@ test("startup probe: the reranker module never statically imports transformers/o
     !src.includes('from "@huggingface/transformers"'),
     "no static transformers.js import in reranker.js"
   );
-  assert.match(src, /await import\("@huggingface\/transformers"\)/, "transformers.js loads lazily via dynamic import");
+  // issue #131 之后，懒加载的落点从 reranker 内部搬到了 src/runtime/loader.js
+  // （三层解析：自管 payload → 宿主裸 specifier）。判据随之改成两条，意图不变：
+  // reranker 不得静态导入，且必须经由 loader 间接加载；动态 import 只允许出现在
+  // loader 里（它是唯一知道「运行时从哪来」的模块）。
+  assert.match(src, /from "\.\/runtime\/loader\.js"/, "reranker 经 runtime/loader.js 取运行时");
+  assert.match(src, /loadTransformers\(/, "reranker 必须走三层解析，而不是自己拼 import");
+  assert.ok(
+    !/^\s*import[^\n]*@huggingface\/transformers/m.test(src),
+    "reranker 不允许任何形式的静态 transformers 导入"
+  );
+
+  const loaderSrc = readFileSync(new URL("../src/runtime/loader.js", import.meta.url), "utf8");
+  assert.match(loaderSrc, /import\(specifier\)/, "loader 用动态 import 保持懒加载");
+  assert.ok(
+    !/^\s*import[^\n]*@huggingface\/transformers/m.test(loaderSrc),
+    "loader 不得静态导入 transformers，否则惰性加载就失效了"
+  );
 });

--- a/dsh-mneme/test/runtime-adopt.test.js
+++ b/dsh-mneme/test/runtime-adopt.test.js
@@ -1,0 +1,171 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { adoptRuntime, materializePackage, RUNTIME_MANIFEST_VERSION } from "../lib/runtime/adopt.js";
+import { describePayload, nodeModulesDir, payloadDir, payloadId, runtimeManifestPath } from "../lib/runtime/layout.js";
+import { readJsonSafe } from "../lib/runtime/layout.js";
+
+// 收编（issue #131 / PR-A）：守住「老用户升级后本地嵌入不断」这条底线。
+// 关键判据是——源布局被如实镜像（含嵌套层）、同卷走硬链接、符号链接不跟随、
+// 产出的目录能通过结构检查。
+
+/** 造一份「像真的」源 node_modules：入口 + 三平台单包 + 平台分片 + 嵌套版本冲突。 */
+function makeSource({ withSymlink = false } = {}) {
+  const base = mkdtempSync(join(tmpdir(), "mneme-adopt-src-"));
+  const nm = join(base, "node_modules");
+  const write = (rel, body) => {
+    const full = join(nm, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, body);
+  };
+  const pkg = (rel, manifest) => write(join(rel, "package.json"), JSON.stringify(manifest));
+
+  pkg("@huggingface/transformers", {
+    name: "@huggingface/transformers",
+    version: "4.2.0",
+    dependencies: { "onnxruntime-node": "1.24.3", sharp: "^0.34.5" }
+  });
+  write("@huggingface/transformers/dist/transformers.node.mjs", "export const real = true;\n");
+
+  pkg("onnxruntime-node", { name: "onnxruntime-node", version: "1.24.3", dependencies: { "onnxruntime-common": "1.24.3" } });
+  write("onnxruntime-node/bin/napi-v6/win32/onnxruntime.dll", "dll-bytes\n");
+  write("onnxruntime-node/bin/napi-v6/darwin/arm64/libonnxruntime.dylib", "dylib-bytes\n");
+
+  pkg("onnxruntime-common", { name: "onnxruntime-common", version: "1.24.3" });
+  write("onnxruntime-common/index.js", "export default 1;\n");
+
+  pkg("sharp", { name: "sharp", version: "0.34.5" });
+  write("sharp/index.js", "export default 2;\n");
+
+  if (withSymlink) write("sharp/linked.js", "export default 3;\n");
+
+  return { base, nm, write };
+}
+
+test("收编：镜像源布局（含嵌套层），并写出清单", () => {
+  const { nm } = makeSource();
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  const result = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+
+  assert.equal(result.ok, true, result.reason);
+  assert.equal(result.payloadId, "transformers-4.2.0-node-win32-x64");
+  assert.equal(result.payloadDir, payloadDir(runtimeDir, payloadId({ version: "4.2.0", platform: "win32", arch: "x64" })));
+
+  const manifest = readJsonSafe(runtimeManifestPath(result.payloadDir));
+  assert.equal(manifest.manifestVersion, RUNTIME_MANIFEST_VERSION);
+  assert.equal(manifest.procedure, "adopted");
+  assert.equal(manifest.version, "4.2.0");
+  assert.ok(manifest.packages.some((p) => p.rel === "onnxruntime-node"));
+
+  // 收编产物必须能通过结构检查——这是「adopt 与 layout 契约一致」的整合判据。
+  const report = describePayload(result.payloadDir, { platform: "win32" });
+  assert.equal(report.ok, true, `missing=${report.missing} reasons=${report.reasons}`);
+  assert.equal(report.manifest?.procedure, "adopted");
+});
+
+test("收编：同卷走硬链接（不额外占盘），且文件内容一致", () => {
+  const { nm } = makeSource();
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  const result = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+
+  assert.equal(result.totals.files, result.totals.linked + result.totals.copied, "每个文件要么链接要么复制");
+  assert.ok(result.totals.linked > 0, `同卷应当走硬链接，实际 linked=${result.totals.linked} copied=${result.totals.copied}`);
+  assert.ok(result.totals.bytes > 0);
+  assert.equal(result.manifest.materialize.mode, "hardlink");
+  assert.equal(result.manifest.materialize.linkError, null, "没回退就不该有 linkError");
+
+  const copied = join(nodeModulesDir(result.payloadDir), "onnxruntime-node", "bin", "napi-v6", "win32", "onnxruntime.dll");
+  assert.equal(readJsonSafe(copied), undefined, "非 JSON 内容应当原样搬过来");
+});
+
+test("收编：硬链接不可用时回退复制，并把原因如实记进清单与 warnings", () => {
+  const { nm } = makeSource();
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  // 注入一个必定失败的 linkSync，覆盖「跨卷 / 权限不足」这类本机不可复现的环境差异。
+  const denyLink = () => {
+    const error = new Error("operation not permitted, link");
+    error.code = "EPERM";
+    throw error;
+  };
+  const result = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64", link: denyLink });
+
+  assert.equal(result.ok, true, result.reason);
+  assert.equal(result.totals.linked, 0);
+  assert.equal(result.totals.copied, result.totals.files);
+  assert.equal(result.manifest.materialize.mode, "copy");
+  assert.match(result.manifest.materialize.linkError, /EPERM/);
+  assert.equal(
+    result.manifest.warnings.filter((w) => w.includes("硬链接不可用")).length,
+    1,
+    "同一次收编只该记一条回退原因，不是每个文件记一条"
+  );
+  // 回退之后产物依然必须能通过结构检查——回退不能以正确性为代价。
+  assert.equal(describePayload(result.payloadDir, { platform: "win32" }).ok, true);
+});
+
+test("收编：跳过嵌套 node_modules，避免把同一份包搬两遍", () => {
+  const { nm, write } = makeSource();
+  // 给入口包塞一个嵌套副本：闭包不会把它当作依赖，因此不该被搬进产物。
+  write("@huggingface/transformers/node_modules/orphan/index.js", "orphan\n");
+  write("@huggingface/transformers/node_modules/orphan/package.json", JSON.stringify({ name: "orphan", version: "1.0.0" }));
+
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  const result = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+  assert.equal(result.ok, true, result.reason);
+
+  const orphan = join(nodeModulesDir(result.payloadDir), "@huggingface", "transformers", "node_modules", "orphan");
+  assert.equal(describePayload(result.payloadDir, { platform: "win32" }).ok, true);
+  assert.equal(readJsonSafe(join(orphan, "package.json")), undefined, "不可达的嵌套包不该被搬进来");
+});
+
+test("收编：符号链接不跟随，记进 warnings（isolated 布局的来源会被如实暴露）", (t) => {
+  const { nm, write } = makeSource();
+  const real = join(nm, "sharp", "index.js");
+  const link = join(nm, "sharp", "linked.js");
+  try {
+    symlinkSync(real, link, "file");
+  } catch {
+    t.skip("当前环境不允许创建符号链接（Windows 需要开发者模式），跳过该断言");
+    return;
+  }
+  assert.ok(write);
+
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  const result = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+  assert.equal(result.totals.symlinks, 1);
+  assert.ok(result.manifest.warnings.some((w) => w.includes("符号链接")));
+});
+
+test("收编：目标已存在时默认拒绝，overwrite 才覆盖", () => {
+  const { nm } = makeSource();
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  const first = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+  assert.equal(first.ok, true);
+
+  const again = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+  assert.equal(again.ok, false);
+  assert.match(again.reason, /目标已存在/);
+
+  const forced = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64", overwrite: true });
+  assert.equal(forced.ok, true);
+});
+
+test("收编：源里没有入口包时给出可读原因，不抛异常", () => {
+  const empty = mkdtempSync(join(tmpdir(), "mneme-adopt-empty-"));
+  mkdirSync(join(empty, "node_modules"), { recursive: true });
+  const result = adoptRuntime({ fromModulesDir: join(empty, "node_modules") });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /入口包不存在|入口包未解析到/);
+});
+
+test("materializePackage：统计文件与字节数，返回自身可测", () => {
+  const { base } = makeSource();
+  const src = join(base, "node_modules", "onnxruntime-common");
+  const dest = mkdtempSync(join(tmpdir(), "mneme-materialize-"));
+  const stats = materializePackage({ srcDir: src, destDir: join(dest, "pkg") });
+  assert.equal(stats.files, 2, "package.json + index.js");
+  assert.ok(stats.bytes > 0);
+  assert.equal(stats.symlinks, 0);
+});

--- a/dsh-mneme/test/runtime-adopt.test.js
+++ b/dsh-mneme/test/runtime-adopt.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { adoptRuntime, materializePackage, RUNTIME_MANIFEST_VERSION } from "../lib/runtime/adopt.js";
@@ -30,7 +30,7 @@ function makeSource({ withSymlink = false } = {}) {
   write("@huggingface/transformers/dist/transformers.node.mjs", "export const real = true;\n");
 
   pkg("onnxruntime-node", { name: "onnxruntime-node", version: "1.24.3", dependencies: { "onnxruntime-common": "1.24.3" } });
-  write("onnxruntime-node/bin/napi-v6/win32/onnxruntime.dll", "dll-bytes\n");
+  write("onnxruntime-node/bin/napi-v6/win32/x64/onnxruntime.dll", "dll-bytes\n");
   write("onnxruntime-node/bin/napi-v6/darwin/arm64/libonnxruntime.dylib", "dylib-bytes\n");
 
   pkg("onnxruntime-common", { name: "onnxruntime-common", version: "1.24.3" });
@@ -60,7 +60,7 @@ test("收编：镜像源布局（含嵌套层），并写出清单", () => {
   assert.ok(manifest.packages.some((p) => p.rel === "onnxruntime-node"));
 
   // 收编产物必须能通过结构检查——这是「adopt 与 layout 契约一致」的整合判据。
-  const report = describePayload(result.payloadDir, { platform: "win32" });
+  const report = describePayload(result.payloadDir, { platform: "win32", arch: "x64" });
   assert.equal(report.ok, true, `missing=${report.missing} reasons=${report.reasons}`);
   assert.equal(report.manifest?.procedure, "adopted");
 });
@@ -76,7 +76,7 @@ test("收编：同卷走硬链接（不额外占盘），且文件内容一致",
   assert.equal(result.manifest.materialize.mode, "hardlink");
   assert.equal(result.manifest.materialize.linkError, null, "没回退就不该有 linkError");
 
-  const copied = join(nodeModulesDir(result.payloadDir), "onnxruntime-node", "bin", "napi-v6", "win32", "onnxruntime.dll");
+  const copied = join(nodeModulesDir(result.payloadDir), "onnxruntime-node", "bin", "napi-v6", "win32", "x64", "onnxruntime.dll");
   assert.equal(readJsonSafe(copied), undefined, "非 JSON 内容应当原样搬过来");
 });
 
@@ -102,7 +102,7 @@ test("收编：硬链接不可用时回退复制，并把原因如实记进清�
     "同一次收编只该记一条回退原因，不是每个文件记一条"
   );
   // 回退之后产物依然必须能通过结构检查——回退不能以正确性为代价。
-  assert.equal(describePayload(result.payloadDir, { platform: "win32" }).ok, true);
+  assert.equal(describePayload(result.payloadDir, { platform: "win32", arch: "x64" }).ok, true);
 });
 
 test("收编：跳过嵌套 node_modules，避免把同一份包搬两遍", () => {
@@ -116,7 +116,7 @@ test("收编：跳过嵌套 node_modules，避免把同一份包搬两遍", () =
   assert.equal(result.ok, true, result.reason);
 
   const orphan = join(nodeModulesDir(result.payloadDir), "@huggingface", "transformers", "node_modules", "orphan");
-  assert.equal(describePayload(result.payloadDir, { platform: "win32" }).ok, true);
+  assert.equal(describePayload(result.payloadDir, { platform: "win32", arch: "x64" }).ok, true);
   assert.equal(readJsonSafe(join(orphan, "package.json")), undefined, "不可达的嵌套包不该被搬进来");
 });
 
@@ -168,4 +168,39 @@ test("materializePackage：统计文件与字节数，返回自身可测", () =>
   assert.equal(stats.files, 2, "package.json + index.js");
   assert.ok(stats.bytes > 0);
   assert.equal(stats.symlinks, 0);
+});
+
+test("覆盖收编：先清空目标目录，否则硬链接全部退化成复制、残留文件也清不掉", () => {
+  const { nm } = makeSource();
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  const first = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64" });
+  assert.equal(first.ok, true, first.reason);
+  assert.equal(first.manifest.materialize.mode, "hardlink");
+
+  // 只可能来自上一次收编的残留文件：覆盖时必须被清掉。
+  const stale = join(first.payloadDir, "stale-from-previous-run");
+  writeFileSync(stale, "stale\n");
+
+  const second = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64", overwrite: true });
+  assert.equal(second.ok, true, second.reason);
+  // 不清空目标目录的话，linkSync 对已存在的目标路径抛 EEXIST，每个文件都掉进复制分支：
+  // 物化方式会假报成 copy，warnings 会错说「硬链接不可用」，整份闭包真实占盘。
+  assert.equal(second.manifest.materialize.mode, "hardlink", "覆盖不该把硬链接降级成复制");
+  assert.equal(second.manifest.materialize.linkError, null);
+  assert.equal(existsSync(stale), false, "上一次收编的残留文件必须被清掉");
+});
+
+test("截断的闭包必须拒绝：宁可明确失败，也不要产出一份看起来可用的运行时", () => {
+  const { nm } = makeSource();
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-adopt-dst-"));
+  // 上限 1 个包，必然截断传递依赖。结构检查只看必需包/版本/入口，所以这种残缺 payload
+  // 本来会被判为可用、被 loader 选中，然后在 import 原生模块时才炸。
+  const result = adoptRuntime({ fromModulesDir: nm, runtimeDir, platform: "win32", arch: "x64", maxPackages: 1 });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /截断/);
+  assert.equal(
+    existsSync(payloadDir(runtimeDir, payloadId({ version: "4.2.0", platform: "win32", arch: "x64" }))),
+    false,
+    "拒绝时不该留下半份 payload"
+  );
 });

--- a/dsh-mneme/test/runtime-cli.test.js
+++ b/dsh-mneme/test/runtime-cli.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// 这个 CLI 脚本原先不在任何测试覆盖里：USAGE 模板字面量里多一个反引号就能让它整体语法错误，
+// 而 CI 依然全绿 —— package.json 的 `test` 只跑 test/*.test.js，从不碰 scripts/。踩过一次。
+//
+// 这里动态 import 它：解析与求值都会真的发生，任何语法错都会让下面的测试直接炸。
+// 脚本侧有 invokedDirectly 守卫，所以 import 不会顺带跑起 CLI。
+const cli = await import("../scripts/mneme-runtime.mjs");
+
+test("CLI 脚本能被解析并求值（语法错必须在这里现形，而不是发布出去）", () => {
+  assert.equal(typeof cli.main, "function");
+  assert.equal(typeof cli.parseArgs, "function");
+  assert.equal(typeof cli.UsageError, "function");
+});
+
+test("CLI：--key value 与 --flag 各自解析正确", () => {
+  assert.deepEqual(cli.parseArgs(["--runtime", "/rt", "--from", "/nm", "--json"]), {
+    runtime: "/rt",
+    from: "/nm",
+    json: true
+  });
+  assert.deepEqual(cli.parseArgs(["--overwrite"]), { overwrite: true });
+  assert.deepEqual(cli.parseArgs([]), {});
+});
+
+test("CLI：带值选项缺值必须是用法错误 —— 不能把 \"true\" 当路径用下去", () => {
+  for (const key of ["runtime", "from", "cache-dir"]) {
+    assert.throws(() => cli.parseArgs([`--${key}`]), cli.UsageError, `--${key} 缺值应当报用法错误`);
+    // 后面紧跟另一个选项同样算缺值：不能把这个选项吞成上一个选项的值。
+    assert.throws(() => cli.parseArgs([`--${key}`, "--json"]), cli.UsageError, `--${key} 后接选项也算缺值`);
+  }
+});
+
+test("CLI：未知选项立刻报错，而不是静默忽略（打错字要立刻可见）", () => {
+  assert.throws(() => cli.parseArgs(["--runtim", "/rt"]), cli.UsageError);
+  assert.throws(() => cli.parseArgs(["-h"]), cli.UsageError);
+  assert.throws(() => cli.parseArgs(["/rt"]), cli.UsageError);
+});

--- a/dsh-mneme/test/runtime-cli.test.js
+++ b/dsh-mneme/test/runtime-cli.test.js
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // 这个 CLI 脚本原先不在任何测试覆盖里：USAGE 模板字面量里多一个反引号就能让它整体语法错误，
 // 而 CI 依然全绿 —— package.json 的 `test` 只跑 test/*.test.js，从不碰 scripts/。踩过一次。
@@ -36,4 +39,84 @@ test("CLI：未知选项立刻报错，而不是静默忽略（打错字要立�
   assert.throws(() => cli.parseArgs(["--runtim", "/rt"]), cli.UsageError);
   assert.throws(() => cli.parseArgs(["-h"]), cli.UsageError);
   assert.throws(() => cli.parseArgs(["/rt"]), cli.UsageError);
+});
+
+/** 捕获 console.log，用来断言 CLI 打印给用户的那几行。 */
+async function captureLog(fn) {
+  const original = console.log;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    return { value: await fn(), text: lines.join("\n") };
+  } finally {
+    console.log = original;
+  }
+}
+
+/**
+ * 造一个最小可收编的源 node_modules。
+ *
+ * transformers 必须把 onnxruntime-node / sharp 声明成自己的依赖，闭包计划才会收它们 ——
+ * 否则 payload 里不会有这两个包，结构检查会因为「缺必需包」而失败，测的就不是下面这件事了。
+ *
+ * withMissingDep=true 时再声明一个装不上的必需依赖：planClosure 会记一条 gap，
+ * 而 describePayload 只看那三个必需包 —— 这正是「结构说通过、闭包其实缺件」的场景。
+ */
+function makeAdoptSource({ withMissingDep = false } = {}) {
+  const base = mkdtempSync(join(tmpdir(), "mneme-cli-src-"));
+  const nm = join(base, "node_modules");
+  const write = (rel, body) => {
+    const full = join(nm, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, body);
+  };
+  const dependencies = {
+    "onnxruntime-node": "^1.24.3",
+    sharp: "^0.34.5",
+    ...(withMissingDep ? { "definitely-not-installed-pkg": "^1.0.0" } : {})
+  };
+  write(
+    "@huggingface/transformers/package.json",
+    JSON.stringify({ name: "@huggingface/transformers", version: "4.2.0", dependencies })
+  );
+  write("@huggingface/transformers/dist/transformers.node.mjs", "export const x = 1;\n");
+  write("onnxruntime-node/package.json", JSON.stringify({ name: "onnxruntime-node", version: "1.24.3" }));
+  write("sharp/package.json", JSON.stringify({ name: "sharp", version: "0.34.5" }));
+  // 结构检查点名到平台 + 架构，夹具必须照真实布局建，且要用「本机」平台，否则 CI 上必挂。
+  mkdirSync(join(nm, "onnxruntime-node", "bin", "napi-v6", process.platform, process.arch), { recursive: true });
+  return { nm, runtimeDir: mkdtempSync(join(tmpdir(), "mneme-cli-dst-")) };
+}
+
+test("CLI adopt：源里没有入口包时给出干净原因，不能抛 TypeError（评审阻塞项）", async () => {
+  const empty = mkdtempSync(join(tmpdir(), "mneme-cli-empty-"));
+  mkdirSync(join(empty, "node_modules"), { recursive: true });
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-cli-dst-"));
+  // 修之前这里会抛：adoptRuntime 失败时不带 payloadDir，却被当成路径喂给 describePayload。
+  const { value, text } = await captureLog(() =>
+    cli.runAdopt({ runtimeDir, asJson: false, options: { from: join(empty, "node_modules") } })
+  );
+  assert.equal(value, 1);
+  assert.match(text, /收编失败：/, `应当打印干净原因，实际输出：${text}`);
+  assert.match(text, /入口包/);
+});
+
+test("CLI adopt：必需传递依赖缺口必须让退出码变红（评审阻塞项）", async () => {
+  const src = makeAdoptSource({ withMissingDep: true });
+  const { value, text } = await captureLog(() =>
+    cli.runAdopt({ runtimeDir: src.runtimeDir, asJson: false, options: { from: src.nm } })
+  );
+  // 结构检查会「通过」——它只看三个必需包；缺口只有闭包计划知道。
+  assert.match(text, /结构检查：通过/);
+  assert.match(text, /缺失依赖：definitely-not-installed-pkg/);
+  assert.match(text, /闭包完整性：未通过/);
+  assert.equal(value, 1, "闭包缺件时退出码必须是 1，否则脚本化 gate 会在最需要它的时候误报健康");
+});
+
+test("CLI adopt：闭包完整时仍然报 0（防止上面那条修复过度触发）", async () => {
+  const src = makeAdoptSource({ withMissingDep: false });
+  const { value, text } = await captureLog(() =>
+    cli.runAdopt({ runtimeDir: src.runtimeDir, asJson: false, options: { from: src.nm } })
+  );
+  assert.match(text, /结构检查：通过/);
+  assert.equal(value, 0, text);
 });

--- a/dsh-mneme/test/runtime-closure.test.js
+++ b/dsh-mneme/test/runtime-closure.test.js
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DEFAULT_MAX_PACKAGES, matchesPlatform, planClosure, resolvePackageDir } from "../lib/runtime/closure.js";
+
+// 依赖闭包遍历（issue #131 / PR-A）：守住四条判据——按源布局镜像、平台过滤、
+// 可选依赖缺失不算错、peer 不进闭包。它是 adopt / export 的共同地基，
+// 走错一步就会把宿主整棵树拖进来（或漏带一个真需要的包）。
+
+/** 从 rel 路径推导包名（处理 scope 与嵌套 node_modules）。 */
+function nameFromRel(rel) {
+  const parts = rel.split("/");
+  const i = parts.lastIndexOf("node_modules");
+  return (i === -1 ? parts : parts.slice(i + 1)).join("/");
+}
+
+/** 按紧凑的 spec 造一棵假的 node_modules 树。 */
+function makeTree(spec) {
+  const base = mkdtempSync(join(tmpdir(), "mneme-closure-"));
+  // 刻意多套一层 proj/：这样「不允许解析越出源树」这条判据才测得出来
+  // （源树的上一级就是 base，base/node_modules 里的包必须解析不到）。
+  const nm = join(base, "proj", "node_modules");
+  mkdirSync(nm, { recursive: true });
+  for (const [rel, def = {}] of Object.entries(spec)) {
+    const dir = join(nm, rel);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: def.name ?? nameFromRel(rel),
+        version: def.version ?? "1.0.0",
+        ...(def.deps ? { dependencies: def.deps } : {}),
+        ...(def.optional ? { optionalDependencies: def.optional } : {}),
+        ...(def.peers ? { peerDependencies: def.peers } : {}),
+        ...(def.os ? { os: def.os } : {}),
+        ...(def.cpu ? { cpu: def.cpu } : {})
+      })
+    );
+  }
+  return { base, nm };
+}
+
+/**
+ * 一份贴近真实的树：transformers 是入口，它同时带 onnxruntime-node（多平台单包）、
+ * onnxruntime-web（自带一份不同版本的 onnxruntime-common）、sharp（平台分片走
+ * optionalDependencies），外加 peer、环、缺件四种边界。
+ */
+function realisticTree() {
+  return makeTree({
+    "@huggingface/transformers": {
+      version: "4.2.0",
+      deps: {
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev",
+        sharp: "^0.34.5",
+        "@huggingface/tokenizers": "^0.1.3",
+        "@huggingface/jinja": "^0.5.6",
+        "darwin-only-pkg": "1.0.0"
+      },
+      peers: { "@deepseek-ai/cordis": "^4.0.1" }
+    },
+    "onnxruntime-node": { version: "1.24.3", deps: { "onnxruntime-common": "1.24.3", "adm-zip": "^0.5.16" } },
+    "onnxruntime-web": {
+      version: "1.26.0-dev",
+      deps: { "onnxruntime-common": "1.24.0-dev" }
+    },
+    "onnxruntime-web/node_modules/onnxruntime-common": { version: "1.24.0-dev" },
+    "onnxruntime-common": { version: "1.24.3" },
+    "adm-zip": { deps: { "global-agent": "^3.0.0" } },
+    "global-agent": { deps: { "adm-zip": "^0.5.16" } },
+    sharp: { version: "0.34.5", optional: { "@img/sharp-win32-x64": "0.34.5", "@img/sharp-darwin-arm64": "0.34.5" } },
+    "@img/sharp-win32-x64": { version: "0.34.5", os: ["win32"], cpu: ["x64"] },
+    "@img/sharp-darwin-arm64": { version: "0.34.5", os: ["darwin"], cpu: ["arm64"] },
+    "@huggingface/tokenizers": { version: "0.1.3", optional: { "not-installed-optional": "^1.0.0" } },
+    "@huggingface/jinja": { version: "0.5.6", deps: { "missing-required-thing": "^1.0.0" } },
+    "darwin-only-pkg": { os: ["darwin"] },
+    // 只在 root 之外存在，用来验证解析不会越出源树
+    "@deepseek-ai/cordis": { version: "4.0.2" }
+  });
+}
+
+test("按源布局镜像：嵌套的那份依赖与原位版本都被保留", () => {
+  const { nm } = realisticTree();
+  const plan = planClosure({ rootModulesDir: nm, platform: "win32", arch: "x64" });
+  const byRel = new Map(plan.packages.map((p) => [p.rel, p]));
+
+  assert.equal(byRel.get("@huggingface/transformers")?.version, "4.2.0");
+  assert.equal(byRel.get("onnxruntime-common")?.version, "1.24.3", "顶层那份");
+  assert.equal(
+    byRel.get("onnxruntime-web/node_modules/onnxruntime-common")?.version,
+    "1.24.0-dev",
+    "嵌套那份必须按原层级保留，否则解析结果会被悄悄改掉"
+  );
+  assert.equal(plan.gaps.filter((g) => g.reason === "必需依赖未找到").length, 1);
+  assert.deepEqual(plan.gaps[0], { name: "missing-required-thing", from: "@huggingface/jinja", reason: "必需依赖未找到" });
+});
+
+test("平台分片包：只带当前平台的，另一个记进 skipped", () => {
+  const { nm } = realisticTree();
+  const plan = planClosure({ rootModulesDir: nm, platform: "win32", arch: "x64" });
+  const rels = plan.packages.map((p) => p.rel);
+  assert.ok(rels.includes("@img/sharp-win32-x64"));
+  assert.equal(rels.includes("@img/sharp-darwin-arm64"), false, "darwin 分片不该进闭包");
+  assert.deepEqual(
+    plan.skipped.map((s) => s.rel).sort(),
+    ["@img/sharp-darwin-arm64", "darwin-only-pkg"].sort(),
+    "两个平台不匹配的包都该被记下来"
+  );
+  // 交叉验证：换成 darwin/arm64 时，该带的是另外那个。
+  const darwin = planClosure({ rootModulesDir: nm, platform: "darwin", arch: "arm64" });
+  const darwinRels = darwin.packages.map((p) => p.rel);
+  assert.ok(darwinRels.includes("@img/sharp-darwin-arm64"));
+  assert.equal(darwinRels.includes("@img/sharp-win32-x64"), false);
+});
+
+test("peerDependencies 不进闭包（宿主提供的东西不该被复制进来）", () => {
+  const { nm } = realisticTree();
+  const plan = planClosure({ rootModulesDir: nm, platform: "win32", arch: "x64" });
+  assert.equal(plan.packages.some((p) => p.rel === "@deepseek-ai/cordis"), false);
+});
+
+test("可选依赖缺失不算错，必需依赖缺失才记 gap", () => {
+  const { nm } = realisticTree();
+  const plan = planClosure({ rootModulesDir: nm, platform: "win32", arch: "x64" });
+  assert.equal(plan.gaps.some((g) => g.name === "not-installed-optional"), false);
+  assert.equal(plan.gaps.filter((g) => g.name === "missing-required-thing").length, 1);
+  // 平台分片包在别的平台上缺席，同样不算 gap
+  assert.equal(plan.gaps.some((g) => g.name === "@img/sharp-darwin-arm64"), false);
+});
+
+test("依赖成环也能终止，且每个包只出现一次", () => {
+  const { nm } = realisticTree();
+  const plan = planClosure({ rootModulesDir: nm, platform: "win32", arch: "x64" });
+  const rels = plan.packages.map((p) => p.rel);
+  assert.equal(rels.filter((r) => r === "adm-zip").length, 1);
+  assert.equal(rels.filter((r) => r === "global-agent").length, 1);
+});
+
+test("条目上限命中时截断并如实上报，不静默丢包", () => {
+  const { nm } = realisticTree();
+  const plan = planClosure({ rootModulesDir: nm, platform: "win32", arch: "x64", maxPackages: 3 });
+  assert.equal(plan.truncated, true);
+  assert.equal(plan.packages.length, 3);
+  assert.ok(DEFAULT_MAX_PACKAGES >= 100, "默认上限应当足够容纳真实闭包");
+});
+
+test("入口包不存在：只记一条 gap，不抛异常", () => {
+  const { nm } = makeTree({});
+  const plan = planClosure({ rootModulesDir: nm, entry: "@huggingface/transformers" });
+  assert.deepEqual(plan.packages, []);
+  assert.equal(plan.gaps.length, 1);
+  assert.match(plan.gaps[0].reason, /入口包不存在/);
+});
+
+test("resolvePackageDir：优先取最近的一层，且绝不越出源树", () => {
+  const { nm } = realisticTree();
+  const web = join(nm, "onnxruntime-web");
+  const nested = resolvePackageDir(web, "onnxruntime-common", nm);
+  assert.equal(nested, join(nm, "onnxruntime-web", "node_modules", "onnxruntime-common"), "就近优先");
+  assert.equal(resolvePackageDir(web, "adm-zip", nm), join(nm, "adm-zip"), "回退到顶层");
+  assert.equal(resolvePackageDir(nm, "definitely-not-there", nm), null);
+
+  // root 之外存在同名包时也不能解析到它——否则闭包就不是自包含的。
+  const outside = join(dirname(dirname(nm)), "node_modules", "outside-only-pkg");
+  mkdirSync(outside, { recursive: true });
+  writeFileSync(join(outside, "package.json"), JSON.stringify({ name: "outside-only-pkg", version: "1.0.0" }));
+  assert.equal(resolvePackageDir(nm, "outside-only-pkg", nm), null, "源树之外的包不该被解析进来");
+});
+
+test("matchesPlatform 支持正向与 `!` 反向两种写法，缺省表示不限", () => {
+  assert.equal(matchesPlatform({}, "win32", "x64"), true);
+  assert.equal(matchesPlatform({ os: ["win32"] }, "win32", "x64"), true);
+  assert.equal(matchesPlatform({ os: ["win32"] }, "darwin", "arm64"), false);
+  assert.equal(matchesPlatform({ os: ["!darwin"] }, "win32", "x64"), true);
+  assert.equal(matchesPlatform({ os: ["!darwin"] }, "darwin", "arm64"), false);
+  assert.equal(matchesPlatform({ cpu: ["x64"] }, "win32", "arm64"), false);
+});

--- a/dsh-mneme/test/runtime-layout.test.js
+++ b/dsh-mneme/test/runtime-layout.test.js
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  RUNTIME_MANIFEST,
+  TRANSFORMERS_ENTRY,
+  defaultRuntimeDir,
+  describePayload,
+  listPayloadDirs,
+  nodeModulesDir,
+  payloadDir,
+  payloadId,
+  runtimeManifestPath,
+  transformersVersionOk
+} from "../lib/runtime/layout.js";
+
+// 运行时目录契约（issue #131 / PR-A）：这里守住的是「结构检查能不能准确地
+// 指出缺了什么」。功能验证（真 import 并跑推理）不在本文件覆盖范围，
+// 由后续的 verify 模块负责。
+
+/**
+ * 造一份假的 payload。默认是一个「完整可用」的形态，各选项用来单独破坏一处，
+ * 这样每个用例只验证一条判据。
+ */
+function makePayload({
+  version = "4.2.0",
+  platform = "win32",
+  arch = "x64",
+  packages = ["@huggingface/transformers", "onnxruntime-node", "sharp"],
+  withEntry = true,
+  nodePlatform = platform,
+  withManifest = false
+} = {}) {
+  const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-runtime-"));
+  const dir = payloadDir(runtimeDir, payloadId({ version, platform, arch }));
+  const nm = nodeModulesDir(dir);
+
+  for (const name of packages) {
+    const pkgDir = join(nm, name);
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name, version: name === "@huggingface/transformers" ? version : "1.0.0" })
+    );
+  }
+
+  if (withEntry) {
+    const entry = join(dir, TRANSFORMERS_ENTRY);
+    mkdirSync(dirname(entry), { recursive: true });
+    writeFileSync(entry, "// 占位：真实运行时这里是可被 import 的 ESM 入口\n");
+  }
+
+  if (nodePlatform && packages.includes("onnxruntime-node")) {
+    mkdirSync(join(nm, "onnxruntime-node", "bin", "napi-v6", nodePlatform), { recursive: true });
+  }
+
+  if (withManifest) {
+    writeFileSync(
+      runtimeManifestPath(dir),
+      JSON.stringify({ payloadId: payloadId({ version, platform, arch }), procedure: "adopted" })
+    );
+  }
+
+  return { runtimeDir, dir };
+}
+
+test("payloadId 带版本、平台与架构，多份可共存", () => {
+  assert.equal(payloadId({ version: "4.2.0", platform: "win32", arch: "x64" }), "transformers-4.2.0-node-win32-x64");
+  assert.equal(payloadId({ version: "4.3.1", platform: "darwin", arch: "arm64" }), "transformers-4.3.1-node-darwin-arm64");
+});
+
+test("运行时根目录默认挂在 ~/.dsh/mneme/runtime 下", () => {
+  assert.equal(defaultRuntimeDir("/home/u"), join("/home/u", ".dsh", "mneme", "runtime"));
+});
+
+test("transformersVersionOk 只认 >=4.2.0 <5", () => {
+  assert.equal(transformersVersionOk("4.2.0"), true);
+  assert.equal(transformersVersionOk("4.10.3"), true);
+  assert.equal(transformersVersionOk("4.2.0-rc.1"), true, "预发布后缀按主版本号判断即可");
+  assert.equal(transformersVersionOk("4.1.9"), false);
+  assert.equal(transformersVersionOk("5.0.0"), false);
+  assert.equal(transformersVersionOk("garbage"), false);
+  assert.equal(transformersVersionOk(undefined), false);
+});
+
+test("完整的 payload：结构检查通过，且不报任何缺件", () => {
+  const { dir } = makePayload({ withManifest: true });
+  const report = describePayload(dir, { platform: "win32" });
+  assert.equal(report.ok, true, `不应有失败：missing=${report.missing} reasons=${report.reasons}`);
+  assert.deepEqual(report.missing, []);
+  assert.deepEqual(report.reasons, []);
+  assert.equal(report.version, "4.2.0");
+  assert.equal(report.manifest?.procedure, "adopted");
+});
+
+test("目录不存在（没装过）时给出可读原因，而不是抛异常", () => {
+  const { runtimeDir } = makePayload();
+  const report = describePayload(join(runtimeDir, "transformers-9.9.9-node-win32-x64"), { platform: "win32" });
+  assert.equal(report.ok, false);
+  assert.equal(report.missing.length, 0);
+  assert.match(report.reasons.join("\n"), /node_modules 不存在/);
+});
+
+test("缺入口文件时点名入口本身", () => {
+  const { dir } = makePayload({ withEntry: false });
+  const report = describePayload(dir, { platform: "win32" });
+  assert.equal(report.ok, false);
+  assert.ok(report.missing.includes(TRANSFORMERS_ENTRY), `missing=${JSON.stringify(report.missing)}`);
+});
+
+test("缺必需包时逐个点名", () => {
+  const { dir } = makePayload({ packages: ["@huggingface/transformers"] });
+  const report = describePayload(dir, { platform: "win32" });
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.missing.includes("onnxruntime-node"), true);
+  assert.deepEqual(report.missing.includes("sharp"), true);
+  // 包整个不在时，不应再额外抱怨平台子树——否则同一件事会被报两次。
+  assert.equal(report.reasons.some((r) => r.includes("平台")), false);
+});
+
+test("onnxruntime-node 在，但缺少当前平台的二进制子树：报平台原因（裁剪/搬运最常见的错）", () => {
+  const { dir } = makePayload({ nodePlatform: "darwin" });
+  const report = describePayload(dir, { platform: "win32" });
+  assert.equal(report.ok, false);
+  assert.equal(report.missing.length, 0, "包都在，不该算缺件");
+  assert.match(report.reasons.join("\n"), /win32 平台的二进制子树/);
+});
+
+test("版本落在认可区间之外：结构不缺件，但要报版本原因", () => {
+  const { dir } = makePayload({ version: "5.0.0" });
+  const report = describePayload(dir, { platform: "win32" });
+  assert.equal(report.ok, false);
+  assert.equal(report.missing.length, 0);
+  assert.match(report.reasons.join("\n"), /不在认可区间/);
+  assert.equal(report.version, "5.0.0");
+});
+
+test("listPayloadDirs 只列目录、名称排序，且对不存在的根目录返回空数组", () => {
+  const { runtimeDir } = makePayload();
+  makePayload();
+  assert.deepEqual(listPayloadDirs(join(runtimeDir, "nope")), []);
+  assert.deepEqual(listPayloadDirs(runtimeDir), ["transformers-4.2.0-node-win32-x64"]);
+});
+
+test("清单文件名与路径稳定（契约的一部分）", () => {
+  assert.equal(RUNTIME_MANIFEST, "mneme-runtime.json");
+  assert.equal(runtimeManifestPath("/rt/p"), join("/rt/p", "mneme-runtime.json"));
+});

--- a/dsh-mneme/test/runtime-layout.test.js
+++ b/dsh-mneme/test/runtime-layout.test.js
@@ -31,6 +31,7 @@ function makePayload({
   packages = ["@huggingface/transformers", "onnxruntime-node", "sharp"],
   withEntry = true,
   nodePlatform = platform,
+  nodeArch = arch,
   withManifest = false
 } = {}) {
   const runtimeDir = mkdtempSync(join(tmpdir(), "mneme-runtime-"));
@@ -53,7 +54,8 @@ function makePayload({
   }
 
   if (nodePlatform && packages.includes("onnxruntime-node")) {
-    mkdirSync(join(nm, "onnxruntime-node", "bin", "napi-v6", nodePlatform), { recursive: true });
+    // 真实包结构是 bin/napi-v6/<平台>/<架构>/，夹具必须照做，否则测不到架构这一层。
+    mkdirSync(join(nm, "onnxruntime-node", "bin", "napi-v6", nodePlatform, nodeArch), { recursive: true });
   }
 
   if (withManifest) {
@@ -87,7 +89,7 @@ test("transformersVersionOk 只认 >=4.2.0 <5", () => {
 
 test("完整的 payload：结构检查通过，且不报任何缺件", () => {
   const { dir } = makePayload({ withManifest: true });
-  const report = describePayload(dir, { platform: "win32" });
+  const report = describePayload(dir, { platform: "win32", arch: "x64" });
   assert.equal(report.ok, true, `不应有失败：missing=${report.missing} reasons=${report.reasons}`);
   assert.deepEqual(report.missing, []);
   assert.deepEqual(report.reasons, []);
@@ -97,7 +99,7 @@ test("完整的 payload：结构检查通过，且不报任何缺件", () => {
 
 test("目录不存在（没装过）时给出可读原因，而不是抛异常", () => {
   const { runtimeDir } = makePayload();
-  const report = describePayload(join(runtimeDir, "transformers-9.9.9-node-win32-x64"), { platform: "win32" });
+  const report = describePayload(join(runtimeDir, "transformers-9.9.9-node-win32-x64"), { platform: "win32", arch: "x64" });
   assert.equal(report.ok, false);
   assert.equal(report.missing.length, 0);
   assert.match(report.reasons.join("\n"), /node_modules 不存在/);
@@ -105,14 +107,14 @@ test("目录不存在（没装过）时给出可读原因，而不是抛异常",
 
 test("缺入口文件时点名入口本身", () => {
   const { dir } = makePayload({ withEntry: false });
-  const report = describePayload(dir, { platform: "win32" });
+  const report = describePayload(dir, { platform: "win32", arch: "x64" });
   assert.equal(report.ok, false);
   assert.ok(report.missing.includes(TRANSFORMERS_ENTRY), `missing=${JSON.stringify(report.missing)}`);
 });
 
 test("缺必需包时逐个点名", () => {
   const { dir } = makePayload({ packages: ["@huggingface/transformers"] });
-  const report = describePayload(dir, { platform: "win32" });
+  const report = describePayload(dir, { platform: "win32", arch: "x64" });
   assert.equal(report.ok, false);
   assert.deepEqual(report.missing.includes("onnxruntime-node"), true);
   assert.deepEqual(report.missing.includes("sharp"), true);
@@ -122,15 +124,26 @@ test("缺必需包时逐个点名", () => {
 
 test("onnxruntime-node 在，但缺少当前平台的二进制子树：报平台原因（裁剪/搬运最常见的错）", () => {
   const { dir } = makePayload({ nodePlatform: "darwin" });
-  const report = describePayload(dir, { platform: "win32" });
+  const report = describePayload(dir, { platform: "win32", arch: "x64" });
   assert.equal(report.ok, false);
   assert.equal(report.missing.length, 0, "包都在，不该算缺件");
-  assert.match(report.reasons.join("\n"), /win32 平台的二进制子树/);
+  assert.match(report.reasons.join("\n"), /win32\/x64 的二进制子树/);
+});
+
+test("同平台但架构不符必须拒绝：linux-arm64 的 payload 不能在 linux-x64 上通过", () => {
+  // 真实包内是 bin/napi-v6/{darwin,linux,win32}/{arm64,x64}，只查平台会让架构不符的
+  // payload 通过结构检查、被 loader 选中，然后在 import 原生模块时才失败。
+  const { dir } = makePayload({ platform: "linux", arch: "arm64" });
+  assert.equal(describePayload(dir, { platform: "linux", arch: "arm64" }).ok, true, "同架构应当通过");
+  const mismatched = describePayload(dir, { platform: "linux", arch: "x64" });
+  assert.equal(mismatched.ok, false, "架构不符必须不通过");
+  assert.equal(mismatched.missing.length, 0, "包都在，不该算缺件");
+  assert.match(mismatched.reasons.join("\n"), /linux\/x64 的二进制子树/);
 });
 
 test("版本落在认可区间之外：结构不缺件，但要报版本原因", () => {
   const { dir } = makePayload({ version: "5.0.0" });
-  const report = describePayload(dir, { platform: "win32" });
+  const report = describePayload(dir, { platform: "win32", arch: "x64" });
   assert.equal(report.ok, false);
   assert.equal(report.missing.length, 0);
   assert.match(report.reasons.join("\n"), /不在认可区间/);

--- a/dsh-mneme/test/runtime-loader.test.js
+++ b/dsh-mneme/test/runtime-loader.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describeLocalRuntime, loadTransformers, resolveRuntimeEntry } from "../lib/runtime/loader.js";
 import { TRANSFORMERS_ENTRY, defaultRuntimeDir, payloadDir, payloadId } from "../lib/runtime/layout.js";
 
@@ -41,7 +42,13 @@ test("第 ① 层：自管运行时可用时优先用它，并报出来源与 pa
   assert.equal(loaded.payloadId, "transformers-4.2.0-node-win32-x64");
   assert.equal(loaded.version, "4.2.0");
   assert.ok(loaded.entryUrl.startsWith("file:///"), "必须是绝对 file URL，否则内部裸导入解析不到同目录的包");
-  assert.ok(loaded.entryUrl.includes(dir.replace(/\\/g, "/").replace(/^/, "")), "entryUrl 应指向该 payload");
+  // 断言「URL 反解回来就是那个入口文件」，而不是拿 URL 字符串去 includes 一个 OS 路径字符串：
+  // 后者会被 pathToFileURL 的百分号编码打败（路径含空格等字符时必误报，实测 CI Windows 上就挂了）。
+  assert.equal(
+    fileURLToPath(loaded.entryUrl),
+    join(dir, TRANSFORMERS_ENTRY),
+    `entryUrl=${loaded.entryUrl} dir=${dir}`
+  );
 });
 
 test("第 ② 层：没有自管运行时时退回宿主裸 specifier（PR-A 期间老用户靠这层不断线）", async () => {

--- a/dsh-mneme/test/runtime-loader.test.js
+++ b/dsh-mneme/test/runtime-loader.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTransformers, resolveRuntimeEntry } from "../lib/runtime/loader.js";
+import { TRANSFORMERS_ENTRY, payloadDir, payloadId } from "../lib/runtime/layout.js";
+
+// 三层解析（issue #131 / PR-A）。这里守的是两条容易出错的承诺：
+//   ① 自管运行时优先，且能用绝对 file URL 真的加载起来；
+//   ② 降级路径不许静默 —— 「自管那份坏了」和「本机根本没有」必须能分辨。
+// 第 ② 层（宿主裸 specifier）是 PR-A 期间老用户不断线的保障，必须真的会退回去。
+
+/** 造一份结构合法的 payload。 */
+function makePayload(runtimeDir, { version = "4.2.0", platform = "win32", withEntry = true } = {}) {
+  const dir = payloadDir(runtimeDir, payloadId({ version, platform, arch: "x64" }));
+  const write = (rel, body) => {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, body);
+  };
+  for (const name of ["@huggingface/transformers", "onnxruntime-node", "sharp"]) {
+    write(join("node_modules", name, "package.json"), JSON.stringify({ name, version: name === "@huggingface/transformers" ? version : "1.0.0" }));
+  }
+  if (withEntry) write(TRANSFORMERS_ENTRY, "export const source = 'runtime';\n");
+  mkdirSync(join(dir, "node_modules", "onnxruntime-node", "bin", "napi-v6", platform), { recursive: true });
+  return dir;
+}
+
+const emptyRuntime = () => mkdtempSync(join(tmpdir(), "mneme-loader-rt-"));
+
+test("第 ① 层：自管运行时可用时优先用它，并报出来源与 payloadId", async () => {
+  const runtimeDir = emptyRuntime();
+  const dir = makePayload(runtimeDir);
+  const loaded = await loadTransformers({
+    runtimeDir,
+    platform: "win32",
+    importModule: async (specifier) => ({ loadedFrom: specifier })
+  });
+  assert.equal(loaded.source, "runtime");
+  assert.equal(loaded.payloadId, "transformers-4.2.0-node-win32-x64");
+  assert.equal(loaded.version, "4.2.0");
+  assert.ok(loaded.entryUrl.startsWith("file:///"), "必须是绝对 file URL，否则内部裸导入解析不到同目录的包");
+  assert.ok(loaded.entryUrl.includes(dir.replace(/\\/g, "/").replace(/^/, "")), "entryUrl 应指向该 payload");
+});
+
+test("第 ② 层：没有自管运行时时退回宿主裸 specifier（PR-A 期间老用户靠这层不断线）", async () => {
+  const seen = [];
+  const loaded = await loadTransformers({
+    runtimeDir: emptyRuntime(),
+    importModule: async (specifier) => {
+      seen.push(specifier);
+      return { loadedFrom: specifier };
+    }
+  });
+  assert.equal(loaded.source, "host");
+  assert.deepEqual(seen, ["@huggingface/transformers"]);
+});
+
+test("降级不许静默：自管那份坏了要回调出来，同时仍然退到宿主", async () => {
+  const runtimeDir = emptyRuntime();
+  makePayload(runtimeDir);
+  const failures = [];
+  const loaded = await loadTransformers({
+    runtimeDir,
+    platform: "win32",
+    onFailure: (m) => failures.push(m),
+    importModule: async (specifier) => {
+      if (specifier.startsWith("file:///")) throw new Error("Cannot find package 'onnxruntime-node'");
+      return { loadedFrom: "host" };
+    }
+  });
+  assert.equal(loaded.source, "host");
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /自管运行时 transformers-4.2.0-node-win32-x64 加载失败/);
+  assert.match(failures[0], /onnxruntime-node/);
+});
+
+test("第 ③ 层：两层都没有时给出可操作提示，并列出每一层为什么失败", async () => {
+  const runtimeDir = emptyRuntime();
+  makePayload(runtimeDir);
+  await assert.rejects(
+    () =>
+      loadTransformers({
+        runtimeDir,
+        platform: "win32",
+        importModule: async (specifier) => {
+          throw new Error(specifier.startsWith("file:///") ? "payload broken" : "Cannot find module");
+        }
+      }),
+    (error) => {
+      assert.equal(error.code, "MNEME_RUNTIME_UNAVAILABLE");
+      assert.match(error.message, /本地推理运行时不可用/);
+      assert.match(error.message, /runtime adopt --from/, "要给出可执行的下一步，而不是一句 module not found");
+      assert.match(error.message, /payload broken/, "自管那层的失败原因要带出来");
+      assert.match(error.message, /Cannot find module/, "宿主那层的失败原因也要带出来");
+      assert.equal(error.failures.length, 2);
+      return true;
+    }
+  );
+});
+
+test("resolveRuntimeEntry：跳过结构不合法的 payload，取到可用的那份；全不合规则返回 null", () => {
+  const runtimeDir = emptyRuntime();
+  makePayload(runtimeDir, { version: "4.2.0", withEntry: false }); // 缺入口 → 不合法
+  assert.equal(resolveRuntimeEntry({ runtimeDir, platform: "win32" }), null, "结构不合法的不能被选中");
+
+  makePayload(runtimeDir, { version: "4.3.0" });
+  const picked = resolveRuntimeEntry({ runtimeDir, platform: "win32" });
+  assert.equal(picked.payloadId, "transformers-4.3.0-node-win32-x64");
+  assert.equal(picked.version, "4.3.0");
+});
+
+test("resolveRuntimeEntry：运行时根目录不存在时返回 null（不是抛错）", () => {
+  assert.equal(resolveRuntimeEntry({ runtimeDir: join(tmpdir(), "mneme-nope-" + Date.now()), platform: "win32" }), null);
+});

--- a/dsh-mneme/test/runtime-loader.test.js
+++ b/dsh-mneme/test/runtime-loader.test.js
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describeLocalRuntime, loadTransformers, resolveRuntimeEntry } from "../lib/runtime/loader.js";
+import { describeLocalRuntime, loadTransformers, publicRuntimeStatus, resolveRuntimeEntry } from "../lib/runtime/loader.js";
 import { TRANSFORMERS_ENTRY, defaultRuntimeDir, payloadDir, payloadId } from "../lib/runtime/layout.js";
 
 // 三层解析（issue #131 / PR-A）。这里守的是两条容易出错的承诺：
@@ -13,7 +13,7 @@ import { TRANSFORMERS_ENTRY, defaultRuntimeDir, payloadDir, payloadId } from "..
 // 第 ② 层（宿主裸 specifier）是 PR-A 期间老用户不断线的保障，必须真的会退回去。
 
 /** 造一份结构合法的 payload。 */
-function makePayload(runtimeDir, { version = "4.2.0", platform = "win32", withEntry = true } = {}) {
+function makePayload(runtimeDir, { version = "4.2.0", platform = "win32", arch = "x64", withEntry = true } = {}) {
   const dir = payloadDir(runtimeDir, payloadId({ version, platform, arch: "x64" }));
   const write = (rel, body) => {
     const full = join(dir, rel);
@@ -24,7 +24,7 @@ function makePayload(runtimeDir, { version = "4.2.0", platform = "win32", withEn
     write(join("node_modules", name, "package.json"), JSON.stringify({ name, version: name === "@huggingface/transformers" ? version : "1.0.0" }));
   }
   if (withEntry) write(TRANSFORMERS_ENTRY, "export const source = 'runtime';\n");
-  mkdirSync(join(dir, "node_modules", "onnxruntime-node", "bin", "napi-v6", platform), { recursive: true });
+  mkdirSync(join(dir, "node_modules", "onnxruntime-node", "bin", "napi-v6", platform, arch), { recursive: true });
   return dir;
 }
 
@@ -35,7 +35,7 @@ test("第 ① 层：自管运行时可用时优先用它，并报出来源与 pa
   const dir = makePayload(runtimeDir);
   const loaded = await loadTransformers({
     runtimeDir,
-    platform: "win32",
+    platform: "win32", arch: "x64",
     importModule: async (specifier) => ({ loadedFrom: specifier })
   });
   assert.equal(loaded.source, "runtime");
@@ -70,7 +70,7 @@ test("降级不许静默：自管那份坏了要回调出来，同时仍然退�
   const failures = [];
   const loaded = await loadTransformers({
     runtimeDir,
-    platform: "win32",
+    platform: "win32", arch: "x64",
     onFailure: (m) => failures.push(m),
     importModule: async (specifier) => {
       if (specifier.startsWith("file:///")) throw new Error("Cannot find package 'onnxruntime-node'");
@@ -90,7 +90,7 @@ test("第 ③ 层：两层都没有时给出可操作提示，并列出每一层
     () =>
       loadTransformers({
         runtimeDir,
-        platform: "win32",
+        platform: "win32", arch: "x64",
         importModule: async (specifier) => {
           throw new Error(specifier.startsWith("file:///") ? "payload broken" : "Cannot find module");
         }
@@ -116,16 +116,46 @@ test("第 ③ 层：两层都没有时给出可操作提示，并列出每一层
 test("resolveRuntimeEntry：跳过结构不合法的 payload，取到可用的那份；全不合规则返回 null", () => {
   const runtimeDir = emptyRuntime();
   makePayload(runtimeDir, { version: "4.2.0", withEntry: false }); // 缺入口 → 不合法
-  assert.equal(resolveRuntimeEntry({ runtimeDir, platform: "win32" }), null, "结构不合法的不能被选中");
+  assert.equal(resolveRuntimeEntry({ runtimeDir, platform: "win32", arch: "x64" }), null, "结构不合法的不能被选中");
 
   makePayload(runtimeDir, { version: "4.3.0" });
-  const picked = resolveRuntimeEntry({ runtimeDir, platform: "win32" });
+  const picked = resolveRuntimeEntry({ runtimeDir, platform: "win32", arch: "x64" });
   assert.equal(picked.payloadId, "transformers-4.3.0-node-win32-x64");
   assert.equal(picked.version, "4.3.0");
 });
 
 test("resolveRuntimeEntry：运行时根目录不存在时返回 null（不是抛错）", () => {
-  assert.equal(resolveRuntimeEntry({ runtimeDir: join(tmpdir(), "mneme-nope-" + Date.now()), platform: "win32" }), null);
+  assert.equal(resolveRuntimeEntry({ runtimeDir: join(tmpdir(), "mneme-nope-" + Date.now()), platform: "win32", arch: "x64" }), null);
+});
+
+test("publicRuntimeStatus：只放行白名单字段，绝对路径与原始错误一律不进 HTTP", () => {
+  // /api/dsh-mneme/semantic 是刻意不鉴权的只读端点。完整状态里有 runtimeDir（绝对路径）、
+  // hint（内嵌脚本绝对路径）以及 reason/reasons（原始错误文本里带完整文件路径），
+  // 发给任何能连上该端口的人就是信息泄漏（CWE-200）。用精确白名单守住这件事：
+  // 将来谁往里加字段，这条测试就会红。
+  const EXPECTED = ["functional", "integrity", "materialize", "payloadId", "procedure", "status", "version"];
+
+  const missing = describeLocalRuntime({ runtimeDir: join(tmpdir(), `mneme-secret-${Date.now()}`), platform: "win32", arch: "x64" });
+  const pubMissing = publicRuntimeStatus(missing);
+  assert.deepEqual(Object.keys(pubMissing).sort(), EXPECTED);
+  assert.equal(pubMissing.status, "missing");
+  // 完整状态里确实带着这些敏感字段 —— 否则这条测试就没在测东西。
+  assert.ok(missing.runtimeDir.startsWith(tmpdir()));
+  assert.ok(missing.hint.includes("mneme-runtime.mjs"));
+
+  const runtimeDir = emptyRuntime();
+  const dir = makePayload(runtimeDir);
+  writeFileSync(join(dir, "mneme-runtime.json"), JSON.stringify({ procedure: "adopted", materialize: { mode: "hardlink" } }));
+  const pubAvailable = publicRuntimeStatus(describeLocalRuntime({ runtimeDir, platform: "win32", arch: "x64" }));
+  assert.deepEqual(Object.keys(pubAvailable).sort(), EXPECTED);
+  assert.equal(pubAvailable.status, "available");
+  assert.equal(pubAvailable.payloadId, "transformers-4.2.0-node-win32-x64");
+  assert.equal(pubAvailable.procedure, "adopted");
+  assert.equal(pubAvailable.materialize, "hardlink");
+  // 整份投影里不能出现本机路径的任何形态。
+  const text = JSON.stringify(pubAvailable);
+  assert.equal(text.includes(runtimeDir), false);
+  assert.equal(text.includes(runtimeDir.replace(/\\/g, "/")), false);
 });
 
 test("describeLocalRuntime：可用时报出 payload 与来源，且不假装验过", () => {
@@ -136,7 +166,7 @@ test("describeLocalRuntime：可用时报出 payload 与来源，且不假装验
     join(dir, "mneme-runtime.json"),
     JSON.stringify({ procedure: "adopted", materialize: { mode: "hardlink" } })
   );
-  const report = describeLocalRuntime({ runtimeDir, platform: "win32" });
+  const report = describeLocalRuntime({ runtimeDir, platform: "win32", arch: "x64" });
   assert.equal(report.status, "available");
   assert.equal(report.payloadId, "transformers-4.2.0-node-win32-x64");
   assert.equal(report.version, "4.2.0");
@@ -150,14 +180,14 @@ test("describeLocalRuntime：可用时报出 payload 与来源，且不假装验
 });
 
 test("describeLocalRuntime：没有 payload 时报 missing，而不是报坏掉", () => {
-  const report = describeLocalRuntime({ runtimeDir: emptyRuntime(), platform: "win32" });
+  const report = describeLocalRuntime({ runtimeDir: emptyRuntime(), platform: "win32", arch: "x64" });
   assert.equal(report.status, "missing");
 });
 
 test("describeLocalRuntime：有目录但缺件时报 broken 并点名缺了什么", () => {
   const runtimeDir = emptyRuntime();
   makePayload(runtimeDir, { withEntry: false });
-  const report = describeLocalRuntime({ runtimeDir, platform: "win32" });
+  const report = describeLocalRuntime({ runtimeDir, platform: "win32", arch: "x64" });
   assert.equal(report.status, "broken");
   assert.deepEqual(report.missing, [TRANSFORMERS_ENTRY]);
 });
@@ -165,7 +195,7 @@ test("describeLocalRuntime：有目录但缺件时报 broken 并点名缺了什�
 test("describeLocalRuntime：空 runtimeDir 走默认目录，不能把空串当相对路径", () => {
   // 配置项 runtimeDir 的默认值就是空串。原样传下去 readdirSync("") 会失败，
   // 「没配」会被误报成「坏了」—— 这条守的就是它。
-  const report = describeLocalRuntime({ runtimeDir: "  ", platform: "win32" });
+  const report = describeLocalRuntime({ runtimeDir: "  ", platform: "win32", arch: "x64" });
   assert.equal(report.runtimeDir, defaultRuntimeDir());
   assert.ok(isAbsolute(report.runtimeDir));
   assert.notEqual(report.status, "unreadable");

--- a/dsh-mneme/test/runtime-loader.test.js
+++ b/dsh-mneme/test/runtime-loader.test.js
@@ -1,10 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { loadTransformers, resolveRuntimeEntry } from "../lib/runtime/loader.js";
-import { TRANSFORMERS_ENTRY, payloadDir, payloadId } from "../lib/runtime/layout.js";
+import { isAbsolute, join } from "node:path";
+import { describeLocalRuntime, loadTransformers, resolveRuntimeEntry } from "../lib/runtime/loader.js";
+import { TRANSFORMERS_ENTRY, defaultRuntimeDir, payloadDir, payloadId } from "../lib/runtime/layout.js";
 
 // 三层解析（issue #131 / PR-A）。这里守的是两条容易出错的承诺：
 //   ① 自管运行时优先，且能用绝对 file URL 真的加载起来；
@@ -91,7 +91,13 @@ test("第 ③ 层：两层都没有时给出可操作提示，并列出每一层
     (error) => {
       assert.equal(error.code, "MNEME_RUNTIME_UNAVAILABLE");
       assert.match(error.message, /本地推理运行时不可用/);
-      assert.match(error.message, /runtime adopt --from/, "要给出可执行的下一步，而不是一句 module not found");
+      assert.match(error.message, /mneme-runtime\.mjs/, "提示要指向真实存在的入口，而不是一个不存在的子命令");
+      // 提示里给的入口脚本必须真的存在。这条踩过：提示指向了一个并不存在的子命令，
+      // 用户照着敲只会得到「command not found」，比不给提示更糟。
+      const script = /node "([^"]+mneme-runtime\.mjs)"/.exec(error.message);
+      assert.ok(script, "提示要带出入口脚本的绝对路径");
+      assert.ok(existsSync(script[1]), `提示指向的脚本不存在：${script[1]}`);
+      assert.match(error.message, /adopt --from/, "要给出可执行的下一步，而不是一句 module not found");
       assert.match(error.message, /payload broken/, "自管那层的失败原因要带出来");
       assert.match(error.message, /Cannot find module/, "宿主那层的失败原因也要带出来");
       assert.equal(error.failures.length, 2);
@@ -113,4 +119,47 @@ test("resolveRuntimeEntry：跳过结构不合法的 payload，取到可用的�
 
 test("resolveRuntimeEntry：运行时根目录不存在时返回 null（不是抛错）", () => {
   assert.equal(resolveRuntimeEntry({ runtimeDir: join(tmpdir(), "mneme-nope-" + Date.now()), platform: "win32" }), null);
+});
+
+test("describeLocalRuntime：可用时报出 payload 与来源，且不假装验过", () => {
+  const runtimeDir = emptyRuntime();
+  const dir = makePayload(runtimeDir);
+  // 收编来的 payload 会带一份清单，验证来源/物化方式确实被带出来。
+  writeFileSync(
+    join(dir, "mneme-runtime.json"),
+    JSON.stringify({ procedure: "adopted", materialize: { mode: "hardlink" } })
+  );
+  const report = describeLocalRuntime({ runtimeDir, platform: "win32" });
+  assert.equal(report.status, "available");
+  assert.equal(report.payloadId, "transformers-4.2.0-node-win32-x64");
+  assert.equal(report.version, "4.2.0");
+  assert.equal(report.procedure, "adopted");
+  assert.equal(report.materialize, "hardlink");
+  // 结构检查是 GET 端点能负担的；功能验证要真加载原生模块跑推理，状态探针不做 ——
+  // 如实说「不知道」，而不是把「文件都在」说成「验过了」。
+  assert.equal(report.functional, "unknown");
+  assert.equal(report.integrity, "unverified");
+  assert.match(report.hint, /mneme-runtime\.mjs/);
+});
+
+test("describeLocalRuntime：没有 payload 时报 missing，而不是报坏掉", () => {
+  const report = describeLocalRuntime({ runtimeDir: emptyRuntime(), platform: "win32" });
+  assert.equal(report.status, "missing");
+});
+
+test("describeLocalRuntime：有目录但缺件时报 broken 并点名缺了什么", () => {
+  const runtimeDir = emptyRuntime();
+  makePayload(runtimeDir, { withEntry: false });
+  const report = describeLocalRuntime({ runtimeDir, platform: "win32" });
+  assert.equal(report.status, "broken");
+  assert.deepEqual(report.missing, [TRANSFORMERS_ENTRY]);
+});
+
+test("describeLocalRuntime：空 runtimeDir 走默认目录，不能把空串当相对路径", () => {
+  // 配置项 runtimeDir 的默认值就是空串。原样传下去 readdirSync("") 会失败，
+  // 「没配」会被误报成「坏了」—— 这条守的就是它。
+  const report = describeLocalRuntime({ runtimeDir: "  ", platform: "win32" });
+  assert.equal(report.runtimeDir, defaultRuntimeDir());
+  assert.ok(isAbsolute(report.runtimeDir));
+  assert.notEqual(report.status, "unreadable");
 });

--- a/dsh-mneme/test/runtime-verify.test.js
+++ b/dsh-mneme/test/runtime-verify.test.js
@@ -11,7 +11,7 @@ import { TRANSFORMERS_ENTRY } from "../lib/runtime/layout.js";
 // 这些都必须变成一条可读的失败结论，而不是让调用方拿到一个假的 ok。
 
 /** 造一个结构上合法的 payload（只有形状，没有真东西）。 */
-function makePayload({ platform = "win32", withEntry = true } = {}) {
+function makePayload({ platform = "win32", arch = "x64", withEntry = true } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "mneme-verify-"));
   const write = (rel, body) => {
     const full = join(dir, rel);
@@ -22,7 +22,7 @@ function makePayload({ platform = "win32", withEntry = true } = {}) {
     write(join("node_modules", name, "package.json"), JSON.stringify({ name, version: name === "@huggingface/transformers" ? "4.2.0" : "1.0.0" }));
   }
   if (withEntry) write(TRANSFORMERS_ENTRY, "export const x = 1;\n");
-  mkdirSync(join(dir, "node_modules", "onnxruntime-node", "bin", "napi-v6", platform), { recursive: true });
+  mkdirSync(join(dir, "node_modules", "onnxruntime-node", "bin", "napi-v6", platform, arch), { recursive: true });
   return dir;
 }
 
@@ -98,6 +98,7 @@ test("三件套：结构不过就不再做功能验证（省掉一次无谓的�
   let engineCalled = false;
   const result = await verifyPayload(dir, {
     platform: "win32",
+    arch: "x64",
     engine: async () => {
       engineCalled = true;
       return async () => fakeRows(2, 8);
@@ -111,7 +112,11 @@ test("三件套：结构不过就不再做功能验证（省掉一次无谓的�
 
 test("三件套：结构 + 功能都过、完整性缺失时如实标 unverified 且不判定失败", async () => {
   const dir = makePayload();
-  const result = await verifyPayload(dir, { platform: "win32", engine: engineReturning(fakeRows(2, 8)) });
+  const result = await verifyPayload(dir, {
+    platform: "win32",
+    arch: "x64",
+    engine: engineReturning(fakeRows(2, 8))
+  });
   assert.equal(result.ok, true);
   assert.equal(result.integrity.status, "unverified");
   assert.equal(result.integrity.ok, true);
@@ -122,6 +127,7 @@ test("三件套：--strict 场景下哈希不匹配即整体不通过", async ()
   const dir = makePayload();
   const matched = await verifyPayload(dir, {
     platform: "win32",
+    arch: "x64",
     engine: engineReturning(fakeRows(2, 8)),
     integrity: { status: "sha512-matched", detail: "tarball 比对通过" }
   });
@@ -130,12 +136,38 @@ test("三件套：--strict 场景下哈希不匹配即整体不通过", async ()
 
   const mismatch = await verifyPayload(dir, {
     platform: "win32",
+    arch: "x64",
     engine: engineReturning(fakeRows(2, 8)),
     integrity: { status: "sha512-mismatch", detail: "与钉死的哈希不一致" }
   });
   assert.equal(mismatch.ok, false);
   assert.equal(mismatch.structural.ok, true, "结构仍然是对的，失败来自完整性");
   assert.equal(mismatch.functional.ok, true);
+});
+
+test("假通过防线 ①：行不是数组时返回失败，而不是抛异常", async () => {
+  // 契约是「任何失败都返回结果对象，不抛」；非数组行会让 .length/.some 直接抛。
+  const dir = makePayload();
+  const result = await verifyPayload(dir, {
+    platform: "win32",
+    arch: "x64",
+    engine: engineReturning([null, null])
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.functional.reason, /不是数组/);
+});
+
+test("假通过防线 ②：非有限数值必须判失败（NaN 的比较恒为 false，会静默通过）", async () => {
+  const dir = makePayload();
+  for (const bad of [[NaN, 0], [Infinity, 0], ["0.5", "0.5"]]) {
+    const result = await verifyPayload(dir, {
+      platform: "win32",
+      arch: "x64",
+      engine: engineReturning([bad, [0, 0]])
+    });
+    assert.equal(result.ok, false, `含 ${JSON.stringify(bad)} 的向量不该被判通过`);
+    assert.match(result.functional.reason, /非有限数值/);
+  }
 });
 
 test("默认 engine 是导出的函数，且探针文本固定（改它等于改验收标准）", () => {

--- a/dsh-mneme/test/runtime-verify.test.js
+++ b/dsh-mneme/test/runtime-verify.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_PROBE_TEXTS, defaultEngine, verifyFunctional, verifyPayload } from "../lib/runtime/verify.js";
+import { TRANSFORMERS_ENTRY } from "../lib/runtime/layout.js";
+
+// 验证三件套（issue #131 / PR-A）。重点不是「能跑通」，而是「坏的那几种能被抓住」：
+// 结构对但原生二进制与本机不匹配、返回非归一化向量、向量退化、加载直接抛——
+// 这些都必须变成一条可读的失败结论，而不是让调用方拿到一个假的 ok。
+
+/** 造一个结构上合法的 payload（只有形状，没有真东西）。 */
+function makePayload({ platform = "win32", withEntry = true } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "mneme-verify-"));
+  const write = (rel, body) => {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, body);
+  };
+  for (const name of ["@huggingface/transformers", "onnxruntime-node", "sharp"]) {
+    write(join("node_modules", name, "package.json"), JSON.stringify({ name, version: name === "@huggingface/transformers" ? "4.2.0" : "1.0.0" }));
+  }
+  if (withEntry) write(TRANSFORMERS_ENTRY, "export const x = 1;\n");
+  mkdirSync(join(dir, "node_modules", "onnxruntime-node", "bin", "napi-v6", platform), { recursive: true });
+  return dir;
+}
+
+/** 归一化的假向量：`rows` 行，每行 dim 维，方向由 seed 决定。 */
+function fakeRows(rows, dim, seed = 0) {
+  return Array.from({ length: rows }, (_, r) => {
+    const v = Array.from({ length: dim }, (_, i) => Math.sin((i + 1) * (r + 1 + seed)));
+    const length = Math.hypot(...v);
+    return v.map((x) => x / length);
+  });
+}
+
+/** 注入一个「什么都能返回」的 engine。 */
+function engineReturning(value) {
+  return async () => async () => value;
+}
+
+test("功能验证：正常的向量通过，并报出维度与耗时", async () => {
+  const result = await verifyFunctional("/whatever", { engine: engineReturning(fakeRows(2, 512)) });
+  assert.equal(result.ok, true, result.reason);
+  assert.equal(result.dim, 512);
+  assert.equal(result.rows, 2);
+  assert.ok(result.elapsedMs >= 0);
+});
+
+test("功能验证：行数不符要报出来（而不是只取第一行当作通过）", async () => {
+  const result = await verifyFunctional("/whatever", { engine: engineReturning(fakeRows(1, 512)) });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /返回行数不符/);
+});
+
+test("功能验证：非归一化向量要报出来（说明 normalize 没生效）", async () => {
+  const rows = fakeRows(2, 8).map((row) => row.map((x) => x * 3));
+  const result = await verifyFunctional("/whatever", { engine: engineReturning(rows) });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /不是 L2 归一化/);
+});
+
+test("功能验证：向量退化成同一方向要报出来", async () => {
+  const one = fakeRows(1, 16)[0];
+  const result = await verifyFunctional("/whatever", { engine: engineReturning([one, one]) });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /嵌入退化/);
+});
+
+test("功能验证：加载失败与推理失败分别给出不同措辞", async () => {
+  const loadFail = await verifyFunctional("/whatever", {
+    engine: async () => {
+      throw new Error("Cannot find package 'onnxruntime-node'");
+    }
+  });
+  assert.equal(loadFail.ok, false);
+  assert.match(loadFail.reason, /加载运行时失败/);
+  assert.match(loadFail.reason, /onnxruntime-node/);
+
+  const embedFail = await verifyFunctional("/whatever", {
+    engine: async () => async () => {
+      throw new Error("boom");
+    }
+  });
+  assert.equal(embedFail.ok, false);
+  assert.match(embedFail.reason, /推理失败/);
+});
+
+test("功能验证：返回空向量要报出来，而不是当成 dim=0 通过", async () => {
+  const result = await verifyFunctional("/whatever", { engine: engineReturning([[], []]) });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /空向量/);
+});
+
+test("三件套：结构不过就不再做功能验证（省掉一次无谓的加载）", async () => {
+  const dir = makePayload({ withEntry: false });
+  let engineCalled = false;
+  const result = await verifyPayload(dir, {
+    platform: "win32",
+    engine: async () => {
+      engineCalled = true;
+      return async () => fakeRows(2, 8);
+    }
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.functional.ok, false);
+  assert.match(result.functional.reason, /跳过功能验证/);
+  assert.equal(engineCalled, false);
+});
+
+test("三件套：结构 + 功能都过、完整性缺失时如实标 unverified 且不判定失败", async () => {
+  const dir = makePayload();
+  const result = await verifyPayload(dir, { platform: "win32", engine: engineReturning(fakeRows(2, 8)) });
+  assert.equal(result.ok, true);
+  assert.equal(result.integrity.status, "unverified");
+  assert.equal(result.integrity.ok, true);
+  assert.equal(result.version, "4.2.0");
+});
+
+test("三件套：--strict 场景下哈希不匹配即整体不通过", async () => {
+  const dir = makePayload();
+  const matched = await verifyPayload(dir, {
+    platform: "win32",
+    engine: engineReturning(fakeRows(2, 8)),
+    integrity: { status: "sha512-matched", detail: "tarball 比对通过" }
+  });
+  assert.equal(matched.ok, true);
+  assert.equal(matched.integrity.status, "sha512-matched");
+
+  const mismatch = await verifyPayload(dir, {
+    platform: "win32",
+    engine: engineReturning(fakeRows(2, 8)),
+    integrity: { status: "sha512-mismatch", detail: "与钉死的哈希不一致" }
+  });
+  assert.equal(mismatch.ok, false);
+  assert.equal(mismatch.structural.ok, true, "结构仍然是对的，失败来自完整性");
+  assert.equal(mismatch.functional.ok, true);
+});
+
+test("默认 engine 是导出的函数，且探针文本固定（改它等于改验收标准）", () => {
+  assert.equal(typeof defaultEngine, "function");
+  assert.deepEqual(DEFAULT_PROBE_TEXTS, ["猫咪喜欢晒太阳", "the quick brown fox"]);
+});


### PR DESCRIPTION
## 这个 PR 解决什么

`dsh-mneme` 把 `@huggingface/transformers` 声明在 `dependencies`，它带来的原生闭包会进入宿主 profile 的安装图。而 profile 是**所有插件共用的同一张依赖图**，于是「安装任何插件」都要替它重走一遍这条链——弱网下安装直接卡住（issue #131）。

本机实测这份闭包：**49 个包 / 3203 个文件 / 393,206,416 字节**，其中 `onnxruntime-node` 210.1MB、`onnxruntime-web` 127.7MB、`sharp` 19.0MB、`@huggingface/transformers` 9.1MB。

## 这个 PR 做什么（以及刻意不做什么）

**PR-A：只加基础设施，不动依赖声明。** 全部改动都是新增路径：

| 模块 | 职责 |
| --- | --- |
| `src/runtime/layout.js` | 目录契约（`<runtimeDir>/<payloadId>/mneme-runtime.json` + 扁平 `node_modules/`）与结构检查 |
| `src/runtime/closure.js` | 从宿主 `node_modules` 解出依赖闭包（平台过滤、越界拒绝、缺件记为 gap） |
| `src/runtime/adopt.js` | 把闭包收编进自管目录：优先硬链接，失败回退复制，并把原因如实写进清单 |
| `src/runtime/verify.js` | 三件套验证：结构 / 功能（真推理，离线）/ 完整性 |
| `src/runtime/loader.js` | 三层解析：① 自管目录 → ② 宿主裸 specifier → ③ 带可操作提示地失败；另加只读状态探针 `describeLocalRuntime` |
| `scripts/mneme-runtime.mjs` | `status` / `adopt` / `verify` 离线入口，退出码 `0` 健康 / `1` 不健康 / `2` 用法错误 |
| `GET /api/dsh-mneme/semantic` | 增加 `localRuntime` 状态字段（面板与 CLI 同源） |

刻意不做的三件事：

- **不改 `package.json` 的 `dependencies`** —— 那是 PR-B；
- **不改 `bin/cli.mjs`** —— 那个 CLI 的契约是「外部 HTTP API 客户端，要求服务在跑」，而收编/验证恰恰发生在服务没起来、插件装不上的时候，两者是相反的使用场景；放 `scripts/` 既符合既有约定（`benchmark-embed.js` 等），也不用动那个零依赖 CLI；
- **不引入任何新依赖** —— `scripts/` 入口只用 node 内建 + 本仓库 `lib/`。

**因此单独合入 PR-A 不会修复 issue 里报告的症状**：profile 仍然持有这 393MB。它的价值是让 PR-B 能安全落地，并且**必须先合**。

## 为什么顺序不能反

pnpm 的 prune 和清单变更发生在同一次安装里。如果先摘掉 `dependencies` 再收编，宿主那份已经被删掉，收编就没有源了——只能走联网下载（PR-B 的下载器）。所以正确顺序是：**先用 `adopt` 把运行时落到 `~/.dsh/mneme/runtime/`，再升级到摘掉依赖的版本。**

## 兼容性

`loader.js` 的第 ② 层（宿主裸 specifier）是专门为老用户保留的：PR-A 期间依赖声明没变，宿主那份还在，本地嵌入照常工作；等 PR-B 摘掉声明、pnpm 把它 prune 掉之后，第 ① 层顶上。

三层全失败时抛出带 `code = "MNEME_RUNTIME_UNAVAILABLE"` 的错误，附带「试过哪几层、各自为什么失败」和可执行的下一步（指向真实存在的 `scripts/mneme-runtime.mjs`，并有测试守住该路径存在）；调用方（`index.js:243-245`、`index.js:280-281`）照旧降级——**检索退化为关键词/BM25，读写在任何情况下都不受影响**。

## 验证（本机实测，非 CI 结果）

自管运行时端到端，`--from` 指向本机真实已装的 `node_modules`：

```
adopt  49 个包 / 3203 个文件 / 393,206,416 字节；物化方式 hardlink；结构检查通过
status 可用 / transformers 4.2.0 / 来源 adopted / 物化 hardlink / 完整性 unverified / 功能 unknown
verify 结构通过；功能通过（维度 512，2 行，359ms，离线）；完整性 unverified
```

几点如实说明：

- `verify` 的功能验证**故意不触网**（`env.allowRemoteModels=false`）：缓存命中就本地加载，命中不了就明确失败。验证不该偷偷下载。
- 收编来的目录没有可比对的原始产物，完整性如实标 `unverified`，不假装验过（`--strict` 留给 PR-B 的 tarball 通道）。
- 硬链接：源与目标同盘时 `linkSync` 成功，本机 393MB 未额外占盘；跨盘或权限不允许时逐文件回退复制，并把 `materialize: {mode, linkError}` 写进清单，面板据此能解释「本该不占盘却占了盘」。
- **测试：本机 791 passed / 1 failed。** 唯一失败是 `test/peer-blockers.test.js`（`spawn EPERM`）：该文件用 `execFileP` 起 8 个子进程，而我所在环境禁止 Node 子进程的管道 stdio，同环境下 `node --test` 也无法启动，所以以上是逐文件运行的结果；**改动前也是这唯一一个失败**。CI（Node 24 全量 + Codecov）应能正常跑完。

## 想请维护者确认的点

1. payload 目录命名 `transformers-<version>-node-<platform>-<arch>` 与默认位置 `~/.dsh/mneme/runtime/` 是否符合项目预期；
2. 是否接受 PR-B 把 `@huggingface/transformers` 从 `dependencies` 降为 **optional peer**（`peerDependenciesMeta.optional`）；
3. 项目对「插件自行下载运行时依赖」的立场（PR-B 的下载器：固定 `runtime-manifest.json` 记录 name@version + sha512 + 平台规则，镜像可配、支持重试与 `Range` 续传，解包前校验 sha512）；
4. 是否先单独审 PR-A。

关联 issue #131。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-managed local runtime support for semantic search, including runtime adoption, status checks, and offline verification.
  * Added configurable runtime directory support, defaulting to `~/.dsh/mneme/runtime`.
  * Added structured local runtime status to the semantic API response.
  * Added graceful fallback to keyword/BM25 retrieval when local inference is unavailable.
  * Runtime management commands support human-readable and JSON output with documented exit codes.

* **Documentation**
  * Added guidance for runtime setup, model caching, verification, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->