### PR TITLE
fix(service): 质量过滤 importance 豁免 + 系统信号标签不被 update 抹掉（issue #135）

### DIFF
--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -187,7 +187,7 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 - `30 ≤ score < 60`：`quality_score` 落库，注入排序改为按 `importance × quality/100` 降权（degraded）
 - `score < 30`：归档并标记 `low_quality`——仍可显式搜索召回，只是**永不自动注入**。**例外（#135）**：`importance ≥ memoryQualityFilter.exemptImportance`（默认 4）的记忆只降权不归档——评分与信号标签照常落库，归档决定不再静默越过用户标注的重要性
 
-`memoryQualityFilter.enabled` 可整体关闭，`archiveThreshold` / `degradeThreshold` / `minContentLength` / `exemptImportance`（1=全部豁免，5=仅最重要豁免）可调。此外更新记忆（`memory_update` 等）不会抹掉系统信号标签（`low_quality` / `duplicate` / `meta` / `repetitive` / `short_content`）——它们是「为什么被降权/归档」的审计线索，与用户自传标签并集保留（#135）。
+`memoryQualityFilter.enabled` 可整体关闭，`archiveThreshold` / `degradeThreshold` / `minContentLength` / `exemptImportance`（1=全部豁免，5=仅最重要豁免）可调。此外更新记忆（`memory_update` 等）不会抹掉系统信号标签（`low_quality` / `duplicate` / `meta` / `self_referential` / `repetitive` / `short_content`）——它们是「为什么被降权/归档」的审计线索，与用户自传标签并集保留（#135）。
 
 ### LLM 消耗审计 📊（v0.4.6，默认开）
 

--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -185,9 +185,9 @@ v0.3.0 起新增**记忆基因**层：从记忆里抽取**命名实体**、**带
 
 - `score ≥ 60`：正常存储
 - `30 ≤ score < 60`：`quality_score` 落库，注入排序改为按 `importance × quality/100` 降权（degraded）
-- `score < 30`：归档并标记 `low_quality`——仍可显式搜索召回，只是**永不自动注入**
+- `score < 30`：归档并标记 `low_quality`——仍可显式搜索召回，只是**永不自动注入**。**例外（#135）**：`importance ≥ memoryQualityFilter.exemptImportance`（默认 4）的记忆只降权不归档——评分与信号标签照常落库，归档决定不再静默越过用户标注的重要性
 
-`memoryQualityFilter.enabled` 可整体关闭，`archiveThreshold` / `degradeThreshold` / `minContentLength` 可调。
+`memoryQualityFilter.enabled` 可整体关闭，`archiveThreshold` / `degradeThreshold` / `minContentLength` / `exemptImportance`（1=全部豁免，5=仅最重要豁免）可调。此外更新记忆（`memory_update` 等）不会抹掉系统信号标签（`low_quality` / `duplicate` / `meta` / `repetitive` / `short_content`）——它们是「为什么被降权/归档」的审计线索，与用户自传标签并集保留（#135）。
 
 ### LLM 消耗审计 📊（v0.4.6，默认开）
 
@@ -449,7 +449,7 @@ dsh web
 | `selectiveInjectEnabled` | `true` | 选择性注入（v0.5.0）：query 向量可用时注入候选按主题相似度重排，替代固定规则序 |
 | `searchSemanticDedup` | `false` | 搜索时语义去重（v0.5.0，激进选项默认关）：embedding 余弦 ≥0.95 近重复行在 Rerank 前丢弃 |
 | `searchSemanticDedupThreshold` | `0.95` | 语义去重相似度阈值（v0.5.0，默认 0.95，范围 0.5-1.0）：`searchSemanticDedup=true` 时生效，调整可防小模型误折叠 |
-| `memoryQualityFilter` | `{enabled:true, archiveThreshold:30, degradeThreshold:60, minContentLength:10}` | 记忆质量过滤（v0.4.6，默认开）：写库前启发式打分 0-100，元记忆词汇/自指/过短/重复/近似重复扣分；≥60 正常存储，30-60 降权（注入排序按 importance×quality/100），<30 归档标记 `low_quality`（显式搜索仍可召回，永不自动注入） |
+| `memoryQualityFilter` | `{enabled:true, archiveThreshold:30, degradeThreshold:60, minContentLength:10, exemptImportance:4}` | 记忆质量过滤（v0.4.6，默认开）：写库前启发式打分 0-100，元记忆词汇/自指/过短/重复/近似重复扣分；≥60 正常存储，30-60 降权（注入排序按 importance×quality/100），<30 归档标记 `low_quality`（显式搜索仍可召回，永不自动注入；`exemptImportance` 豁免：importance ≥ 该值只降权不归档，#135） |
 | `llmAudit` | `{enabled:true, retentionDays:90}` | LLM 消耗审计（v0.4.6，默认开）：每次后台 LLM 调用（autoDream/autoSummarize）写 `llm_audit_logs`（tokens/duration/status/source）；失败记 error 不阻塞；只读 API `/api/dsh-mneme/semantic/llm-audit` + `/llm-audit/stats` |
 
 > 🔐 **API 安全**：DSH 无内置鉴权且默认仅监听 `127.0.0.1`。插件 API 默认开放（便于 Web 面板即装即用）。如需防护（如局域网暴露），在配置中设置 `apiToken`：写操作（画像/规则/命令）与密钥端点（`vector-config`、`vector-reindex`）需携带 `Authorization: Bearer <token>`（前端设置面板可填入同一 token），只读的 `list` / `search` / `semantic` 保持开放。`/api/dsh-mneme/vector-config` 返回的 `apiKey` 已掩码（`sk-***…`），存储仍保留明文供调用；前端回传空或掩码值表示"不改 key"。

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -331,7 +331,12 @@ export const Config = z.object({
     enabled: z.boolean().default(true),
     archiveThreshold: z.natural().min(1).max(100).default(30),
     degradeThreshold: z.natural().min(1).max(100).default(60),
-    minContentLength: z.natural().min(1).max(1000).default(10)
+    minContentLength: z.natural().min(1).max(1000).default(10),
+    // Issue #135 附属发现 1：importance ≥ 该值的记忆不参与静默自动归档——评分
+    // 与信号标签照常写入（可观测）、注入排序照常降权，但 setArchived 跳过。
+    // 报告实测 150 条低分归档里 128 条 importance ≥ 4（51 条 = 5）。设 1 = 全部
+    // 豁免（等效关闭自动归档），设 5 = 仅最重要的豁免。
+    exemptImportance: z.natural().min(1).max(5).default(4)
   }).default({}),
 
   // --- LLM audit trail (Bug8) ------------------------------------------------

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -35,7 +35,8 @@ const CONTENT_HISTORY_MAX = 20;
 
 // Issue #135 附属发现 2：质量过滤器写下的系统信号标签（「为什么被降权/归档」的
 // 唯一审计线索）。更新路径整组替换 tags 会把它们抹掉——更新时按此清单并集保留。
-const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_content"];
+// 清单必须与 quality-filter.js 的写入端对齐（6 个，含 type 自指的 self_referential）。
+const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_content", "self_referential"];
 
 /** Prepend the previous content to a memory's content_history (FIFO capped). */
 function pushContentHistory(existing, source) {

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -33,6 +33,10 @@ const EPISTEMIC_WEIGHTS = { observation: 1.0, inferred: 0.85, subjective: 0.7 };
 // how the version was superseded (auto_merge | human_override | overwrite).
 const CONTENT_HISTORY_MAX = 20;
 
+// Issue #135 附属发现 2：质量过滤器写下的系统信号标签（「为什么被降权/归档」的
+// 唯一审计线索）。更新路径整组替换 tags 会把它们抹掉——更新时按此清单并集保留。
+const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_content"];
+
 /** Prepend the previous content to a memory's content_history (FIFO capped). */
 function pushContentHistory(existing, source) {
   const history = Array.isArray(existing?.content_history) ? existing.content_history : [];
@@ -963,6 +967,12 @@ export function createService({ store, mirror, config, onWrite, logger }) {
    * (importance × score/100). Best-effort: a disposition write failure must
    * never fail the save. Returns the (possibly refreshed) memory row so callers
    * see the archived/tagged state, not the pre-disposition snapshot.
+   *
+   * Issue #135 附属发现 1：importance ≥ memoryQualityFilter.exemptImportance
+   * （默认 4）的记忆不参与静默自动归档——评分与信号标签照常写入（可观测），
+   * 注入排序照常按 importance × score/100 降权，但 setArchived 跳过。报告实测
+   * 150 条低分归档里 128 条 importance ≥ 4（51 条 = 5）：一条被显式标为重要的
+   * 记忆不该被规则分静默归档、无感知无豁免。
    */
   function applyQualityDisposition(memory, quality, qf) {
     if (!quality || qf?.enabled !== true) return memory;
@@ -970,14 +980,21 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     // Signal tags (meta / repetitive / duplicate / short_content / low_quality)
     // are merged onto the stored row in every assessed band so the verdict is
     // observable, not just the numeric score. Below the archive threshold the
-    // memory is additionally archived (still explicitly searchable).
+    // memory is additionally archived (still explicitly searchable) — unless
+    // its importance reaches the exemption floor (kept active, demoted only).
     const tags = [...new Set([...(memory.tags ?? []), ...(quality.tags ?? [])])];
-    if (tags.length === (memory.tags?.length ?? 0) && quality.score >= archiveThreshold) {
+    const exemptImportance = qf.exemptImportance ?? 4;
+    const importanceExempt = Number.isInteger(memory.importance) && memory.importance >= exemptImportance;
+    if (tags.length === (memory.tags?.length ?? 0) && (quality.score >= archiveThreshold || importanceExempt)) {
       return memory; // no tag drift and not archived → nothing extra to write
     }
     try {
       store.update(memory.id, { tags, quality_score: quality.score });
-      if (quality.score < archiveThreshold) store.setArchived(memory.id, true);
+      if (quality.score < archiveThreshold && !importanceExempt) {
+        store.setArchived(memory.id, true);
+      } else if (quality.score < archiveThreshold) {
+        logger?.info?.(`[dsh-mneme] quality filter: memory ${memory.id} scored ${quality.score} < ${archiveThreshold} but importance ${memory.importance} >= exemptImportance ${exemptImportance}; demoted, not archived`);
+      }
       return store.getById(memory.id);
     } catch {
       return memory;
@@ -1492,7 +1509,15 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     },
     update: (id, p, ctx = {}) => {
       const old = store.getById(id);
-      const updated = store.update(id, p);
+      // Issue #135 附属发现 2：质量过滤器把「为什么被降权/归档」写在系统信号标签
+      // 上（SIGNAL_TAGS，applyQualityDisposition 以并集写入），而这里整组替换
+      // tags——任何带 tags 的更新都会抹掉这条唯一的审计线索（报告实测 150 条低分
+      // 记忆里恰好缺的 2 条就是被 update 过的，并因此误判过归档来源）。把 existing
+      // 的系统信号标签并集保留；用户自传的标签照常生效。
+      const patch = (p && Array.isArray(p.tags) && old && Array.isArray(old.tags))
+        ? { ...p, tags: [...new Set([...p.tags, ...old.tags.filter((t) => SIGNAL_TAGS.includes(t))])] }
+        : p;
+      const updated = store.update(id, patch);
       // Record a user correction when any meaningful field changed and the
       // reflection failure tracker is enabled. expected = what it became,
       // actual = what it was before; query (when provided) captures the

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -331,7 +331,12 @@ export const Config = z.object({
     enabled: z.boolean().default(true),
     archiveThreshold: z.natural().min(1).max(100).default(30),
     degradeThreshold: z.natural().min(1).max(100).default(60),
-    minContentLength: z.natural().min(1).max(1000).default(10)
+    minContentLength: z.natural().min(1).max(1000).default(10),
+    // Issue #135 附属发现 1：importance ≥ 该值的记忆不参与静默自动归档——评分
+    // 与信号标签照常写入（可观测）、注入排序照常降权，但 setArchived 跳过。
+    // 报告实测 150 条低分归档里 128 条 importance ≥ 4（51 条 = 5）。设 1 = 全部
+    // 豁免（等效关闭自动归档），设 5 = 仅最重要的豁免。
+    exemptImportance: z.natural().min(1).max(5).default(4)
   }).default({}),
 
   // --- LLM audit trail (Bug8) ------------------------------------------------

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -35,7 +35,8 @@ const CONTENT_HISTORY_MAX = 20;
 
 // Issue #135 附属发现 2：质量过滤器写下的系统信号标签（「为什么被降权/归档」的
 // 唯一审计线索）。更新路径整组替换 tags 会把它们抹掉——更新时按此清单并集保留。
-const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_content"];
+// 清单必须与 quality-filter.js 的写入端对齐（6 个，含 type 自指的 self_referential）。
+const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_content", "self_referential"];
 
 /** Prepend the previous content to a memory's content_history (FIFO capped). */
 function pushContentHistory(existing, source) {

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -33,6 +33,10 @@ const EPISTEMIC_WEIGHTS = { observation: 1.0, inferred: 0.85, subjective: 0.7 };
 // how the version was superseded (auto_merge | human_override | overwrite).
 const CONTENT_HISTORY_MAX = 20;
 
+// Issue #135 附属发现 2：质量过滤器写下的系统信号标签（「为什么被降权/归档」的
+// 唯一审计线索）。更新路径整组替换 tags 会把它们抹掉——更新时按此清单并集保留。
+const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_content"];
+
 /** Prepend the previous content to a memory's content_history (FIFO capped). */
 function pushContentHistory(existing, source) {
   const history = Array.isArray(existing?.content_history) ? existing.content_history : [];
@@ -963,6 +967,12 @@ export function createService({ store, mirror, config, onWrite, logger }) {
    * (importance × score/100). Best-effort: a disposition write failure must
    * never fail the save. Returns the (possibly refreshed) memory row so callers
    * see the archived/tagged state, not the pre-disposition snapshot.
+   *
+   * Issue #135 附属发现 1：importance ≥ memoryQualityFilter.exemptImportance
+   * （默认 4）的记忆不参与静默自动归档——评分与信号标签照常写入（可观测），
+   * 注入排序照常按 importance × score/100 降权，但 setArchived 跳过。报告实测
+   * 150 条低分归档里 128 条 importance ≥ 4（51 条 = 5）：一条被显式标为重要的
+   * 记忆不该被规则分静默归档、无感知无豁免。
    */
   function applyQualityDisposition(memory, quality, qf) {
     if (!quality || qf?.enabled !== true) return memory;
@@ -970,14 +980,21 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     // Signal tags (meta / repetitive / duplicate / short_content / low_quality)
     // are merged onto the stored row in every assessed band so the verdict is
     // observable, not just the numeric score. Below the archive threshold the
-    // memory is additionally archived (still explicitly searchable).
+    // memory is additionally archived (still explicitly searchable) — unless
+    // its importance reaches the exemption floor (kept active, demoted only).
     const tags = [...new Set([...(memory.tags ?? []), ...(quality.tags ?? [])])];
-    if (tags.length === (memory.tags?.length ?? 0) && quality.score >= archiveThreshold) {
+    const exemptImportance = qf.exemptImportance ?? 4;
+    const importanceExempt = Number.isInteger(memory.importance) && memory.importance >= exemptImportance;
+    if (tags.length === (memory.tags?.length ?? 0) && (quality.score >= archiveThreshold || importanceExempt)) {
       return memory; // no tag drift and not archived → nothing extra to write
     }
     try {
       store.update(memory.id, { tags, quality_score: quality.score });
-      if (quality.score < archiveThreshold) store.setArchived(memory.id, true);
+      if (quality.score < archiveThreshold && !importanceExempt) {
+        store.setArchived(memory.id, true);
+      } else if (quality.score < archiveThreshold) {
+        logger?.info?.(`[dsh-mneme] quality filter: memory ${memory.id} scored ${quality.score} < ${archiveThreshold} but importance ${memory.importance} >= exemptImportance ${exemptImportance}; demoted, not archived`);
+      }
       return store.getById(memory.id);
     } catch {
       return memory;
@@ -1492,7 +1509,15 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     },
     update: (id, p, ctx = {}) => {
       const old = store.getById(id);
-      const updated = store.update(id, p);
+      // Issue #135 附属发现 2：质量过滤器把「为什么被降权/归档」写在系统信号标签
+      // 上（SIGNAL_TAGS，applyQualityDisposition 以并集写入），而这里整组替换
+      // tags——任何带 tags 的更新都会抹掉这条唯一的审计线索（报告实测 150 条低分
+      // 记忆里恰好缺的 2 条就是被 update 过的，并因此误判过归档来源）。把 existing
+      // 的系统信号标签并集保留；用户自传的标签照常生效。
+      const patch = (p && Array.isArray(p.tags) && old && Array.isArray(old.tags))
+        ? { ...p, tags: [...new Set([...p.tags, ...old.tags.filter((t) => SIGNAL_TAGS.includes(t))])] }
+        : p;
+      const updated = store.update(id, patch);
       // Record a user correction when any meaningful field changed and the
       // reflection failure tracker is enabled. expected = what it became,
       // actual = what it was before; query (when provided) captures the

--- a/dsh-mneme/test/quality-filter.test.js
+++ b/dsh-mneme/test/quality-filter.test.js
@@ -169,3 +169,18 @@ test("Issue #135: update without tags leaves the row untouched (legacy path)", (
   service.update(memory.id, { content: "只改内容，不带 tags 字段" });
   assert.deepEqual(store.getById(memory.id).tags, before, "no tags in patch → tags untouched");
 });
+
+test("Issue #135 review: self_referential is a signal tag and survives a tagged update", () => {
+  const { store, service } = setup();
+  // type 自指（title 提到自身类型标签「偏好」）→ quality-filter.js 写
+  // self_referential（−15）；加短内容一起跌破归档线。SIGNAL_TAGS 清单必须
+  // 覆盖它，否则带 tags 的 update 恰好把这个标签抹掉（审计线索缺口）。
+  const { memory } = service.saveWithDedupe({ type: "preference", title: "偏好记录", content: "短" });
+  const tagged = store.getById(memory.id);
+  assert.ok(tagged.tags.includes("self_referential"), "precondition: self_referential written");
+
+  service.update(memory.id, { tags: ["用户标签"], content: "补充后的完整内容" });
+  const after = store.getById(memory.id);
+  assert.ok(after.tags.includes("self_referential"), "self_referential preserved through the update");
+  assert.ok(after.tags.includes("用户标签"), "user tags still applied");
+});

--- a/dsh-mneme/test/quality-filter.test.js
+++ b/dsh-mneme/test/quality-filter.test.js
@@ -116,3 +116,56 @@ test("exported helpers behave (meta regex, similarity, dedup ratio)", () => {
   assert.ok(dedupRatio("哈哈哈哈哈哈") < 0.3, "repetitive filler has low dedup ratio");
   assert.ok(dedupRatio("一句信息量足够的话") > 0.3);
 });
+
+// --- Issue #135 附属发现 1：importance ≥ exemptImportance 只降权，不静默归档 ----
+
+test("Issue #135: importance-5 memory below archive threshold is demoted, not archived", () => {
+  const { store, service } = setup();
+  const { memory } = service.saveWithDedupe({
+    type: "preference", title: "关键决策", content: "短", importance: 5
+  });
+  const got = store.getById(memory.id);
+  assert.equal(got.archived, false, "importance 5 >= exemptImportance 4 → kept active");
+  assert.ok(got.quality_score < 30, `score still persisted, got ${got.quality_score}`);
+  assert.ok(got.tags.includes("low_quality"), "signal tag still written (verdict observable)");
+});
+
+test("Issue #135: importance-4 is exempt by default; importance-3 is still archived", () => {
+  const { store, service } = setup();
+  const four = service.saveWithDedupe({ type: "preference", title: "决策甲", content: "短", importance: 4 }).memory;
+  const three = service.saveWithDedupe({ type: "preference", title: "决策乙", content: "短", importance: 3 }).memory;
+  assert.equal(store.getById(four.id).archived, false, "importance 4 exempt by default");
+  assert.equal(store.getById(three.id).archived, true, "importance 3 below the floor still archived");
+});
+
+test("Issue #135: exemptImportance=1 disables auto-archive; =5 narrows the floor", () => {
+  const one = setup({ memoryQualityFilter: { enabled: true, exemptImportance: 1 } });
+  const threeLow = one.service.saveWithDedupe({ type: "preference", title: "语言", content: "短", importance: 3 }).memory;
+  assert.equal(one.store.getById(threeLow.id).archived, false, "exemptImportance 1 exempts everything");
+
+  const five = setup({ memoryQualityFilter: { enabled: true, exemptImportance: 5 } });
+  const four = five.service.saveWithDedupe({ type: "preference", title: "决策甲", content: "短", importance: 4 }).memory;
+  assert.equal(five.store.getById(four.id).archived, true, "importance 4 no longer exempt at floor 5");
+});
+
+// --- Issue #135 附属发现 2：update 的 tags 整组替换不再抹掉系统信号标签 --------
+
+test("Issue #135: update with tags preserves the filter's signal tags", () => {
+  const { store, service } = setup();
+  const { memory } = service.saveWithDedupe({ type: "preference", title: "语言", content: "短" });
+  assert.ok(store.getById(memory.id).tags.includes("low_quality"), "precondition: filter tagged the row");
+
+  service.update(memory.id, { tags: ["用户标签"], content: "补充后的完整内容，不再是短文本了" });
+  const after = store.getById(memory.id);
+  assert.ok(after.tags.includes("用户标签"), "user tags applied");
+  assert.ok(after.tags.includes("low_quality"), "low_quality preserved through the update");
+  assert.ok(after.tags.includes("short_content"), "short_content preserved too");
+});
+
+test("Issue #135: update without tags leaves the row untouched (legacy path)", () => {
+  const { store, service } = setup();
+  const { memory } = service.saveWithDedupe({ type: "preference", title: "语言", content: "短" });
+  const before = store.getById(memory.id).tags;
+  service.update(memory.id, { content: "只改内容，不带 tags 字段" });
+  assert.deepEqual(store.getById(memory.id).tags, before, "no tags in patch → tags untouched");
+});


### PR DESCRIPTION
承接 #135 附属发现两问（第三批，此前认领时留作兜底块）。建议 1/2 在 #137、3/4/5 在 #138（均已合并），本 PR 收尾 #135 我方承诺的最后一块；建议 9（ready 语义）由报告者实施中，文件面零重叠。

## 问题 1：`importance` 完全不参与静默归档

`applyQualityDisposition` 在 `score < archiveThreshold`（默认 30）时无条件归档：报告实测 150 条低分条目 100% 被归档，其中 **128 条 `importance ≥ 4`（51 条 = 5）**——一条被显式标为最重要的记忆，会被规则分无感知、无豁免地静默归档。

**修法**：`memoryQualityFilter.exemptImportance`（默认 **4**）——`importance ≥ 该值`的记忆**评分与信号标签照常落库**（裁决可观测）、**注入排序照常降权**（`importance × score/100`），但 `setArchived` 跳过，并记一条 info 说明豁免原因。可调：`1` = 全部豁免（等效关闭自动归档），`5` = 仅最重要豁免。

## 问题 2：系统信号标签被 update 整组抹掉

`applyQualityDisposition` 以并集写入信号标签（`low_quality` / `duplicate` / `meta` / `repetitive` / `short_content`），但 `service.update` 把 `tags` 整组替换——任何带 tags 的 `memory_update` 都会抹掉这条「为什么被降权/归档」的唯一审计线索。报告实测：150 条低分记忆里恰好缺的 2 条都是被 update 过的，并因此误判过归档来源。

**修法**：`service.update` 在调用方传入 `tags` 时，把 existing 行里的系统信号标签**并集保留**（用户自传标签照常生效）；不带 tags 的更新路径完全不变。信号标签清单收在模块常量 `SIGNAL_TAGS`，与 `applyQualityDisposition` 的写入端对齐。

## 测试

+5 用例（`test/quality-filter.test.js`）：

- importance 5 低于归档阈值 → 豁免不归档，score + `low_quality` 标签照常落库；
- 默认档位边界：importance 4 豁免 / importance 3 仍归档；
- `exemptImportance` 两端：设 1 全豁免、设 5 收紧到仅 importance 5；
- 带 tags 的 update：用户标签生效、`low_quality`/`short_content` 保留；
- 不带 tags 的 update：tags 完全不受影响（legacy 路径不变）。

全量 **827 项通过**（0 fail，1 skip 为既有）。

## 文档

README「记忆质量过滤」小节与配置表同步（豁免语义 + 信号标签保留说明）。
