### PR TITLE
fix(vector): boot 回填不再被模型指纹短路 + 只补活跃行（issue #128）

### DIFF
--- a/dsh-mneme/README.md
+++ b/dsh-mneme/README.md
@@ -433,7 +433,7 @@ dsh web
 | `entitySearchEnabled` | `true` | `entity:` / `attr:` 前缀搜索开关 |
 | `trustEpistemicWeighting` | `false` | 记忆可信度加权（v0.4.5，opt-in 默认关）：记忆按来源分级 `observation`> `inferred` > `subjective`，开启后检索排序优先高可信记忆、注入对 observation 标注 `[verified]`、dream merge/conflict 偏向高可信一方；关闭时 `epistemic_status` 仅随保存落库、不参与行为 |
 | `evalPersistTestResults` | `false` | 检索评估落库（v0.4.5，opt-in 默认关）：开启后 `evaluateRetrieval` 把 precision/recall/mrr 快照写入 `recall_evals`；默认关时仅返回调用方不落库。生产 `searchMemories` 审计始终走 `recall_runs`，无条件不触碰 `recall_evals` |
-| `autoReindexOnBoot` | `true` | 存量记忆缺 embedding 时，向量已配置则启动后延迟后台按批次限速自动回填重建（设为 `false` 仅手动重建） |
+| `autoReindexOnBoot` | `true` | 存量记忆缺 embedding 时，向量已配置则启动后延迟后台按批次限速自动回填重建（设为 `false` 仅手动重建）。只补**活跃**记忆（归档/遗忘行不参与召回，#128）；模型指纹一致时照常补缺失行、不再短路（#128） |
 | `hybridInject` | `true` | 注入语义召回优先（v0.4.6，Bug4）：`injectCandidates` 带非空 query 时先走向量索引语义召回候选，规则筛选补足/去重；空 query / 无向量回退旧逻辑 |
 | `bm25SearchEnabled` | `true` | BM25 稀疏第三路召回（v0.5.0）：ASCII 词元 + CJK bigram，IDF 加权，散词/ID/代码片段查询不再依赖子串命中 |
 | `adaptiveThresholdEnabled` | `true` | 自适应相似度阈值（v0.5.0）：按查询形态动态截断（前缀 0.5 / 短查询 0.7 / 长查询 0.6 / 头部分差大放宽 0.5），显式传 `threshold` 走旧行为 |

--- a/dsh-mneme/lib/index.js
+++ b/dsh-mneme/lib/index.js
@@ -87,6 +87,44 @@ export function createEntityStreamAdapter({ llm, agentDefaultModel, logger }) {
   };
 }
 
+/**
+ * Issue #128: bounded backfill of rows still missing an embedding (active rows
+ * only — needsEmbedding filters archived/forgotten). Exported for tests.
+ *
+ * Runs regardless of the model fingerprint: the old call-site gate returned
+ * early when vector_meta already held the embedder's hash, permanently
+ * orphaning rows whose embed failed at write time (embedder not ready /
+ * provider rate limit) — one successful embed was enough to never backfill
+ * again. markModel is idempotent when the fingerprint already matches, so
+ * re-running costs nothing beyond the actually-missing rows.
+ */
+export async function backfillMissingEmbeddings({
+  store, embedder, vectorIndex, logger,
+  maxTotal = 500, batchSize = 10, rateLimitMs = 200
+}) {
+  let indexed = 0;
+  for (let done = 0; done < maxTotal;) {
+    const rows = store.needsEmbedding(batchSize);
+    if (!rows.length) break;
+    for (const row of rows) {
+      try {
+        const text = [row.title, row.content].filter(Boolean).join("\n");
+        const vector = await embedder.embedSingle(text);
+        if (vector?.length) {
+          store.setEmbedding(row.id, vector);
+          indexed++;
+        }
+      } catch { /* skip the bad row */ }
+    }
+    done += rows.length;
+    // Rate limit: space out batches so the provider is not hammered.
+    if (store.needsEmbedding(1).length) await new Promise((r) => setTimeout(r, rateLimitMs));
+  }
+  if (indexed > 0 && embedder.modelHash) vectorIndex.markModel?.(embedder.modelHash, embedder.dimension);
+  logger?.info?.(`[dsh-mneme] auto-reindex backfilled ${indexed} embeddings on boot`);
+  return indexed;
+}
+
 export const apply = (ctx, config) => {
   const rawCfg = Config(config);
 
@@ -303,10 +341,10 @@ export const apply = (ctx, config) => {
 
   // Bug2: lazy auto-backfill of missing embeddings on boot. When the vector API
   // is configured and rows still lack an embedding (e.g. written before vector
-  // search was enabled) AND the vector_meta fingerprint is absent or stale, the
-  // index is rebuilt in the background after a short delay. Gated on
-  // cfg.autoReindexOnBoot; rate-limited in small batches so a large backlog
-  // never floods the provider. Failures degrade silently — search stays keyword.
+  // search was enabled), the backfill runs in the background after a short
+  // delay. Gated on cfg.autoReindexOnBoot; rate-limited in small batches so a
+  // large backlog never floods the provider. Failures degrade silently —
+  // search stays keyword.
   function scheduleAutoReindex() {
     if (cfg.autoReindexOnBoot === false) return;
     const attempt = (tries) => {
@@ -319,36 +357,13 @@ export const apply = (ctx, config) => {
           return;
         }
         if (!store.needsEmbedding(1).length) return; // nothing to backfill
-        // Model fingerprint gate: vectors already produced by the same model
-        // mean there is no drift and no rebuild needed.
-        const current = embedder.modelHash;
-        if (current && vectorIndex.modelHash?.() === current) return;
-        const BATCH = 10;
-        const MAX_TOTAL = 500; // bound boot-time work
-        (async () => {
-          let indexed = 0;
-          for (let done = 0; done < MAX_TOTAL;) {
-            const rows = store.needsEmbedding(BATCH);
-            if (!rows.length) break;
-            for (const row of rows) {
-              try {
-                const text = [row.title, row.content].filter(Boolean).join("\n");
-                const vector = await embedder.embedSingle(text);
-                if (vector?.length) {
-                  store.setEmbedding(row.id, vector);
-                  indexed++;
-                }
-              } catch { /* skip the bad row */ }
-            }
-            done += rows.length;
-            // Rate limit: space out batches so the provider is not hammered.
-            if (store.needsEmbedding(1).length) await new Promise((r) => setTimeout(r, 200));
-          }
-          if (indexed > 0 && current) vectorIndex.markModel?.(current, embedder.dimension);
-          ctx.logger?.info?.(`[dsh-mneme] auto-reindex backfilled ${indexed} embeddings on boot`);
-        })().catch((error) => {
-          ctx.logger?.warn?.(`[dsh-mneme] auto-reindex failed: ${String(error)}`);
-        });
+        // Issue #128: no fingerprint gate here anymore — a matching fingerprint
+        // used to return early and permanently orphan rows whose embed failed
+        // at write time. See backfillMissingEmbeddings().
+        backfillMissingEmbeddings({ store, embedder, vectorIndex, logger: ctx.logger })
+          .catch((error) => {
+            ctx.logger?.warn?.(`[dsh-mneme] auto-reindex failed: ${String(error)}`);
+          });
       } catch (error) {
         ctx.logger?.warn?.(`[dsh-mneme] auto-reindex failed: ${String(error)}`);
       }

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -1031,11 +1031,18 @@ export function createStore(path) {
     ).get().c;
   }
 
-  /** Candidate rows still missing an embedding, for incremental re-indexing. */
+  /**
+   * Candidate rows still missing an embedding, for incremental re-indexing.
+   * Issue #128: active rows only — archived/forgotten rows never participate in
+   * recall or dream clustering, so backfill quota must not be eaten by them
+   * (report measured 25/50 reindex slots landing on archived rows while 88
+   * active rows stayed un-embedded). Same 口径 as embeddedCount()/count().
+   */
   function needsEmbedding(limit = 50) {
     return db.prepare(
       `SELECT id, title, content FROM memories
-       WHERE embedding IS NULL OR embedding = ''
+       WHERE (embedding IS NULL OR embedding = '')
+         AND forgotten = 0 AND archived = 0
        ORDER BY updated_at DESC LIMIT ?`
     ).all(limit);
   }

--- a/dsh-mneme/src/index.js
+++ b/dsh-mneme/src/index.js
@@ -87,6 +87,44 @@ export function createEntityStreamAdapter({ llm, agentDefaultModel, logger }) {
   };
 }
 
+/**
+ * Issue #128: bounded backfill of rows still missing an embedding (active rows
+ * only — needsEmbedding filters archived/forgotten). Exported for tests.
+ *
+ * Runs regardless of the model fingerprint: the old call-site gate returned
+ * early when vector_meta already held the embedder's hash, permanently
+ * orphaning rows whose embed failed at write time (embedder not ready /
+ * provider rate limit) — one successful embed was enough to never backfill
+ * again. markModel is idempotent when the fingerprint already matches, so
+ * re-running costs nothing beyond the actually-missing rows.
+ */
+export async function backfillMissingEmbeddings({
+  store, embedder, vectorIndex, logger,
+  maxTotal = 500, batchSize = 10, rateLimitMs = 200
+}) {
+  let indexed = 0;
+  for (let done = 0; done < maxTotal;) {
+    const rows = store.needsEmbedding(batchSize);
+    if (!rows.length) break;
+    for (const row of rows) {
+      try {
+        const text = [row.title, row.content].filter(Boolean).join("\n");
+        const vector = await embedder.embedSingle(text);
+        if (vector?.length) {
+          store.setEmbedding(row.id, vector);
+          indexed++;
+        }
+      } catch { /* skip the bad row */ }
+    }
+    done += rows.length;
+    // Rate limit: space out batches so the provider is not hammered.
+    if (store.needsEmbedding(1).length) await new Promise((r) => setTimeout(r, rateLimitMs));
+  }
+  if (indexed > 0 && embedder.modelHash) vectorIndex.markModel?.(embedder.modelHash, embedder.dimension);
+  logger?.info?.(`[dsh-mneme] auto-reindex backfilled ${indexed} embeddings on boot`);
+  return indexed;
+}
+
 export const apply = (ctx, config) => {
   const rawCfg = Config(config);
 
@@ -303,10 +341,10 @@ export const apply = (ctx, config) => {
 
   // Bug2: lazy auto-backfill of missing embeddings on boot. When the vector API
   // is configured and rows still lack an embedding (e.g. written before vector
-  // search was enabled) AND the vector_meta fingerprint is absent or stale, the
-  // index is rebuilt in the background after a short delay. Gated on
-  // cfg.autoReindexOnBoot; rate-limited in small batches so a large backlog
-  // never floods the provider. Failures degrade silently — search stays keyword.
+  // search was enabled), the backfill runs in the background after a short
+  // delay. Gated on cfg.autoReindexOnBoot; rate-limited in small batches so a
+  // large backlog never floods the provider. Failures degrade silently —
+  // search stays keyword.
   function scheduleAutoReindex() {
     if (cfg.autoReindexOnBoot === false) return;
     const attempt = (tries) => {
@@ -319,36 +357,13 @@ export const apply = (ctx, config) => {
           return;
         }
         if (!store.needsEmbedding(1).length) return; // nothing to backfill
-        // Model fingerprint gate: vectors already produced by the same model
-        // mean there is no drift and no rebuild needed.
-        const current = embedder.modelHash;
-        if (current && vectorIndex.modelHash?.() === current) return;
-        const BATCH = 10;
-        const MAX_TOTAL = 500; // bound boot-time work
-        (async () => {
-          let indexed = 0;
-          for (let done = 0; done < MAX_TOTAL;) {
-            const rows = store.needsEmbedding(BATCH);
-            if (!rows.length) break;
-            for (const row of rows) {
-              try {
-                const text = [row.title, row.content].filter(Boolean).join("\n");
-                const vector = await embedder.embedSingle(text);
-                if (vector?.length) {
-                  store.setEmbedding(row.id, vector);
-                  indexed++;
-                }
-              } catch { /* skip the bad row */ }
-            }
-            done += rows.length;
-            // Rate limit: space out batches so the provider is not hammered.
-            if (store.needsEmbedding(1).length) await new Promise((r) => setTimeout(r, 200));
-          }
-          if (indexed > 0 && current) vectorIndex.markModel?.(current, embedder.dimension);
-          ctx.logger?.info?.(`[dsh-mneme] auto-reindex backfilled ${indexed} embeddings on boot`);
-        })().catch((error) => {
-          ctx.logger?.warn?.(`[dsh-mneme] auto-reindex failed: ${String(error)}`);
-        });
+        // Issue #128: no fingerprint gate here anymore — a matching fingerprint
+        // used to return early and permanently orphan rows whose embed failed
+        // at write time. See backfillMissingEmbeddings().
+        backfillMissingEmbeddings({ store, embedder, vectorIndex, logger: ctx.logger })
+          .catch((error) => {
+            ctx.logger?.warn?.(`[dsh-mneme] auto-reindex failed: ${String(error)}`);
+          });
       } catch (error) {
         ctx.logger?.warn?.(`[dsh-mneme] auto-reindex failed: ${String(error)}`);
       }

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -1031,11 +1031,18 @@ export function createStore(path) {
     ).get().c;
   }
 
-  /** Candidate rows still missing an embedding, for incremental re-indexing. */
+  /**
+   * Candidate rows still missing an embedding, for incremental re-indexing.
+   * Issue #128: active rows only — archived/forgotten rows never participate in
+   * recall or dream clustering, so backfill quota must not be eaten by them
+   * (report measured 25/50 reindex slots landing on archived rows while 88
+   * active rows stayed un-embedded). Same 口径 as embeddedCount()/count().
+   */
   function needsEmbedding(limit = 50) {
     return db.prepare(
       `SELECT id, title, content FROM memories
-       WHERE embedding IS NULL OR embedding = ''
+       WHERE (embedding IS NULL OR embedding = '')
+         AND forgotten = 0 AND archived = 0
        ORDER BY updated_at DESC LIMIT ?`
     ).all(limit);
   }

--- a/dsh-mneme/test/reindex-backfill.test.js
+++ b/dsh-mneme/test/reindex-backfill.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { backfillMissingEmbeddings } from "../src/index.js";
+import { createStore } from "../src/store.js";
+import { createService } from "../src/service.js";
+import { createVectorIndex } from "../src/vector-index.js";
+
+// Issue #128：boot 回填曾被模型指纹门短路——任意一条嵌入成功写入 vector_meta
+// 指纹后，指纹匹配的每次启动都在门上直接 return，写入时嵌入失败（embedder 未
+// 就绪 / 服务商限流）的活跃行从此永远补不上（报告实测 88 条活跃记忆长期缺失，
+// /vector-reindex 的配额还被归档死行吃掉）。
+
+test("Issue #128: fingerprint match no longer blocks backfill; archived rows are skipped", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  const active = service.saveWithDedupe({ type: "preference", title: "活跃", content: "内容" }).memory;
+  const dead = service.saveWithDedupe({ type: "preference", title: "死行", content: "内容" }).memory;
+  store.setArchived(dead.id, true);
+
+  // 指纹已与 embedder 一致 —— 旧的早退条件在此成立，旧实现会整场不回填。
+  const vectorIndex = createVectorIndex({ store });
+  vectorIndex.markModel("mock-model#abc", 3);
+  const embedded = [];
+  const embedder = {
+    embedSingle: async (text) => { embedded.push(text); return [1, 0, 0]; },
+    modelHash: "mock-model#abc",
+    dimension: 3
+  };
+
+  const logs = [];
+  const indexed = await backfillMissingEmbeddings({
+    store, embedder, vectorIndex,
+    logger: { info: (m) => logs.push(m) },
+    rateLimitMs: 0
+  });
+
+  assert.equal(indexed, 1, "the active row is backfilled despite the matching fingerprint");
+  assert.equal(store.getEmbeddings([active.id]).get(active.id)?.length, 3, "active row now carries a vector");
+  assert.equal(store.getEmbeddings([dead.id]).get(dead.id), undefined, "archived row is skipped");
+  assert.equal(vectorIndex.modelHash(), "mock-model#abc", "fingerprint unchanged (markModel idempotent)");
+  assert.ok(logs.some((m) => m.includes("backfilled 1")), "boot log records the backfill");
+  store.close();
+});
+
+test("Issue #128: backfill is bounded by maxTotal; the rest stays queued", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  for (let i = 0; i < 5; i++) {
+    service.saveWithDedupe({ type: "preference", title: `记忆${i}`, content: `内容${i}` });
+  }
+  const embedder = { embedSingle: async () => [1, 0, 0], modelHash: "h#1", dimension: 3 };
+  const vectorIndex = createVectorIndex({ store });
+
+  const indexed = await backfillMissingEmbeddings({
+    store, embedder, vectorIndex,
+    logger: { info() {} },
+    maxTotal: 4, batchSize: 2, rateLimitMs: 0
+  });
+  assert.equal(indexed, 4, "stops at the maxTotal bound");
+  assert.equal(store.needsEmbedding(10).length, 1, "remaining rows stay queued for the next boot");
+  store.close();
+});

--- a/dsh-mneme/test/store.test.js
+++ b/dsh-mneme/test/store.test.js
@@ -367,3 +367,17 @@ test("conflict_pending table persists across store reopen", () => {
   assert.equal(pending[0].reason, "x");
   s2.close();
 });
+
+// Issue #128：回填候选只取活跃行——归档/遗忘行不参与召回与聚类，不该吃掉
+// 回填配额（报告实测 50 个 reindex 名额全部落在归档行，88 条活跃记忆永远轮不到）。
+test("Issue #128: needsEmbedding skips archived and forgotten rows", () => {
+  const store = openMemory();
+  const active = store.save({ type: "preference", title: "活跃", content: "内容" });
+  const archived = store.save({ type: "preference", title: "归档", content: "内容" });
+  const forgotten = store.save({ type: "preference", title: "遗忘", content: "内容" });
+  store.setArchived(archived.id, true);
+  store.setForget(forgotten.id, true);
+  const ids = store.needsEmbedding(50).map((r) => r.id);
+  assert.deepEqual(ids, [active.id], "only the active row is a backfill candidate");
+  store.close();
+});


### PR DESCRIPTION
承接 #128（维护者已标注「数据损坏类，尽快修」；认领评论见 issue）。两处根因都在向量回填链路上，改动收敛于 `store.js` 一条 SQL 与 `index.js` 一个早退。

## 根因 1：`needsEmbedding` 未过滤归档行

```sql
SELECT id, title, content FROM memories
 WHERE embedding IS NULL OR embedding = ''
 ORDER BY updated_at DESC LIMIT ?
```

归档/遗忘行不参与召回、不进 dream 聚类，但报告实测 **/vector-reindex 的 50 个名额全部落在归档行**（dream/sleep 每小时都在新增归档行且按 `updated_at DESC` 排队首），88 条活跃记忆永远轮不到，embedding 配额/费用花在死行上。

**修法**：补 `AND forgotten = 0 AND archived = 0`——与 `embeddedCount()`/`count()` 的既有口径对齐。boot 回填与 `/vector-reindex`（`rebuildIndex` 同样走 `needsEmbedding`）一并生效。

## 根因 2：boot 回填被模型指纹门短路

```js
if (!store.needsEmbedding(1).length) return;
const current = embedder.modelHash;
if (current && vectorIndex.modelHash?.() === current) return;  // ← 永久短路
```

「指纹相同」只说明**已有**向量是该模型产的，不代表没有缺失行。任意一条嵌入成功写入 `vector_meta` 后，此后每次启动都在这行 return——写入时嵌入失败（embedder 未就绪 / 服务商限流）的行**永久失去补回机会**（报告实测 88 条，创建时间跨 3 周）。

**修法**：删除指纹早退；回填循环抽成导出的 `backfillMissingEmbeddings()`（便于直测），指纹只保留 `markModel` 记账用途——匹配时幂等，无额外代价。`MAX_TOTAL=500` 上限与 200ms 批次限速原样保留，行为面唯一变化就是「指纹匹配 + 有缺失行」从「不作为」变为「按上限补缺」。

## 测试（+3）

- `needsEmbedding` 只返回活跃行（归档/遗忘跳过）；
- **指纹匹配场景**（旧实现的短路条件）下：活跃行被补回、归档行跳过、指纹不变（markModel 幂等）；
- `maxTotal` 上限生效、剩余行留给下次启动。

全量 **839 项通过**（0 fail，1 skip 为既有）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boot-time embedding backfill now includes missing active memories even when the model fingerprint matches.
  * Archived and forgotten memories are excluded from embedding backfill and do not consume backfill capacity.
  * Backfill remains bounded and processes records in rate-limited batches.

* **Tests**
  * Added coverage for fingerprint-matched backfill, active-memory filtering, and maximum backfill limits.

* **Documentation**
  * Updated configuration guidance to describe active-memory filtering and continued backfill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->