### PR TITLE
fix(semantic): ready 区分「未配置」与「初始化中」+ 索引覆盖度降级告警（#135）

### DIFF
--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -606,11 +606,31 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     handler(req, res) {
       try {
         const stats = semantic?.vectorIndex?.getStats?.() ?? null;
+        // #118: expose readiness so the status card can tell "initializing /
+        // unreachable" from "disabled". An embedder carrying no `ready` prop at
+        // all (test doubles, third-party adapters) is assumed usable.
+        // issue #135: 但「可用」和「配了」是两件事 —— legacy OpenAI embedder
+        // 此前恒报 ready，于是 baseUrl/apiKey/model 全空时状态卡依然是绿的
+        // （"绿色假阳性"）。下面把两者分开，并附上索引覆盖度。
+        const ready = embedder ? ("ready" in embedder ? embedder.ready === true : true) : null;
+        // local/ollama 的配置来自 settings 兜底，没有「未配置」态：它们的
+        // ready=false 表示「还在初始化」，不是「没配」。
+        const configured = embedder ? (typeof embedder.configured === "boolean" ? embedder.configured : true) : null;
+        const embedded = Number(stats?.embeddedCount ?? 0);
+        const total = Number(stats?.totalCount ?? 0);
         sendJson(res, 200, {
-          // #118: expose readiness so the status card can tell "initializing /
-          // unreachable" from "disabled". Legacy OpenAI embedder has no `ready`
-          // prop and is immediately usable, so treat that as ready.
-          ready: embedder ? ("ready" in embedder ? embedder.ready === true : true) : null,
+          ready,
+          configured,
+          // 机器可读的原因；null = 一切正常。面板按它选文案，不用猜布尔组合。
+          reason: !embedder ? "no-embedder"
+            : configured === false ? "not-configured"
+              : ready !== true ? "initializing"
+                : null,
+          // 空库时 ratio 必须是 null 而非 0 —— 0 会被读成「一条都没嵌上」。
+          coverage: { embedded, total, ratio: total > 0 ? embedded / total : null },
+          // 配了、库里有东西可嵌、却一条都没嵌上 = 真的降级（本机此前长期
+          // 处于 ready:true + embeddedCount:0，面板却显示正常）。
+          degraded: configured === true && total > 0 && embedded === 0,
           // Explicit display name first: the legacy OpenAI-compatible embedder
           // is an object literal, so constructor.name would be "Object".
           embedProvider: embedder ? (embedder.name ?? embedder.constructor?.name ?? "unknown") : null,

--- a/dsh-mneme/lib/client.js
+++ b/dsh-mneme/lib/client.js
@@ -428,6 +428,9 @@ window.__ModuleLoader__.load({
         "memory.status.vectorInit": "初始化中",
         "memory.status.vectorInitHint": "embedder 不可达，正在重试",
         "memory.status.vectorIndexed": "已索引 {n} / {m} 条",
+      "memory.status.vectorUnconfigured": "未配置",
+      "memory.status.vectorUnconfiguredHint": "未填 embedding 端点/模型或未启用，语义召回不可用",
+      "memory.status.vectorDegradedHint": "已索引 0 / {m} 条，语义召回实际不可用",
         "memory.status.llm": "LLM 消耗",
         "memory.status.llmCalls": "近 7 天 · {n} 次调用",
         "memory.status.error": "加载失败"
@@ -733,6 +736,9 @@ window.__ModuleLoader__.load({
         "memory.status.vectorInit": "Initializing",
         "memory.status.vectorInitHint": "embedder unreachable, retrying",
         "memory.status.vectorIndexed": "Indexed {n} / {m} items",
+      "memory.status.vectorUnconfigured": "Not configured",
+      "memory.status.vectorUnconfiguredHint": "No embedding endpoint/model configured — semantic recall is off",
+      "memory.status.vectorDegradedHint": "Indexed 0 / {m} items — semantic recall is effectively unavailable",
         "memory.status.llm": "LLM Usage",
         "memory.status.llmCalls": "Last 7 days · {n} calls",
         "memory.status.error": "Failed to load"
@@ -2586,7 +2592,7 @@ window.__ModuleLoader__.load({
 
     // 向量索引 — whether semantic recall is switched on.
     function VectorStatusCard({ t }) {
-      const [state, setState] = useState({ loading: true, error: false, provider: null, ready: null, dimension: 0, embedded: 0, total: 0 });
+      const [state, setState] = useState({ loading: true, error: false, provider: null, ready: null, configured: null, degraded: false, dimension: 0, embedded: 0, total: 0 });
       useEffect(() => {
         let cancelled = false;
         // #118: /vector-config is secret-bearing (401 without a stored token →
@@ -2602,6 +2608,10 @@ window.__ModuleLoader__.load({
               error: false,
               provider: j?.embedProvider || null,
               ready: j?.ready ?? null,
+              // issue #135: missing on older servers → null/false，卡片退化成
+              // 旧行为（只按 ready 判断），不会误报「未配置」。
+              configured: typeof j?.configured === "boolean" ? j.configured : null,
+              degraded: j?.degraded === true,
               // Legacy OpenAI embedder exposes dimension only after its first
               // successful embed — fall back to the index stats' dimension.
               dimension: Number(j?.dimension ?? j?.index?.dimension ?? 0),
@@ -2613,15 +2623,28 @@ window.__ModuleLoader__.load({
         return () => { cancelled = true; };
       }, []);
       const off = !state.provider;
-      const pending = !off && state.ready !== true;
+      // issue #135: 先把「没配」和「配了但在初始化」分开。此前两者都落到
+      // ready !== true，于是未配置的 legacy embedder（ready 恒 true）反而
+      // 一路显示成正常状态。
+      const unconfigured = !off && state.configured === false;
+      const pending = !off && !unconfigured && state.ready !== true;
+      // 配好了、库里有东西、却一条都没嵌上 —— 这才是真正的降级。
+      const degraded = !off && !unconfigured && !pending && state.degraded === true;
       const num = off
         ? t("memory.status.vectorOff")
+        : unconfigured
+          ? t("memory.status.vectorUnconfigured")
+          : pending
+            ? t("memory.status.vectorInit")
+            : `${state.provider.replace(/Embedder$/, "")} · ${state.dimension}D`;
+      const cap = unconfigured
+        ? t("memory.status.vectorUnconfiguredHint")
         : pending
-          ? t("memory.status.vectorInit")
-          : `${state.provider.replace(/Embedder$/, "")} · ${state.dimension}D`;
-      const cap = pending
-        ? t("memory.status.vectorInitHint")
-        : off ? "" : t("memory.status.vectorIndexed").replace("{n}", state.embedded).replace("{m}", state.total);
+          ? t("memory.status.vectorInitHint")
+          : off ? ""
+            : degraded
+              ? t("memory.status.vectorDegradedHint").replace("{m}", state.total)
+              : t("memory.status.vectorIndexed").replace("{n}", state.embedded).replace("{m}", state.total);
       return h(StatusCard, {
         t,
         title: t("memory.status.vector"),

--- a/dsh-mneme/lib/embedding.js
+++ b/dsh-mneme/lib/embedding.js
@@ -81,9 +81,13 @@ export function createEmbedder({ store, settings, logger, vectorIndex }) {
     } catch { /* metadata write is best-effort */ }
   }
 
+  // issue #135: 「配置是否齐备」的唯一判据 —— embed()/embedFor() 的守卫与下面
+  // ready/configured 两个 getter 共用，避免以后改一处漏一处。
+  const configComplete = (cfg) => !!(cfg?.enabled && cfg.baseUrl && cfg.apiKey && cfg.model);
+
   async function embedFor(id, title, content) {
     const cfg = settings.getVectorConfig();
-    if (!cfg?.enabled || !cfg.baseUrl || !cfg.apiKey || !cfg.model) return;
+    if (!configComplete(cfg)) return;
     const text = [title, content].filter(Boolean).join("\n");
     const vector = await embedText(cfg, text);
     if (vector) {
@@ -100,6 +104,22 @@ export function createEmbedder({ store, settings, logger, vectorIndex }) {
     // Display name for /semantic: a literal's constructor.name is "Object",
     // which the status card would render verbatim.
     name: "OpenAI",
+    /**
+     * issue #135: 这个 embedder 没有异步初始化，`"ready" in embedder` 的通用
+     * 分支会把它恒判为可用 —— 而 vector-config 四项有缺时它一条都嵌不出来。
+     * 对外报真实可用性，让 /semantic 的 ready 不再是「绿色假阳性」。
+     * 用 getter 而非快照字段：设置面板改完配置无需重启即生效（与 embed() 同源读取）。
+     */
+    get ready() {
+      return configComplete(settings.getVectorConfig());
+    },
+    /**
+     * 与 ready 同源，分开两个名字是给 /semantic 用：local/ollama 的
+     * ready=false 表示「还在初始化」，而这里的 false 表示「根本没配」。
+     */
+    get configured() {
+      return configComplete(settings.getVectorConfig());
+    },
     /** Fire-and-forget re-embed of a memory after any write. */
     schedule(memory) {
       if (!memory?.id) return;
@@ -109,7 +129,7 @@ export function createEmbedder({ store, settings, logger, vectorIndex }) {
     /** Embed one text and return its vector (null on failure/disabled). */
     async embed(query) {
       const cfg = settings.getVectorConfig();
-      if (!cfg?.enabled || !cfg.baseUrl || !cfg.apiKey || !cfg.model) return null;
+      if (!configComplete(cfg)) return null;
       const vector = await embedText(cfg, query);
       if (vector) _dimension = vector.length;
       return vector;

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -215,7 +215,18 @@ export const apply = (ctx, config) => {
     // model fingerprint after each successful embed (Bug3).
     embedder = createEmbedder({ store, settings, logger: ctx.logger, vectorIndex });
     service.setEmbedder(embedder);
-    // legacy OpenAI embedder is immediately usable
+    // issue #135: 未配置时明确告警一次。此前 legacy OpenAI embedder 恒报
+    // ready=true，向量层「绿的但全哑」可以静默存在很久（本机持续了数周）。
+    // 只记日志、不阻断启动：轻量模式与「先跑起来再补配置」都是正当用法。
+    if (embedder.configured === false) {
+      ctx.logger?.warn?.(
+        "[dsh-mneme] 向量层未配置（vector-config 的 enabled/baseUrl/apiKey/model 有缺）："
+        + "语义召回、语义去重、rerank、sleep 冲突检测将静默失效，"
+        + "dream 的语义聚类会退化为全量窗口兜底。"
+        + "请在设置面板补全 embedding 端点与模型，或把 embedProvider 改为 local/ollama。"
+      );
+    }
+    // legacy OpenAI embedder needs no async init → human edits apply right away
     applyHumanEdits();
   } else {
     try {

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -606,11 +606,31 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
     handler(req, res) {
       try {
         const stats = semantic?.vectorIndex?.getStats?.() ?? null;
+        // #118: expose readiness so the status card can tell "initializing /
+        // unreachable" from "disabled". An embedder carrying no `ready` prop at
+        // all (test doubles, third-party adapters) is assumed usable.
+        // issue #135: 但「可用」和「配了」是两件事 —— legacy OpenAI embedder
+        // 此前恒报 ready，于是 baseUrl/apiKey/model 全空时状态卡依然是绿的
+        // （"绿色假阳性"）。下面把两者分开，并附上索引覆盖度。
+        const ready = embedder ? ("ready" in embedder ? embedder.ready === true : true) : null;
+        // local/ollama 的配置来自 settings 兜底，没有「未配置」态：它们的
+        // ready=false 表示「还在初始化」，不是「没配」。
+        const configured = embedder ? (typeof embedder.configured === "boolean" ? embedder.configured : true) : null;
+        const embedded = Number(stats?.embeddedCount ?? 0);
+        const total = Number(stats?.totalCount ?? 0);
         sendJson(res, 200, {
-          // #118: expose readiness so the status card can tell "initializing /
-          // unreachable" from "disabled". Legacy OpenAI embedder has no `ready`
-          // prop and is immediately usable, so treat that as ready.
-          ready: embedder ? ("ready" in embedder ? embedder.ready === true : true) : null,
+          ready,
+          configured,
+          // 机器可读的原因；null = 一切正常。面板按它选文案，不用猜布尔组合。
+          reason: !embedder ? "no-embedder"
+            : configured === false ? "not-configured"
+              : ready !== true ? "initializing"
+                : null,
+          // 空库时 ratio 必须是 null 而非 0 —— 0 会被读成「一条都没嵌上」。
+          coverage: { embedded, total, ratio: total > 0 ? embedded / total : null },
+          // 配了、库里有东西可嵌、却一条都没嵌上 = 真的降级（本机此前长期
+          // 处于 ready:true + embeddedCount:0，面板却显示正常）。
+          degraded: configured === true && total > 0 && embedded === 0,
           // Explicit display name first: the legacy OpenAI-compatible embedder
           // is an object literal, so constructor.name would be "Object".
           embedProvider: embedder ? (embedder.name ?? embedder.constructor?.name ?? "unknown") : null,

--- a/dsh-mneme/src/embedding.js
+++ b/dsh-mneme/src/embedding.js
@@ -81,9 +81,13 @@ export function createEmbedder({ store, settings, logger, vectorIndex }) {
     } catch { /* metadata write is best-effort */ }
   }
 
+  // issue #135: 「配置是否齐备」的唯一判据 —— embed()/embedFor() 的守卫与下面
+  // ready/configured 两个 getter 共用，避免以后改一处漏一处。
+  const configComplete = (cfg) => !!(cfg?.enabled && cfg.baseUrl && cfg.apiKey && cfg.model);
+
   async function embedFor(id, title, content) {
     const cfg = settings.getVectorConfig();
-    if (!cfg?.enabled || !cfg.baseUrl || !cfg.apiKey || !cfg.model) return;
+    if (!configComplete(cfg)) return;
     const text = [title, content].filter(Boolean).join("\n");
     const vector = await embedText(cfg, text);
     if (vector) {
@@ -100,6 +104,22 @@ export function createEmbedder({ store, settings, logger, vectorIndex }) {
     // Display name for /semantic: a literal's constructor.name is "Object",
     // which the status card would render verbatim.
     name: "OpenAI",
+    /**
+     * issue #135: 这个 embedder 没有异步初始化，`"ready" in embedder` 的通用
+     * 分支会把它恒判为可用 —— 而 vector-config 四项有缺时它一条都嵌不出来。
+     * 对外报真实可用性，让 /semantic 的 ready 不再是「绿色假阳性」。
+     * 用 getter 而非快照字段：设置面板改完配置无需重启即生效（与 embed() 同源读取）。
+     */
+    get ready() {
+      return configComplete(settings.getVectorConfig());
+    },
+    /**
+     * 与 ready 同源，分开两个名字是给 /semantic 用：local/ollama 的
+     * ready=false 表示「还在初始化」，而这里的 false 表示「根本没配」。
+     */
+    get configured() {
+      return configComplete(settings.getVectorConfig());
+    },
     /** Fire-and-forget re-embed of a memory after any write. */
     schedule(memory) {
       if (!memory?.id) return;
@@ -109,7 +129,7 @@ export function createEmbedder({ store, settings, logger, vectorIndex }) {
     /** Embed one text and return its vector (null on failure/disabled). */
     async embed(query) {
       const cfg = settings.getVectorConfig();
-      if (!cfg?.enabled || !cfg.baseUrl || !cfg.apiKey || !cfg.model) return null;
+      if (!configComplete(cfg)) return null;
       const vector = await embedText(cfg, query);
       if (vector) _dimension = vector.length;
       return vector;

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -215,7 +215,18 @@ export const apply = (ctx, config) => {
     // model fingerprint after each successful embed (Bug3).
     embedder = createEmbedder({ store, settings, logger: ctx.logger, vectorIndex });
     service.setEmbedder(embedder);
-    // legacy OpenAI embedder is immediately usable
+    // issue #135: 未配置时明确告警一次。此前 legacy OpenAI embedder 恒报
+    // ready=true，向量层「绿的但全哑」可以静默存在很久（本机持续了数周）。
+    // 只记日志、不阻断启动：轻量模式与「先跑起来再补配置」都是正当用法。
+    if (embedder.configured === false) {
+      ctx.logger?.warn?.(
+        "[dsh-mneme] 向量层未配置（vector-config 的 enabled/baseUrl/apiKey/model 有缺）："
+        + "语义召回、语义去重、rerank、sleep 冲突检测将静默失效，"
+        + "dream 的语义聚类会退化为全量窗口兜底。"
+        + "请在设置面板补全 embedding 端点与模型，或把 embedProvider 改为 local/ollama。"
+      );
+    }
+    // legacy OpenAI embedder needs no async init → human edits apply right away
     applyHumanEdits();
   } else {
     try {

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -33,7 +33,7 @@ function req(path, method = "GET", body = null) {
   return r;
 }
 
-function setup(embedder, apiToken = "", config = null) {
+function setup(embedder, apiToken = "", config = null, semantic = undefined) {
   const store = createStore(":memory:");
   const service = createService({ store, mirror: null, config: {} });
   const settings = createSettings(store.db);
@@ -51,7 +51,7 @@ function setup(embedder, apiToken = "", config = null) {
       }
     }
   };
-  const api = createApi(ctx, service, settings, commands, embedder, undefined, apiToken, config);
+  const api = createApi(ctx, service, settings, commands, embedder, semantic, apiToken, config);
   return { store, service, routes, api, settings, apiToken };
 }
 
@@ -468,6 +468,73 @@ test("GET /api/dsh-mneme/semantic reports ready state per embedder", async () =>
   const named = await fetchSem({ name: "OpenAI", embed() {} });
   assert.equal(named.embedProvider, "OpenAI", "explicit name beats constructor.name");
   assert.equal(named.ready, true);
+});
+
+// --- #135: /semantic must tell "not configured" apart from "degraded" ---------
+
+test("GET /api/dsh-mneme/semantic reports configured/coverage/degraded", async () => {
+  const fetchSem = async (embedder, semantic) => {
+    const { routes } = setup(embedder, "", null, semantic);
+    const sem = routes.find((r) => r.path === "/api/dsh-mneme/semantic");
+    const res = new FakeRes();
+    await sem.handler(req("/api/dsh-mneme/semantic"), res);
+    assert.equal(res.statusCode, 200);
+    return JSON.parse(res.body);
+  };
+  // Stats double: `total` is the memory count, `embedded` the indexed count.
+  const index = (embeddedCount, totalCount) => ({
+    vectorIndex: { getStats: () => ({ embeddedCount, totalCount }) }
+  });
+  const openai = (ready, configured) => ({
+    name: "OpenAI",
+    get ready() { return ready; },
+    get configured() { return configured; },
+    embed() {}
+  });
+
+  // No embedder at all → everything reports absence, not a false green.
+  const none = await fetchSem(undefined, index(0, 0));
+  assert.equal(none.configured, null);
+  assert.equal(none.reason, "no-embedder");
+  assert.equal(none.degraded, false);
+  assert.deepEqual(none.coverage, { embedded: 0, total: 0, ratio: null },
+    "empty store → ratio null (0 would read as 'nothing embedded')");
+
+  // Configured embedder still initializing: unreachable ≠ unconfigured.
+  assert.equal((await fetchSem(openai(false, true), index(0, 346))).reason, "initializing");
+
+  // Never configured: reported as such even though the index has memories.
+  const unconfigured = await fetchSem(openai(false, false), index(0, 346));
+  assert.equal(unconfigured.ready, false);
+  assert.equal(unconfigured.configured, false);
+  assert.equal(unconfigured.reason, "not-configured");
+  assert.equal(unconfigured.degraded, false, "unconfigured was never meant to index");
+  assert.equal(unconfigured.coverage.ratio, 0);
+
+  // Configured, memories present, zero vectors — the state this machine sat in
+  // for weeks while the card showed a healthy provider.
+  const degraded = await fetchSem(openai(true, true), index(0, 346));
+  assert.equal(degraded.reason, null, "a complete config has no abnormal reason");
+  assert.equal(degraded.degraded, true);
+  assert.equal(degraded.coverage.ratio, 0);
+
+  // Healthy index.
+  const ok = await fetchSem(openai(true, true), index(173, 346));
+  assert.equal(ok.degraded, false);
+  assert.equal(ok.coverage.ratio, 0.5);
+
+  // Adapters without a `configured` field (third-party/test doubles) keep the
+  // old contract: assumed configured, `ready` decides.
+  const legacy = await fetchSem({ embed() {} }, index(5, 10));
+  assert.equal(legacy.configured, true);
+  assert.equal(legacy.reason, null);
+  assert.equal(legacy.ready, true);
+
+  // No stats provider (no vector index) must not throw — coverage falls back
+  // to zeros and an empty store is never "degraded".
+  const noIndex = await fetchSem(openai(true, true), null);
+  assert.deepEqual(noIndex.coverage, { embedded: 0, total: 0, ratio: null });
+  assert.equal(noIndex.degraded, false);
 });
 
 // --- Bug8: llm-audit API (pagination + stats) --------------------------------

--- a/dsh-mneme/test/client.test.js
+++ b/dsh-mneme/test/client.test.js
@@ -625,3 +625,43 @@ test("settings feedback card: prefilled issue + mailto + browse, version from /i
     assert.ok(occurrences >= 2, `i18n key memory.settings.${key} must exist in both zh and en (got ${occurrences})`);
   }
 });
+
+// issue #135：向量状态卡必须区分「没配」与「配了却一条都没嵌上」。此前卡片只看
+// ready，而未配置的 legacy embedder（ready 恒 true）一路显示成正常 provider。
+test("vector status card surfaces the configured/degraded split", () => {
+  // 1. 读后端新字段，缺失（旧服务端）时退化成旧行为而不是误报未配置
+  assert.ok(
+    clientSource.includes('typeof j?.configured === "boolean" ? j.configured : null'),
+    "the card must read `configured` and tolerate older servers that omit it"
+  );
+  assert.ok(
+    clientSource.includes("j?.degraded === true"),
+    "the card must read `degraded`"
+  );
+  // 2. 三态互斥：未配置优先于初始化中，降级只在既非未配置也非初始化时成立
+  assert.ok(
+    clientSource.includes("const unconfigured = !off && state.configured === false;"),
+    "unconfigured must be its own state, not folded into ready"
+  );
+  assert.ok(
+    clientSource.includes("const pending = !off && !unconfigured && state.ready !== true;"),
+    "an unconfigured embedder must not be reported as initializing"
+  );
+  assert.ok(
+    clientSource.includes("const degraded = !off && !unconfigured && !pending && state.degraded === true;"),
+    "degraded must only apply to a configured, settled embedder"
+  );
+  // 3. 三个状态各自的标签/说明走 i18n，双语齐备
+  for (const key of ["vectorUnconfigured", "vectorUnconfiguredHint", "vectorDegradedHint"]) {
+    const occurrences = clientSource.split(`"memory.status.${key}"`).length - 1;
+    assert.ok(occurrences >= 2, `i18n key memory.status.${key} must exist in both zh and en (got ${occurrences})`);
+  }
+  assert.ok(
+    clientSource.includes('t("memory.status.vectorUnconfigured")'),
+    "the unconfigured state must render its own label"
+  );
+  assert.ok(
+    clientSource.includes('t("memory.status.vectorDegradedHint")'),
+    "the degraded state must render its own caption (0 of {m} indexed)"
+  );
+});

--- a/dsh-mneme/test/embedding-ready.test.js
+++ b/dsh-mneme/test/embedding-ready.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createEmbedder } from "../src/embedding.js";
+
+// issue #135: the legacy OpenAI-compatible embedder is an object literal with no
+// async init, so api.js's generic `"ready" in embedder` branch used to fall
+// through to "assume usable" — the status card stayed green while baseUrl /
+// apiKey / model were all empty and not a single vector could be produced
+// ("绿色假阳性"). These tests pin the real predicate and the getter semantics.
+
+const FULL = {
+  enabled: true,
+  baseUrl: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "text-embedding-3-small"
+};
+
+/** Build the embedder against a settings double + a recording store. */
+function make(cfg, { live = false } = {}) {
+  const writes = [];
+  const box = { cfg };
+  const embedder = createEmbedder({
+    store: { setEmbedding: (id, vector) => writes.push({ id, vector }) },
+    settings: { getVectorConfig: () => (live ? box.cfg : cfg) },
+    logger: { info() {}, warn() {} }
+  });
+  return { embedder, writes, box };
+}
+
+test("#135 legacy OpenAI embedder reports ready/configured from the config", () => {
+  const { embedder } = make(FULL);
+  assert.equal(embedder.ready, true, "fully configured → ready");
+  assert.equal(embedder.configured, true);
+
+  // Any of the four fields missing → not configured. `enabled` flips to false,
+  // the rest are blanked (the shape the settings panel leaves behind when the
+  // user never filled the vector section in).
+  for (const key of ["enabled", "baseUrl", "apiKey", "model"]) {
+    const broken = { ...FULL, [key]: key === "enabled" ? false : "" };
+    const { embedder: e } = make(broken);
+    assert.equal(e.configured, false, `blank ${key} → not configured`);
+    assert.equal(e.ready, false, `blank ${key} → not ready`);
+  }
+
+  // Defensive: a settings double returning {} (or nothing) must not throw.
+  assert.equal(make({}).embedder.ready, false);
+  assert.equal(make(undefined).embedder.ready, false);
+});
+
+test("#135 ready/configured are live getters, not boot-time snapshots", () => {
+  // The panel writes vector-config through settings; the legacy embedder reads
+  // it per call (same as embed()), so fixing the config must not need a restart.
+  const { embedder, box } = make(FULL, { live: true });
+  assert.equal(embedder.ready, true);
+  box.cfg = { ...FULL, apiKey: "" };
+  assert.equal(embedder.ready, false, "getter re-reads the live config");
+  assert.equal(embedder.configured, false);
+  box.cfg = FULL;
+  assert.equal(embedder.ready, true, "…and recovers once the config is complete");
+});
+
+test("#135 unconfigured embedder never reaches the network", async () => {
+  const { embedder, writes } = make({ ...FULL, apiKey: "" });
+  // A real fetch here would go out with an empty bearer token.
+  assert.equal(await embedder.embed("hello"), null);
+  assert.equal(await embedder.embedSingle("hello"), null);
+
+  embedder.schedule({ id: "m1", title: "t", content: "c" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(writes, [], "schedule() must not store an embedding");
+
+  // A memory without an id is a no-op (never a store write with undefined id).
+  embedder.schedule(null);
+  embedder.schedule({});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(writes, []);
+});
+
+test("#135 unconfigured embedder reports no model fingerprint or dimension", () => {
+  const { embedder } = make(FULL);
+  assert.equal(embedder.name, "OpenAI", "explicit name for the status card");
+  assert.equal(embedder.dimension, undefined, "no dimension before a first embed");
+  // model#hex — same fingerprint format the local embedders use.
+  assert.match(embedder.modelHash, /^text-embedding-3-small#[0-9a-f]+$/);
+  assert.equal(make({ ...FULL, model: "" }).embedder.modelHash, undefined);
+  assert.equal(make({ ...FULL, enabled: false }).embedder.modelHash, undefined);
+});

--- a/dsh-mneme/test/webServer-optional.test.js
+++ b/dsh-mneme/test/webServer-optional.test.js
@@ -47,3 +47,36 @@ test("headless host (no webServer): plugin must not throw", async () => {
   await fiber;
   assert.ok(true, "headless load must not throw");
 });
+
+/** Boot the plugin with ctx.logger.warn captured. */
+async function bootCapturingWarnings(config) {
+  const { ctx } = buildHost(true);
+  const warnings = [];
+  const original = ctx.logger.warn.bind(ctx.logger);
+  ctx.logger.warn = (...args) => { warnings.push(args.join(" ")); original(...args); };
+  await ctx.plugin(mneme, config);
+  return warnings;
+}
+
+// issue #135：向量层未配置时启动必须留下痕迹。此前 legacy OpenAI embedder 恒报
+// ready=true，于是向量层「绿的但全哑」可以静默存在很久 —— 本机这样过了数周，
+// 语义召回、语义去重、rerank、sleep 冲突检测全部失效而面板一切正常。
+// embedProvider 默认就是 "openai"，所以「默认配置 + 空 vector-config」必现。
+test("unconfigured vector layer warns once at boot (issue #135)", async () => {
+  const warnings = await bootCapturingWarnings({ memoryDir: mkdtempSync(join(tmpdir(), "mneme-warn-")) });
+  const vectorWarnings = warnings.filter((w) => w.includes("向量层未配置"));
+  assert.equal(vectorWarnings.length, 1, "exactly one warning, not one per use:\n" + warnings.join("\n"));
+  // 告警必须点名实际受影响的能力，否则用户不知道该去修什么。
+  for (const feature of ["语义召回", "rerank", "sleep", "dream"]) {
+    assert.ok(vectorWarnings[0].includes(feature), `warning must name ${feature}: ${vectorWarnings[0]}`);
+  }
+});
+
+// 轻量模式是有意的选择、不是配置错误：不能刷这条告警（整条向量管线本就不装配）。
+test("light mode does not warn about the vector layer (issue #135)", async () => {
+  const warnings = await bootCapturingWarnings({
+    memoryDir: mkdtempSync(join(tmpdir(), "mneme-light-")),
+    lightMode: true
+  });
+  assert.deepEqual(warnings.filter((w) => w.includes("向量层未配置")), []);
+});


### PR DESCRIPTION
Refs #135 —— 按 maintainer 的「方案照准，按你的拟法实施 👍」落地，含追加要求（把新字段接线到状态卡）。

## 问题

`legacy OpenAI-compatible embedder`（`src/embedding.js`）是对象字面量、没有异步初始化，`/semantic` 的 `ready` 于是走了通用分支的兜底：

```js
ready: embedder ? ("ready" in embedder ? embedder.ready === true : true) : null
```

`"ready" in embedder` 恒为 false → 恒报 `ready: true`。于是 `baseUrl / apiKey / model` 全空时状态卡显示成健康的 provider，而实际一条向量都产不出来。本机正处于这种状态且持续了数周：语义召回、语义去重、rerank、sleep 冲突检测全部静默失效，没有任何提示。

用本机真实的（空）vector-config 复现：

```
修复前  ready=true          ← 旧实现：通用分支假定可用
修复后  ready=false         ← 本 PR
        configured=false      （新增字段）
```

`GET /api/dsh-mneme/semantic` 修复前实测：`{"ready":true,"embedProvider":"OpenAI","modelHash":null,"dimension":null,"index":{"embeddedCount":0,"totalCount":346}}` —— 346 条记忆、0 条向量，状态却是绿的。

## 改动

**`src/embedding.js`** —— 抽出 `configComplete()` 作唯一判据（`embed()` / `embedFor()` 的既有守卫一并改用它，避免以后改一处漏一处），新增两个 getter：

- `get ready()`：报真实可用性。
- `get configured()`：与 ready 同源，供面板区分「根本没配」与「还在初始化」。

用 getter 而非启动快照：面板改完配置无需重启即生效（与 `embed()` 同源读取）。

**`src/api.js`** —— `/semantic` 新增：

| 字段 | 说明 |
| --- | --- |
| `configured` | 配置是否齐备；无 embedder 时为 `null` |
| `reason` | `no-embedder` / `not-configured` / `initializing` / `null`（正常） |
| `coverage` | `{embedded, total, ratio}`；**空库时 ratio 为 `null` 而非 0** |
| `degraded` | `configured && total > 0 && embedded === 0` |

`ratio` 用 `null` 表示「没有东西可嵌」是刻意的：0 会被读成「一条都没嵌上」。

**`src/index.js`** —— 未配置时启动告警一次。用真实 cordis 宿主实测的输出：

```
[dsh-mneme] 向量层未配置（vector-config 的 enabled/baseUrl/apiKey/model 有缺）：
语义召回、语义去重、rerank、sleep 冲突检测将静默失效，dream 的语义聚类会退化为全量窗口兜底。
请在设置面板补全 embedding 端点与模型，或把 embedProvider 改为 local/ollama。
```

只记日志、不阻断启动 —— 轻量模式与「先跑起来再补配置」都是正当用法。`embedProvider` 默认就是 `openai`，所以「默认配置 + 空 vector-config」必现。

**`lib/client.js`**（追加要求）—— 状态卡三态互斥 + 降级说明：

- `未配置` + 「未填 embedding 端点/模型或未启用，语义召回不可用」
- `初始化中`（原有行为）
- 正常 provider 但 `degraded` → 「已索引 0 / {m} 条，语义召回实际不可用」

三态有意写成互斥的前置条件（`unconfigured` 优先于 `pending`）；旧服务端缺字段时 `configured` 落回 `null`、`degraded` 落回 `false`，卡片退化为原有行为而不是误报「未配置」。

## 兼容性

- `#118` 的 ready 契约（`null` / `false` / `true`）与 `test/api.test.js` 中既有断言**全部未改**。
- 无嵌入端、或适配器不带 `configured` 字段（第三方 / 测试替身）时按「配置齐备」处理，`ready` 仍由适配器自己决定 —— `local`/`ollama` 的 `ready=false` 继续表示「还在初始化」，不是「没配」。
- 没有把 `ready` 改成「coverage > 0」：空库（`totalCount === 0`）会永久显示「初始化中」，且会破坏既有断言。

## 测试

`node --test test/*.test.js` → **836 tests / 835 pass / 1 skip / 0 fail**（main 基线 828）。

- 新增 `test/embedding-ready.test.js`：该模块此前**零覆盖**。覆盖四项配置任缺其一、`{}` / `undefined` 不抛、getter 实时性（补齐配置即恢复）、未配置时 `embed()` / `embedSingle()` / `schedule()` 绝不发网络请求、`modelHash` / `dimension` 在未配置时为 `undefined`。
- `test/api.test.js`：新增四态用例（无 embedder / 未配置 / 初始化中 / 降级 / 正常 / 不带 `configured` 的适配器 / 无 vectorIndex），并断言空库 `ratio: null`。
- `test/client.test.js`：沿用既有源码断言风格，锁住卡片的三态互斥判断、新字段读取（含旧服务端退化）与双语文案齐备。
- `test/webServer-optional.test.js`：用真实 cordis 宿主断言启动告警**恰好一次**、点名四项受影响能力，且**轻量模式不刷**这条告警（有意选择 ≠ 配置错误）。

`lib/` 由 `npm run sync` 生成；`lib/client.js` 为 lib-only 手写文件，同步不会裁剪（`lib-smoke.test.js` 已验证 src/lib 一致）。
