### PR TITLE
fix(inject): read assistant body from data.message.content (Issue #129)

### DIFF
--- a/dsh-mneme/lib/inject.js
+++ b/dsh-mneme/lib/inject.js
@@ -44,7 +44,12 @@ function extractRounds(ctx, maxRounds) {
     const rounds = [];
     let pendingQuery = null;
     const textOf = (event) => {
-      const parts = event?.data?.content;
+      // user/message 的正文就在 data 上，而 assistant/message（以及 tool/result）的消息体
+      // 嵌在 data.message 下 —— DSH 侧由 @deepseek-ai/dsh-session 的
+      // assertMessageEventShape 一行写死：const message = type === "user/message" ? record : record?.["message"]。
+      // 只读 data.content 会让每一轮的 response 恒为空（Issue #129）。
+      // 这里用 ?? 兜底而不是直接改成 data.message.content：user 消息与旧的扁平形状都照旧可用。
+      const parts = event?.data?.content ?? event?.data?.message?.content;
       if (!Array.isArray(parts)) return "";
       return parts
         .map((p) => (typeof p === "string" ? p : p?.text ?? ""))

--- a/dsh-mneme/src/inject.js
+++ b/dsh-mneme/src/inject.js
@@ -44,7 +44,12 @@ function extractRounds(ctx, maxRounds) {
     const rounds = [];
     let pendingQuery = null;
     const textOf = (event) => {
-      const parts = event?.data?.content;
+      // user/message 的正文就在 data 上，而 assistant/message（以及 tool/result）的消息体
+      // 嵌在 data.message 下 —— DSH 侧由 @deepseek-ai/dsh-session 的
+      // assertMessageEventShape 一行写死：const message = type === "user/message" ? record : record?.["message"]。
+      // 只读 data.content 会让每一轮的 response 恒为空（Issue #129）。
+      // 这里用 ?? 兜底而不是直接改成 data.message.content：user 消息与旧的扁平形状都照旧可用。
+      const parts = event?.data?.content ?? event?.data?.message?.content;
       if (!Array.isArray(parts)) return "";
       return parts
         .map((p) => (typeof p === "string" ? p : p?.text ?? ""))

--- a/dsh-mneme/test/inject.test.js
+++ b/dsh-mneme/test/inject.test.js
@@ -105,16 +105,52 @@ test("Bug6: injected block stays within the ~1500 char budget, later entries col
 // DSH ≥0.1.2-rc removed Session.events; events are only reachable via
 // snapshotEvents(). Regression for #59: the hot block must still render from
 // a session object that has no .events property.
+// 注意：assistant/message 的消息体在 data.message 下（见 Issue #129），夹具必须用这个
+// 真实形状 —— 原先的夹具写的是 data.content，与当时有 bug 的实现是同一个错误假设，
+// 所以它永远抓不到这个回归。
 test("extracts hot rounds from snapshotEvents() when Session.events is absent", () => {
   const { contexts } = setup();
   const session = {
     snapshotEvents: () => [
       { type: "user/message", data: { source: { kind: "user" }, content: [{ type: "text", text: "怎么修图谱面板" }] } },
-      { type: "assistant/message", data: { content: [{ type: "text", text: "用 viewBox 单位跑模拟" }] } }
+      { type: "assistant/message", data: { message: { content: [{ type: "text", text: "用 viewBox 单位跑模拟" }] } } }
     ]
   };
   const text = contexts[0].text({ agent: { session } });
   assert.ok(text.includes("[短期上下文]"), "hot block rendered");
   assert.ok(text.includes("怎么修图谱面板"), "round query present");
   assert.ok(text.includes("用 viewBox 单位跑模拟"), "round response present");
+});
+
+// Issue #129 的复现：assistant 轮的正文取自 data.message.content。修复前 textOf 只读
+// data.content，于是每一轮的 response 都落成空串 —— 表现为「N 轮 A 全空」。
+test("Issue #129: response 取自 data.message.content，N 轮不再出现空 A", () => {
+  const { contexts } = setup();
+  const session = {
+    snapshotEvents: () => [
+      { type: "user/message", data: { source: { kind: "user" }, content: [{ type: "text", text: "第一个问题" }] } },
+      { type: "assistant/message", data: { message: { content: [{ type: "text", text: "第一个回答" }] } } },
+      { type: "user/message", data: { source: { kind: "user" }, content: [{ type: "text", text: "第二个问题" }] } },
+      { type: "assistant/message", data: { message: { content: [{ type: "text", text: "第二个回答" }] } } }
+    ]
+  };
+  const text = contexts[0].text({ agent: { session } });
+  for (const s of ["第一个问题", "第一个回答", "第二个问题", "第二个回答"]) {
+    assert.ok(text.includes(s), `hot block 应包含 ${s}`);
+  }
+});
+
+// 修复用的是 ?? 兜底而非破坏性替换：扁平的 data.content 形状（user 消息一贯如此，
+// 历史事件也可能如此）必须继续可用。
+test("Issue #129: 扁平的 data.content 形状仍被兼容", () => {
+  const { contexts } = setup();
+  const session = {
+    snapshotEvents: () => [
+      { type: "user/message", data: { source: { kind: "user" }, content: [{ type: "text", text: "问题" }] } },
+      { type: "assistant/message", data: { content: [{ type: "text", text: "扁平形状的回答" }] } }
+    ]
+  };
+  const text = contexts[0].text({ agent: { session } });
+  assert.ok(text.includes("问题"), "query present");
+  assert.ok(text.includes("扁平形状的回答"), "flat content shape still supported");
 });


### PR DESCRIPTION
> 承接 Issue #129。维护者建议直接提 PR，并补一个「assistant 轮带 `message.content`」的用例。

## 问题

热记忆块（`[短期上下文]`）里每一轮的 `A` 恒为空。

根因在 `src/inject.js` 的 `textOf`：它只读 `event?.data?.content`。而 DSH 的事件契约对两种消息用**两种嵌套层级**（`@deepseek-ai/dsh-session` 的 `assertMessageEventShape` 一行写死）：

```js
const message = type === "user/message" ? record : record?.["message"];
```

即 `user/message` 的正文在 `data.content`，而 `assistant/message`（以及 `tool/result`）的消息体嵌在 **`data.message`**，正文在 `data.message.content`。同仓库的 `src/summarize.js` 走的正是正确路径（`case "assistant/message": const msg = data?.message;`），所以这是 `inject.js` 单处的漏改。

## 改动

`src/inject.js`：用 `??` 兜底，而不是直接替换成 `data.message.content` —— 这样 user 消息与旧的扁平形状都照旧可用。

```diff
-      const parts = event?.data?.content;
+      const parts = event?.data?.content ?? event?.data?.message?.content;
```

`lib/inject.js` 由 `npm run sync` 生成（本仓库约定：`src/` 是唯一事实源，不手改 `lib/`）；`test/lib-smoke.test.js` 的 src↔lib 逐文件一致性守卫通过。

## 测试

**顺带修正了一处夹具错误**（我认为这正是这个回归能溜过去的原因）：

原用例 `extracts hot rounds from snapshotEvents() when Session.events is absent` 给 `assistant/message` 喂的是 `data: { content: [...] }` —— 与当时有 bug 的实现是**同一个错误假设**，所以它对这个回归永远是无感的。已改为真实形状：

```diff
-      { type: "assistant/message", data: { content: [{ type: "text", text: "用 viewBox 单位跑模拟" }] } }
+      { type: "assistant/message", data: { message: { content: [{ type: "text", text: "用 viewBox 单位跑模拟" }] } } }
```

新增两个用例：

- `Issue #129: response 取自 data.message.content，N 轮不再出现空 A` —— issue 里的复现（两轮，断言四个片段都在）。
- `Issue #129: 扁平的 data.content 形状仍被兼容` —— 锁住 `??` 的向后兼容语义，防止将来被「简化」成直接替换。

## 验证

```
npm test
ℹ tests 814   ℹ pass 813   ℹ fail 0   ℹ skipped 1   ℹ duration_ms 11036
```

（Node v24.18.0 / npm 11.16.0；`npm ci` 后全新环境跑出。）

## 影响面

只改热记忆块的读取路径。`textOf` 仍是纯读取 + 容错（非数组即返回 `""`），没有引入新的失败点，符合仓库「后台路径 fail-safe、不阻塞主流程」的约定。

Closes #129


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Assistant and tool responses now display correctly when their content is stored in a nested message payload.
  - Existing message formats remain supported, preventing blank responses in previously compatible data.

- **Tests**
  - Added coverage for nested assistant responses and continued support for the legacy flat content format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->