### PR TITLE
fix(dream): 决策前缀唯一解析 + 失败路径校验明细落库（issue #135）

### DIFF
--- a/dsh-mneme/lib/dream.js
+++ b/dsh-mneme/lib/dream.js
@@ -720,7 +720,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
       logger?.warn?.(`dsh-mneme dream: no json array in llm output (raw length ${decisionText?.length ?? 0}; head: ${head})`);
       return finish({ ok: false, error: "no json array in llm output", summary: false });
     }
-    const { ok, errors, skipped } = validateDecisions(decisions, snapshot, {
+    const { ok, errors, skipped, resolvedShortIds } = validateDecisions(decisions, snapshot, {
       maxUpdatePerRun: config.reflectionUpdateMaxPerRun,
       minAgeHours: config.reflectionUpdateMinAgeHours,
       // v0.4.4 fix：显式透传，用户配 dreamImplicitKeep:false 时严格模式必须
@@ -732,9 +732,28 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
       skipInvalid: config.dreamSkipInvalid !== false,
       allowCrossTypeMerge: config.allowCrossTypeMerge === true
     });
+    // Issue #135：模型把 UUID 缩写成前缀时，唯一前缀已在校验前被解析回完整 id。
+    // 解析量是模型输出质量的一个直接信号（>0 意味着模型在缩写 id），记一条 info
+    // 便于事后从日志侧观察该行为的分布。
+    if (resolvedShortIds > 0) {
+      logger?.info?.(`[dsh-mneme] dream: resolved ${resolvedShortIds} short id prefix(es) to full ids`);
+    }
     if (!ok) {
+      // Issue #135（观测缺口）：失败轮的逐条校验明细此前既不落库也基本不可见——
+      // skipped 的 warn 写在 return 之后（失败路径到不了），dream_runs.decisions
+      // 落 NULL，上百轮失败零现场。这里把明细前置到日志，并把
+      // { _validationFailed, errors, skipped } 随失败行持久化，事后可从审计行
+      // 直接定位「模型输出了什么、为何逐条非法」。
       logger?.warn?.(`dsh-mneme dream: invalid decisions: ${errors.join("; ")}`);
-      return finish({ ok: false, error: `invalid decisions: ${errors.length} errors`, summary: false });
+      if (skipped.length > 0) {
+        logger?.warn?.(`dsh-mneme dream: ${skipped.length} invalid decision(s) skipped: ${skipped.map((s) => `decision[${s.index}]: ${s.error}`).join("; ")}`);
+      }
+      return finish({
+        ok: false,
+        error: `invalid decisions: ${errors.length} errors`,
+        summary: false,
+        decisions: [{ _validationFailed: true, errors, skipped }]
+      });
     }
     const skippedInvalid = skipped.length > 0;
     if (skippedInvalid) {

--- a/dsh-mneme/lib/dream/decisions.js
+++ b/dsh-mneme/lib/dream/decisions.js
@@ -13,7 +13,8 @@ const EPISTEMIC_PRIORITY = { observation: 3, inferred: 2, subjective: 1 };
  *   entries are spliced out of this array in place (the caller reuses the same
  *   reference downstream for apply/audit); implicit keeps are appended here too.
  * @param snapshot - Map<id, memory> of eligible (non-archived, non-summary) entries.
- * @returns {{ok: boolean, errors: string[], skipped?: Array<{index, action, ids, error}>}}
+ * @returns {{ok: boolean, errors: string[], skipped?: Array<{index, action, ids, error}>,
+ *   resolvedShortIds?: number}}
  */
 export function validateDecisions(decisions, snapshot, options = {}) {
   const errors = [];
@@ -28,14 +29,47 @@ export function validateDecisions(decisions, snapshot, options = {}) {
   const maxUpdatePerRun = options.maxUpdatePerRun ?? 2;
   const minAgeHours = options.minAgeHours ?? 24;
   if (!Array.isArray(decisions)) {
-    return { ok: false, errors: ["decision list must be an array"] };
+    return { ok: false, errors: ["decision list must be an array"], resolvedShortIds: 0 };
   }
   // 空决策 = 模型完整评估后确认无需操作（CONSOLIDATION_PROMPT 明确允许"无问题的
   // 条目无需输出"）。合法 JSON [] 不是空体（那是无输出/截断），也不是"残缺输出"
   // ——显式短路直接 ok，避免隐式 keep 的覆盖率检查把 0% 误判为模型坏了。与
   // sleep 的空模式（skipped no-op）语义对齐：下游 applied=0、audit 记 ok。
   if (decisions.length === 0) {
-    return { ok: true, errors: [], skipped: [] };
+    return { ok: true, errors: [], skipped: [], resolvedShortIds: 0 };
+  }
+  // Issue #135：模型常把 36 位 UUID 回填成前缀（实测 78/78 个 8 位前缀都能唯一
+  // 对应窗口内真实记忆，且 few-shot 示例的 "m1"/"m2" 占位符在诱导这种缩写），而
+  // 下方校验用 snapshot.get(id) 整串精确匹配 → 全部 unknown id → claimed=0 →
+  // 覆盖率闸整单拒绝，一整轮语义成果被丢。校验前先把「唯一前缀」解析回完整 id
+  // （git 短哈希式）：仅在 snapshot 内解析，有歧义或匹配不到就原样保留，仍由下
+  // 方 unknown id 校验如实报错。就地改写 ids / keepSource / winner / loser，下
+  // 游 applyDecisions 与审计拿到的同样是完整 id。
+  let resolvedShortIds = 0;
+  const resolveShortId = (value) => {
+    if (typeof value !== "string" || snapshot.has(value)) return value;
+    // 太短不猜（歧义概率高）；长度 ≥36 说明不是前缀缩写，交给校验如实报错。
+    if (value.length < 8 || value.length >= 36) return value;
+    let hit = null;
+    let matches = 0;
+    for (const id of snapshot.keys()) {
+      if (id.startsWith(value)) {
+        hit = id;
+        if (++matches > 1) return value; // 有歧义，不解析
+      }
+    }
+    if (matches === 1) {
+      resolvedShortIds++;
+      return hit;
+    }
+    return value;
+  };
+  for (const d of decisions) {
+    if (!d || typeof d !== "object") continue;
+    if (Array.isArray(d.ids)) d.ids = d.ids.map(resolveShortId);
+    if (typeof d.keepSource === "string") d.keepSource = resolveShortId(d.keepSource);
+    if (typeof d.winner === "string") d.winner = resolveShortId(d.winner);
+    if (typeof d.loser === "string") d.loser = resolveShortId(d.loser);
   }
   const claimed = new Set();
   for (const [index, d] of decisions.entries()) {
@@ -172,14 +206,14 @@ export function validateDecisions(decisions, snapshot, options = {}) {
   // snapshot（claimed.size / snapshot.size < dreamMinExplicitCoverage）时整单拒绝，
   // 而不是用 keep 把绝大部分 snapshot 全部"通过"。
   if (errors.length > 0) {
-    return { ok: false, errors, skipped };
+    return { ok: false, errors, skipped, resolvedShortIds };
   }
   const minCoverage = options.dreamMinExplicitCoverage ?? 0.5;
   if (options.dreamImplicitKeep !== false) {
     const coverage = snapshot.size > 0 ? claimed.size / snapshot.size : 1;
     if (coverage < minCoverage) {
       errors.push(`explicit decision coverage ${Math.round(coverage * 100)}% < minimum ${Math.round(minCoverage * 100)}%`);
-      return { ok: false, errors, skipped };
+      return { ok: false, errors, skipped, resolvedShortIds };
     }
     for (const id of snapshot.keys()) {
       if (!claimed.has(id)) survivors.push({ action: "keep", ids: [id] });
@@ -188,7 +222,7 @@ export function validateDecisions(decisions, snapshot, options = {}) {
     for (const id of snapshot.keys()) {
       if (!claimed.has(id)) errors.push(`memory ${JSON.stringify(id)} missing from decisions`);
     }
-    if (errors.length > 0) return { ok: false, errors, skipped };
+    if (errors.length > 0) return { ok: false, errors, skipped, resolvedShortIds };
   }
   // 调用方下游（apply/audit）复用同一 decisions 引用：就地同步为 survivors——
   // 在 skipInvalid 模式下去掉被跳过的非法决策；在隐式 keep 下追加补齐的 keep。
@@ -196,7 +230,7 @@ export function validateDecisions(decisions, snapshot, options = {}) {
   // 当"被跳过的非法决策数 == 隐式补齐的 keep 数"时长度回到相等但内容已变，
   // 被跳过的决策会残留进 apply/audit。一律无条件 splice 最安全。
   decisions.splice(0, decisions.length, ...survivors);
-  return { ok: true, errors, skipped };
+  return { ok: true, errors, skipped, resolvedShortIds };
 }
 
 /** Marker thrown when a decision target changed since the run snapshot. */

--- a/dsh-mneme/src/dream.js
+++ b/dsh-mneme/src/dream.js
@@ -720,7 +720,7 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
       logger?.warn?.(`dsh-mneme dream: no json array in llm output (raw length ${decisionText?.length ?? 0}; head: ${head})`);
       return finish({ ok: false, error: "no json array in llm output", summary: false });
     }
-    const { ok, errors, skipped } = validateDecisions(decisions, snapshot, {
+    const { ok, errors, skipped, resolvedShortIds } = validateDecisions(decisions, snapshot, {
       maxUpdatePerRun: config.reflectionUpdateMaxPerRun,
       minAgeHours: config.reflectionUpdateMinAgeHours,
       // v0.4.4 fix：显式透传，用户配 dreamImplicitKeep:false 时严格模式必须
@@ -732,9 +732,28 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
       skipInvalid: config.dreamSkipInvalid !== false,
       allowCrossTypeMerge: config.allowCrossTypeMerge === true
     });
+    // Issue #135：模型把 UUID 缩写成前缀时，唯一前缀已在校验前被解析回完整 id。
+    // 解析量是模型输出质量的一个直接信号（>0 意味着模型在缩写 id），记一条 info
+    // 便于事后从日志侧观察该行为的分布。
+    if (resolvedShortIds > 0) {
+      logger?.info?.(`[dsh-mneme] dream: resolved ${resolvedShortIds} short id prefix(es) to full ids`);
+    }
     if (!ok) {
+      // Issue #135（观测缺口）：失败轮的逐条校验明细此前既不落库也基本不可见——
+      // skipped 的 warn 写在 return 之后（失败路径到不了），dream_runs.decisions
+      // 落 NULL，上百轮失败零现场。这里把明细前置到日志，并把
+      // { _validationFailed, errors, skipped } 随失败行持久化，事后可从审计行
+      // 直接定位「模型输出了什么、为何逐条非法」。
       logger?.warn?.(`dsh-mneme dream: invalid decisions: ${errors.join("; ")}`);
-      return finish({ ok: false, error: `invalid decisions: ${errors.length} errors`, summary: false });
+      if (skipped.length > 0) {
+        logger?.warn?.(`dsh-mneme dream: ${skipped.length} invalid decision(s) skipped: ${skipped.map((s) => `decision[${s.index}]: ${s.error}`).join("; ")}`);
+      }
+      return finish({
+        ok: false,
+        error: `invalid decisions: ${errors.length} errors`,
+        summary: false,
+        decisions: [{ _validationFailed: true, errors, skipped }]
+      });
     }
     const skippedInvalid = skipped.length > 0;
     if (skippedInvalid) {

--- a/dsh-mneme/src/dream/decisions.js
+++ b/dsh-mneme/src/dream/decisions.js
@@ -13,7 +13,8 @@ const EPISTEMIC_PRIORITY = { observation: 3, inferred: 2, subjective: 1 };
  *   entries are spliced out of this array in place (the caller reuses the same
  *   reference downstream for apply/audit); implicit keeps are appended here too.
  * @param snapshot - Map<id, memory> of eligible (non-archived, non-summary) entries.
- * @returns {{ok: boolean, errors: string[], skipped?: Array<{index, action, ids, error}>}}
+ * @returns {{ok: boolean, errors: string[], skipped?: Array<{index, action, ids, error}>,
+ *   resolvedShortIds?: number}}
  */
 export function validateDecisions(decisions, snapshot, options = {}) {
   const errors = [];
@@ -28,14 +29,47 @@ export function validateDecisions(decisions, snapshot, options = {}) {
   const maxUpdatePerRun = options.maxUpdatePerRun ?? 2;
   const minAgeHours = options.minAgeHours ?? 24;
   if (!Array.isArray(decisions)) {
-    return { ok: false, errors: ["decision list must be an array"] };
+    return { ok: false, errors: ["decision list must be an array"], resolvedShortIds: 0 };
   }
   // 空决策 = 模型完整评估后确认无需操作（CONSOLIDATION_PROMPT 明确允许"无问题的
   // 条目无需输出"）。合法 JSON [] 不是空体（那是无输出/截断），也不是"残缺输出"
   // ——显式短路直接 ok，避免隐式 keep 的覆盖率检查把 0% 误判为模型坏了。与
   // sleep 的空模式（skipped no-op）语义对齐：下游 applied=0、audit 记 ok。
   if (decisions.length === 0) {
-    return { ok: true, errors: [], skipped: [] };
+    return { ok: true, errors: [], skipped: [], resolvedShortIds: 0 };
+  }
+  // Issue #135：模型常把 36 位 UUID 回填成前缀（实测 78/78 个 8 位前缀都能唯一
+  // 对应窗口内真实记忆，且 few-shot 示例的 "m1"/"m2" 占位符在诱导这种缩写），而
+  // 下方校验用 snapshot.get(id) 整串精确匹配 → 全部 unknown id → claimed=0 →
+  // 覆盖率闸整单拒绝，一整轮语义成果被丢。校验前先把「唯一前缀」解析回完整 id
+  // （git 短哈希式）：仅在 snapshot 内解析，有歧义或匹配不到就原样保留，仍由下
+  // 方 unknown id 校验如实报错。就地改写 ids / keepSource / winner / loser，下
+  // 游 applyDecisions 与审计拿到的同样是完整 id。
+  let resolvedShortIds = 0;
+  const resolveShortId = (value) => {
+    if (typeof value !== "string" || snapshot.has(value)) return value;
+    // 太短不猜（歧义概率高）；长度 ≥36 说明不是前缀缩写，交给校验如实报错。
+    if (value.length < 8 || value.length >= 36) return value;
+    let hit = null;
+    let matches = 0;
+    for (const id of snapshot.keys()) {
+      if (id.startsWith(value)) {
+        hit = id;
+        if (++matches > 1) return value; // 有歧义，不解析
+      }
+    }
+    if (matches === 1) {
+      resolvedShortIds++;
+      return hit;
+    }
+    return value;
+  };
+  for (const d of decisions) {
+    if (!d || typeof d !== "object") continue;
+    if (Array.isArray(d.ids)) d.ids = d.ids.map(resolveShortId);
+    if (typeof d.keepSource === "string") d.keepSource = resolveShortId(d.keepSource);
+    if (typeof d.winner === "string") d.winner = resolveShortId(d.winner);
+    if (typeof d.loser === "string") d.loser = resolveShortId(d.loser);
   }
   const claimed = new Set();
   for (const [index, d] of decisions.entries()) {
@@ -172,14 +206,14 @@ export function validateDecisions(decisions, snapshot, options = {}) {
   // snapshot（claimed.size / snapshot.size < dreamMinExplicitCoverage）时整单拒绝，
   // 而不是用 keep 把绝大部分 snapshot 全部"通过"。
   if (errors.length > 0) {
-    return { ok: false, errors, skipped };
+    return { ok: false, errors, skipped, resolvedShortIds };
   }
   const minCoverage = options.dreamMinExplicitCoverage ?? 0.5;
   if (options.dreamImplicitKeep !== false) {
     const coverage = snapshot.size > 0 ? claimed.size / snapshot.size : 1;
     if (coverage < minCoverage) {
       errors.push(`explicit decision coverage ${Math.round(coverage * 100)}% < minimum ${Math.round(minCoverage * 100)}%`);
-      return { ok: false, errors, skipped };
+      return { ok: false, errors, skipped, resolvedShortIds };
     }
     for (const id of snapshot.keys()) {
       if (!claimed.has(id)) survivors.push({ action: "keep", ids: [id] });
@@ -188,7 +222,7 @@ export function validateDecisions(decisions, snapshot, options = {}) {
     for (const id of snapshot.keys()) {
       if (!claimed.has(id)) errors.push(`memory ${JSON.stringify(id)} missing from decisions`);
     }
-    if (errors.length > 0) return { ok: false, errors, skipped };
+    if (errors.length > 0) return { ok: false, errors, skipped, resolvedShortIds };
   }
   // 调用方下游（apply/audit）复用同一 decisions 引用：就地同步为 survivors——
   // 在 skipInvalid 模式下去掉被跳过的非法决策；在隐式 keep 下追加补齐的 keep。
@@ -196,7 +230,7 @@ export function validateDecisions(decisions, snapshot, options = {}) {
   // 当"被跳过的非法决策数 == 隐式补齐的 keep 数"时长度回到相等但内容已变，
   // 被跳过的决策会残留进 apply/audit。一律无条件 splice 最安全。
   decisions.splice(0, decisions.length, ...survivors);
-  return { ok: true, errors, skipped };
+  return { ok: true, errors, skipped, resolvedShortIds };
 }
 
 /** Marker thrown when a decision target changed since the run snapshot. */

--- a/dsh-mneme/test/dream.test.js
+++ b/dsh-mneme/test/dream.test.js
@@ -27,6 +27,56 @@ test("unknown id rejects whole list", () => {
   assert.ok(errors.some((e) => e.includes("zzz")));
 });
 
+// --- Issue #135: 唯一前缀解析 -------------------------------------------------
+// 模型常把 36 位 UUID 回填成前缀（报告实测 78/78 个 8 位前缀都能唯一对应窗口内
+// 真实记忆，且 few-shot 示例的 "m1"/"m2" 占位符在诱导这种缩写）。校验前的唯一
+// 前缀解析把它们还原成完整 id，而不是逐条 unknown id 后被覆盖率闸整单拒绝。
+
+test("Issue #135: unique short prefixes resolve to full ids (ids + keepSource)", () => {
+  const idA = "f77a0d17-2586-41fe-a789-d69f4d1cee83";
+  const idB = "bc17c9ed-e84c-4b9f-bc36-48f8e9a6b3e0";
+  const snap = snapshot([idA, idB]);
+  const decisions = [
+    { action: "merge", ids: ["f77a0d17", "bc17c9ed"], title: "合并", content: "合并后的内容", importance: 4, keepSource: "f77a0d17" }
+  ];
+  const { ok, errors, resolvedShortIds } = validateDecisions(decisions, snap);
+  assert.equal(ok, true, JSON.stringify(errors));
+  assert.equal(resolvedShortIds, 3, "two ids + keepSource resolved");
+  assert.deepEqual(decisions[0].ids, [idA, idB], "ids rewritten in place");
+  assert.equal(decisions[0].keepSource, idA, "keepSource rewritten");
+});
+
+test("Issue #135: conflict winner/loser short prefixes resolve", () => {
+  const idA = "f77a0d17-2586-41fe-a789-d69f4d1cee83";
+  const idB = "bc17c9ed-e84c-4b9f-bc36-48f8e9a6b3e0";
+  const snap = snapshot([idA, idB]);
+  const decisions = [{ action: "conflict", winner: "f77a0d17", loser: "bc17c9ed", reason: "内容矛盾" }];
+  const { ok, errors, resolvedShortIds } = validateDecisions(decisions, snap);
+  assert.equal(ok, true, JSON.stringify(errors));
+  assert.equal(resolvedShortIds, 2);
+  assert.equal(decisions[0].winner, idA, "winner rewritten");
+  assert.equal(decisions[0].loser, idB, "loser rewritten");
+});
+
+test("Issue #135: ambiguous prefix stays unresolved and reports unknown id", () => {
+  const snap = snapshot([
+    "aaaaaaaa-1111-4111-8111-111111111111",
+    "aaaaaaaa-2222-4222-8222-222222222222"
+  ]);
+  const { ok, errors, resolvedShortIds } = validateDecisions([{ action: "archive", ids: ["aaaaaaaa"] }], snap);
+  assert.equal(ok, false);
+  assert.equal(resolvedShortIds, 0, "ambiguous prefix is never guessed");
+  assert.ok(errors.some((e) => e.includes("unknown id")), JSON.stringify(errors));
+});
+
+test("Issue #135: unmatched prefix is left for the validator to report", () => {
+  const snap = snapshot(["f77a0d17-2586-41fe-a789-d69f4d1cee83"]);
+  const { ok, errors, resolvedShortIds } = validateDecisions([{ action: "archive", ids: ["deadbeef"] }], snap);
+  assert.equal(ok, false);
+  assert.equal(resolvedShortIds, 0, "no match means no rewrite");
+  assert.ok(errors.some((e) => e.includes("deadbeef")), JSON.stringify(errors));
+});
+
 test("invalid action rejects", () => {
   const snap = snapshot(["a"]);
   const { ok } = validateDecisions([{ action: "explode", ids: ["a"] }], snap);
@@ -483,6 +533,36 @@ test("runDream fails safe on invalid decisions", async () => {
   assert.equal(lang.archived, false, "original memory not archived");
   assert.equal(lang.content, "中文", "original memory content untouched");
   assert.ok(warnings.length >= 1, "failure was logged");
+  store.close();
+});
+
+test("Issue #135: failed validation persists { _validationFailed, errors, skipped } into the run row", async () => {
+  const { store, service } = dreamSetup();
+  const saved = service.saveWithDedupe({ type: "preference", title: "语言", content: "中文" });
+  let calls = 0;
+  const ctx = {
+    llm: {
+      stream: async function* () {
+        calls++;
+        yield { type: "text-delta", text: calls === 1 ? JSON.stringify([{ action: "archive", ids: ["deadbeef"] }]) : "summary" };
+        yield { type: "finish", reason: { kind: "ok" } };
+      }
+    },
+    logger: { warn: () => {}, info: () => {} }
+  };
+  const dream = createDreamScheduler({ thresholdCount: 1, thresholdChars: 0, delayMs: 0 });
+  const result = await dream.runDream(ctx, service, { dreamProvider: "deepseek", dreamModel: "deepseek-chat" });
+  assert.equal(result.ok, false, "coverage gate rejects (0% explicit coverage)");
+  assert.ok(Array.isArray(result.decisions) && result.decisions[0]?._validationFailed === true,
+    "failure result carries the validation detail");
+  assert.ok(result.decisions[0].skipped.some((s) => s.error.includes("deadbeef")),
+    "skipped keeps the per-item reason");
+  // 落库验证：dream_runs.decisions 不再是 NULL，事后可离线定位失败原因。
+  const run = store.getDreamRun(result.runId);
+  assert.ok(run?.decisions?.[0]?._validationFailed === true, "detail persisted in dream_runs.decisions");
+  assert.ok(run.decisions[0].skipped.length >= 1);
+  const lang = store.getById(saved.memory.id);
+  assert.equal(lang.archived, false, "unknown-id decision must not touch real memories");
   store.close();
 });
 


### PR DESCRIPTION
承接 #135（第一批：建议 1「唯一前缀解析」+ 建议 2「失败落库」）。预算/档位默认值（建议 3/4/5）随后另行提交，本 PR 不动它们；解析语义参考报告者 @aizhimoran 的验证补丁（认领评论已注明出处，感谢）。

## 问题一：模型缩写 id → 整轮成果被覆盖率闸拒绝

模型常把 36 位 UUID 回填成前缀（报告实测 78/78 个 8 位前缀都能唯一对应窗口内真实记忆），而 `validateDecisions` 用 `snapshot.get(id)` 整串精确匹配 → 全部 `unknown id` → `claimed=0` → 覆盖率闸整单拒绝。

**修法**：校验循环前做「唯一前缀 → 完整 id」解析（git 短哈希式）：

- 仅在 snapshot 内解析；`<8` 位不猜、有歧义不猜、无匹配原样保留——仍由 unknown id 校验如实报错，不引入任何新的宽容度；
- 就地改写 `ids` / `keepSource` / `winner` / `loser`，下游 `applyDecisions`、receipt、审计拿到的同样是完整 id；
- 返回值新增 `resolvedShortIds`，dream 侧解析量 >0 时记一条 info——这是「模型在缩写 id」行为的直接信号，便于从日志观察分布。

## 问题二：失败轮零现场

invalid-decisions 失败路径的 `skipped` 明细 warn 写在 `return` 之后（不可达），`dream_runs.decisions` 落 NULL——报告实测 168 轮失败没有一轮留下「模型输出了什么」的痕迹。

**修法**：skipped 明细 warn 前置到 `return` 之前；失败行持久化 `decisions: [{ _validationFailed: true, errors, skipped }]`（`finish`/`saveDreamRun` 本就透传该字段，无需动 store）。事后从审计行即可直接定位逐条失败原因。

## 测试

+5 用例（`test/dream.test.js`）：

- 唯一前缀还原 `ids` + `keepSource`（merge）
- `conflict` 的 winner/loser 前缀还原
- 歧义前缀不猜（两 id 共享前缀 → 原样保留 → unknown id）
- 无匹配前缀不猜（`deadbeef` → 如实报错）
- 端到端：校验失败的 run 行落库 `{ _validationFailed, errors, skipped }`，且 unknown-id 决策不触碰真实记忆

全量 **819 项通过**（813→818 pass，0 fail，1 skip 为既有）。

## 影响面

- 校验语义零放宽：解析只在「snapshot 内唯一命中」时发生，其余一切照旧；
- 正常输出（完整 id）路径行为不变，`snapshot.has()` 短路；
- 性能：O(未解析 id 数 × snapshot 大小) 的 startsWith 扫描，200×200 量级可忽略。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decision identifiers can now use unique shortened UUID prefixes.
  * Failed decision validations retain detailed error and skipped-item information in run history.
  * Logs now indicate when shortened identifiers were resolved.

* **Bug Fixes**
  * Ambiguous or unmatched identifiers continue to be reported as validation errors.

* **Tests**
  * Added coverage for shortened identifiers across decision and conflict fields, plus validation-failure persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->