### PR TITLE
fix(client): 侧栏记忆入口锚定新会话行，防生态插件挤位 (#130)

### DIFF
--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -3741,8 +3741,10 @@ window.__ModuleLoader__.load({
 
     // --- Sidebar entry: 工作区上方的记忆按钮 ---
     // 注册仍在 sidebar.footer.action（list 插槽）——它既是 React 树的挂载
-    // 锚点，也是 portal 失效时的原位回退。真实按钮 portal 插到 regionArea
-    // （工作区列表容器）之前，即「新会话」按钮下方、工作区上方。
+    // 锚点，也是 portal 失效时的原位回退。真实按钮 portal 插到「新会话」行
+    // 之后、插件入口组的最前：任务看板/技能中心等生态插件也把入口插在新会话
+    // 行后（它们的后插入者在上），若我们固定在 regionArea 之前就会被打成
+    // 入口组末尾的孤立位（issue #130），所以观察器发现错位就搬回锚点位。
     // 几何对齐方案：读取宿主「新会话」按钮的实时 className 原样套用，再用
     // 我们的修饰类覆盖配色（次级观感）。这样展开态与收起态（rail）都直接
     // 继承宿主自己的盒模型与间距——宿主改版/缩进动画零位移，无需硬编码。
@@ -3769,6 +3771,32 @@ window.__ModuleLoader__.load({
         const findNative = (region) =>
           region.parentElement.querySelector('[class*="newSession"]')
           || region.previousElementSibling;
+        // 占位锚点：新会话行（现役外壳里 newSession 按钮嵌在 logoRow 内，
+        // 旧外壳是根的直接子按钮）。判定与生态插件的 sidebar-entry-core
+        // 一致；锚点不可靠时回退到 regionArea 之前的旧位置。
+        const findAnchor = (region) => {
+          const parent = region.parentElement;
+          const btn = parent.querySelector('[class*="newSession"]');
+          if (!btn) return null;
+          const row = btn.closest('[class*="logoRow"]');
+          if (row && row.parentElement === parent) return row;
+          return btn.parentElement === parent ? btn : null;
+        };
+        // 占位规则：紧跟新会话行（插件入口组的顶部），幂等——已在锚点位就
+        // 不动 DOM。生态插件后插入时会把我们压下去一位，观察器里重排搬回；
+        // 它们只在自身节点被移除时才重插，不会与我们来回争抢。
+        // 注意 created 已紧跟锚点时 target 即 created 自身，必须直接返回：
+        // insertBefore(x, x) 在 Chromium 里不是 no-op，会触发 mutation 造成
+        // 观察器自激风暴、冻死整个 SPA。
+        const place = (region) => {
+          const parent = region.parentElement;
+          if (!parent) return;
+          const anchor = findAnchor(region);
+          const target = anchor ? anchor.nextSibling : region;
+          if (target === created) return;
+          if (created.parentElement === parent && created.nextSibling === target) return;
+          parent.insertBefore(created, target);
+        };
         const attempt = () => {
           const region = document.querySelector('[class*="regionArea"]');
           if (region && region.parentElement) {
@@ -3778,12 +3806,13 @@ window.__ModuleLoader__.load({
             // 否则 portal 按钮会停留在捕获时刻的旧类上（宽度/对齐失配）。
             created = document.createElement("div");
             created.dataset.pluginEntry = "@modusensus/dsh-mneme";
-            region.parentElement.insertBefore(created, region);
+            place(region);
             setHost(created);
             setNativeCls(findNative(region)?.className || "");
             mo = new MutationObserver(() => {
               const cur = document.querySelector('[class*="regionArea"]');
               if (!cur || !cur.parentElement) return;
+              place(cur);
               const cls = findNative(cur)?.className || "";
               setNativeCls((prev) => (prev === cls ? prev : cls));
             });

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -121,10 +121,10 @@ test("trigger renders a wide row or a rail icon from the wide flag", () => {
   );
 });
 
-// The entry lives ABOVE the workspaces region: the real button is portalled
-// just before the host's regionArea container (below New Session, above the
-// workspace list), while the sidebar.footer.action registration remains as
-// the React anchor and the in-place fallback when the host markup changes.
+// The entry lives at the top of the plugin-entry group: the real button is
+// portalled right after the host's New-Session row (above the entries other
+// plugins inject there), while the sidebar.footer.action registration remains
+// as the React anchor and the in-place fallback when the host markup changes.
 test("sidebar entry portals above the workspaces region with footer fallback", () => {
   assert.ok(
     clientSource.includes('ctx.slots.inject("sidebar.footer.action"'),
@@ -139,8 +139,8 @@ test("sidebar entry portals above the workspaces region with footer fallback", (
     "the portal must anchor at the host's regionArea container"
   );
   assert.ok(
-    clientSource.includes("insertBefore(created, region)"),
-    "the entry must sit immediately above the workspaces region"
+    clientSource.includes("insertBefore(created, target)"),
+    "the entry must be placed through the idempotent place() helper"
   );
   assert.ok(
     clientSource.includes("if (!host) return fallback;"),
@@ -157,6 +157,33 @@ test("sidebar entry portals above the workspaces region with footer fallback", (
   assert.ok(
     clientSource.includes('"memory.view.label"'),
     "the sheet aria-label must come from the memory.view.label dictionary key"
+  );
+});
+
+// Issue #130: ecosystem plugins (task board, skill explorer, …) inject their
+// own entries right after the New-Session row, and late inserters land above
+// earlier ones — a fixed "before regionArea" slot degrades into the tail of
+// that group, detaching the memory button from its familiar top spot. The
+// entry therefore (a) resolves the same anchor as the ecosystem's shared
+// sidebar-entry-core (logoRow row, legacy direct-child button), (b) re-asserts
+// its slot from the existing observer, and (c) stays idempotent — the anchor
+// check short-circuits before any DOM write, so observers never ping-pong.
+test("entry re-asserts the New-Session-adjacent slot against ecosystem entries", () => {
+  assert.ok(
+    clientSource.includes(`btn.closest('[class*="logoRow"]')`),
+    "the anchor must resolve the New-Session logo row like the ecosystem core"
+  );
+  assert.ok(
+    clientSource.includes("const target = anchor ? anchor.nextSibling : region;"),
+    "the entry must sit right after the New-Session row, falling back before regionArea"
+  );
+  assert.ok(
+    clientSource.includes("if (created.parentElement === parent && created.nextSibling === target) return;"),
+    "placement must be idempotent so the observer never writes on steady state"
+  );
+  assert.ok(
+    /place\(cur\);\s*\n\s*const cls = findNative\(cur\)/.test(clientSource),
+    "the observer must re-place the entry on childList churn, not just re-sync the class"
   );
 });
 


### PR DESCRIPTION
## 问题

任务看板 / 技能中心等生态插件会把各自的侧栏入口插在「新会话」行之后（后插入者在上）；而我们的记忆入口固定插在 regionArea 之前，于是被打成插件入口组的末尾——记忆按钮被顶到任务看板/技能中心下面，视觉上成了孤立位（issue #130 截图）。

## 根因

- 生态插件共用 linxin666 系 `sidebar-entry-core`：占位规则 =「紧跟新会话行（logoRow）之后」，且只在自身节点被移除时才重插。
- 我们的 portal 宿主 `insertBefore(created, regionArea)` 一次性放置，位置完全取决于插件安装/挂载时序。

## 修复

- **占位锚点改为紧跟新会话行**：`logoRow` 行（现役外壳）或直接子按钮（旧外壳）判定与生态 core 一致；锚点不可靠时回退到 regionArea 之前的旧位置。
- **幂等重排**：MutationObserver 回调里发现错位才搬回。生态插件后插入时我们把位置抢回；对方不会响应（它们只在被移除时重插），不会形成拉锯。
- **关键边界**（本地实测踩中）：created 已紧跟锚点时 `target === created`，必须短路返回——`insertBefore(x, x)` 在 Chromium 里**不是 no-op**，会触发 childList mutation 造成观察器自激风暴，冻死整个 SPA。已用最小 DOM 实验证实该行为并修复。

## 验证

- 全量测试 746 绿（新增 1 个 #130 行为测试 + 更新 1 个受影响断言）。
- web 8788（junction 直载本分支）+ 已装任务看板/SSH/技能中心实测：
  - 侧栏顺序稳定为 `新建会话 → 记忆 → 任务看板 → SSH → 技能中心 → 工作区`，多次交互/等待无漂移；
  - 入口点击正常打开记忆面板。

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sidebar entries now appear directly after the New Session row, providing more consistent placement across supported shell layouts.
  - Sidebar placement is maintained when other entries are added, preventing unexpected movement or duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->