### PR TITLE
fix(dream): degraded 轮跳过明细落库到 dream_runs.skipped (#104)

### DIFF
--- a/dsh-mneme/lib/dream.js
+++ b/dsh-mneme/lib/dream.js
@@ -657,7 +657,12 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
           outcome: result.outcome,
           applied,
           summary_stored: summaryStored,
-          receipt
+          receipt,
+          // Issue #104：degraded（合法子集已应用）轮被跳过的决策明细。写成独立字段
+          // 而非内联进 decisions——degraded 的 decisions 是合法子集，下游按「决策
+          // 数组」消费，内联标记会污染其它读者（失败轮的 _validationFailed 是整单
+          // 拒绝哨兵，语义与「部分应用」不同，也不复用）。
+          skipped: result.skipped
         });
       } catch (error) {
         logger?.warn?.(`dsh-mneme dream: failed to record audit run: ${String(error)}`);
@@ -978,7 +983,10 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
       conflicts,
       failures,
       frozen: frozenCount,
-      summary: summaryStored
+      summary: summaryStored,
+      // Issue #104：只有真发生跳过时才落库（degraded 也可能仅因 summary 为空），
+      // ok 轮留 NULL，避免「空数组」与「无此字段」两种假明细占据审计行。
+      skipped: skippedInvalid ? skipped : undefined
     });
   }
 

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS dream_runs (
   summary_stored INTEGER NOT NULL DEFAULT 0,
   receipt        TEXT NOT NULL,
   policy_epoch   INTEGER NOT NULL DEFAULT 0,  -- 裁决规则版本：规则升级后旧裁决降级为历史证据
-  run_type       TEXT NOT NULL DEFAULT 'auto'  -- auto | sleep：睡眠周期的审计区分
+  run_type       TEXT NOT NULL DEFAULT 'auto', -- auto | sleep：睡眠周期的审计区分
+  skipped        TEXT                     -- JSON: degraded 轮被跳过的逐条明细（index/action/ids/error）
 );
 CREATE INDEX IF NOT EXISTS idx_dream_runs_created ON dream_runs(created_at);
 
@@ -371,7 +372,9 @@ function toDreamRun(row) {
     summary_stored: row.summary_stored === 1,
     receipt: row.receipt,
     policy_epoch: row.policy_epoch ?? 0,
-    run_type: row.run_type ?? "auto"
+    run_type: row.run_type ?? "auto",
+    // Issue #104：degraded 轮的逐条跳过明细（JSON 列，NULL = 该轮无跳过项）。
+    skipped: row.skipped ? JSON.parse(row.skipped) : undefined
   };
 }
 
@@ -597,6 +600,9 @@ export function createStore(path) {
   // Legacy dream_runs without policy_epoch → backfill with the default epoch.
   addColumn("dream_runs", "policy_epoch", "ALTER TABLE dream_runs ADD COLUMN policy_epoch INTEGER NOT NULL DEFAULT 0");
   addColumn("dream_runs", "run_type", "ALTER TABLE dream_runs ADD COLUMN run_type TEXT NOT NULL DEFAULT 'auto'");
+  // Issue #104：degraded（合法子集已应用）轮被跳过的决策明细。此前只进 logger.warn，
+  // 离线回放 dream_runs 无法定位 degraded 成因（跨类型 merge / update 保护期 / unknown id）。
+  addColumn("dream_runs", "skipped", "ALTER TABLE dream_runs ADD COLUMN skipped TEXT");
 
   // Legacy mirror_state without v0.3.6 generation columns → add each missing
   // column idempotently (old DBs open cleanly, no data loss).
@@ -1126,16 +1132,20 @@ export function createStore(path) {
     const now = nowIso();
     const policyEpoch = Number.isInteger(run.policy_epoch) ? run.policy_epoch : 0;
     const runType = run.run_type ?? "auto";
+    // Issue #104：degraded 轮的跳过明细（JSON）。与 decisions/outcome 同为可选
+    // 载荷，未提供时落 NULL（而不是 "[]"），审计行只记真实发生过的跳过。
+    const skipped = run.skipped !== undefined ? JSON.stringify(run.skipped) : null;
     db.prepare(
       `INSERT INTO dream_runs (id, created_at, status, error, provider, model, snapshot_hash,
-        input_count, input, decisions, outcome, applied, summary_stored, receipt, policy_epoch, run_type)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        input_count, input, decisions, outcome, applied, summary_stored, receipt, policy_epoch, run_type, skipped)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          created_at=excluded.created_at, status=excluded.status, error=excluded.error,
          provider=excluded.provider, model=excluded.model, snapshot_hash=excluded.snapshot_hash,
          input_count=excluded.input_count, input=excluded.input, decisions=excluded.decisions,
          outcome=excluded.outcome, applied=excluded.applied, summary_stored=excluded.summary_stored,
-         receipt=excluded.receipt, policy_epoch=excluded.policy_epoch, run_type=excluded.run_type`
+         receipt=excluded.receipt, policy_epoch=excluded.policy_epoch, run_type=excluded.run_type,
+         skipped=excluded.skipped`
     ).run(
       id,
       run.created_at ?? now,
@@ -1152,7 +1162,8 @@ export function createStore(path) {
       run.summary_stored ? 1 : 0,
       run.receipt,
       policyEpoch,
-      runType
+      runType,
+      skipped
     );
     return getDreamRun(id);
   }

--- a/dsh-mneme/src/dream.js
+++ b/dsh-mneme/src/dream.js
@@ -657,7 +657,12 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
           outcome: result.outcome,
           applied,
           summary_stored: summaryStored,
-          receipt
+          receipt,
+          // Issue #104：degraded（合法子集已应用）轮被跳过的决策明细。写成独立字段
+          // 而非内联进 decisions——degraded 的 decisions 是合法子集，下游按「决策
+          // 数组」消费，内联标记会污染其它读者（失败轮的 _validationFailed 是整单
+          // 拒绝哨兵，语义与「部分应用」不同，也不复用）。
+          skipped: result.skipped
         });
       } catch (error) {
         logger?.warn?.(`dsh-mneme dream: failed to record audit run: ${String(error)}`);
@@ -978,7 +983,10 @@ export function createDreamScheduler({ onRun, thresholdCount = 10, thresholdChar
       conflicts,
       failures,
       frozen: frozenCount,
-      summary: summaryStored
+      summary: summaryStored,
+      // Issue #104：只有真发生跳过时才落库（degraded 也可能仅因 summary 为空），
+      // ok 轮留 NULL，避免「空数组」与「无此字段」两种假明细占据审计行。
+      skipped: skippedInvalid ? skipped : undefined
     });
   }
 

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS dream_runs (
   summary_stored INTEGER NOT NULL DEFAULT 0,
   receipt        TEXT NOT NULL,
   policy_epoch   INTEGER NOT NULL DEFAULT 0,  -- 裁决规则版本：规则升级后旧裁决降级为历史证据
-  run_type       TEXT NOT NULL DEFAULT 'auto'  -- auto | sleep：睡眠周期的审计区分
+  run_type       TEXT NOT NULL DEFAULT 'auto', -- auto | sleep：睡眠周期的审计区分
+  skipped        TEXT                     -- JSON: degraded 轮被跳过的逐条明细（index/action/ids/error）
 );
 CREATE INDEX IF NOT EXISTS idx_dream_runs_created ON dream_runs(created_at);
 
@@ -371,7 +372,9 @@ function toDreamRun(row) {
     summary_stored: row.summary_stored === 1,
     receipt: row.receipt,
     policy_epoch: row.policy_epoch ?? 0,
-    run_type: row.run_type ?? "auto"
+    run_type: row.run_type ?? "auto",
+    // Issue #104：degraded 轮的逐条跳过明细（JSON 列，NULL = 该轮无跳过项）。
+    skipped: row.skipped ? JSON.parse(row.skipped) : undefined
   };
 }
 
@@ -597,6 +600,9 @@ export function createStore(path) {
   // Legacy dream_runs without policy_epoch → backfill with the default epoch.
   addColumn("dream_runs", "policy_epoch", "ALTER TABLE dream_runs ADD COLUMN policy_epoch INTEGER NOT NULL DEFAULT 0");
   addColumn("dream_runs", "run_type", "ALTER TABLE dream_runs ADD COLUMN run_type TEXT NOT NULL DEFAULT 'auto'");
+  // Issue #104：degraded（合法子集已应用）轮被跳过的决策明细。此前只进 logger.warn，
+  // 离线回放 dream_runs 无法定位 degraded 成因（跨类型 merge / update 保护期 / unknown id）。
+  addColumn("dream_runs", "skipped", "ALTER TABLE dream_runs ADD COLUMN skipped TEXT");
 
   // Legacy mirror_state without v0.3.6 generation columns → add each missing
   // column idempotently (old DBs open cleanly, no data loss).
@@ -1126,16 +1132,20 @@ export function createStore(path) {
     const now = nowIso();
     const policyEpoch = Number.isInteger(run.policy_epoch) ? run.policy_epoch : 0;
     const runType = run.run_type ?? "auto";
+    // Issue #104：degraded 轮的跳过明细（JSON）。与 decisions/outcome 同为可选
+    // 载荷，未提供时落 NULL（而不是 "[]"），审计行只记真实发生过的跳过。
+    const skipped = run.skipped !== undefined ? JSON.stringify(run.skipped) : null;
     db.prepare(
       `INSERT INTO dream_runs (id, created_at, status, error, provider, model, snapshot_hash,
-        input_count, input, decisions, outcome, applied, summary_stored, receipt, policy_epoch, run_type)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        input_count, input, decisions, outcome, applied, summary_stored, receipt, policy_epoch, run_type, skipped)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          created_at=excluded.created_at, status=excluded.status, error=excluded.error,
          provider=excluded.provider, model=excluded.model, snapshot_hash=excluded.snapshot_hash,
          input_count=excluded.input_count, input=excluded.input, decisions=excluded.decisions,
          outcome=excluded.outcome, applied=excluded.applied, summary_stored=excluded.summary_stored,
-         receipt=excluded.receipt, policy_epoch=excluded.policy_epoch, run_type=excluded.run_type`
+         receipt=excluded.receipt, policy_epoch=excluded.policy_epoch, run_type=excluded.run_type,
+         skipped=excluded.skipped`
     ).run(
       id,
       run.created_at ?? now,
@@ -1152,7 +1162,8 @@ export function createStore(path) {
       run.summary_stored ? 1 : 0,
       run.receipt,
       policyEpoch,
-      runType
+      runType,
+      skipped
     );
     return getDreamRun(id);
   }

--- a/dsh-mneme/test/dream.test.js
+++ b/dsh-mneme/test/dream.test.js
@@ -1109,6 +1109,49 @@ test("issue#89: dream run with a skipped invalid decision lands the valid subset
   store.close();
 });
 
+// Issue #104（跟进 #137 失败路径）：degraded（合法子集已应用）轮的跳过明细此前只进
+// logger.warn，splice 之后就地从 decisions 里消失，落库的已是幸存列表——离线回放
+// dream_runs 无法判断被跳的是跨类型 merge、update 保护期还是 unknown id。这里断言
+// 明细进了独立的 skipped 列（而非内联进 decisions），且携带可定位的逐条原因。
+test("issue#104: degraded run persists the skipped decision detail into dream_runs.skipped", async () => {
+  const { store, service } = dreamSetup();
+  const a = service.saveWithDedupe({ type: "project", title: "旧A", content: "过时A" }).memory;
+  const b = service.saveWithDedupe({ type: "project", title: "旧B", content: "过时B" }).memory;
+  const pref = service.saveWithDedupe({ type: "preference", title: "语言", content: "中文" }).memory;
+  const c = service.saveWithDedupe({ type: "project", title: "旧C", content: "过时C" }).memory;
+  const ctx = {
+    logger: { warn: () => {}, info: () => {} },
+    llm: {
+      async *stream(options) {
+        const userText = options.messages.find((m) => m.role === "user")?.content?.[0]?.text ?? "";
+        if (userText.startsWith("id=")) {
+          // 一条跨类型 merge（非法 → 跳过）+ 两条合法 archive（显式覆盖 2/4，过 50% 下限）
+          yield { type: "text-delta", index: 0, text: JSON.stringify([
+            { action: "merge", ids: [pref.id, a.id], keepSource: pref.id, title: "跨类型", content: "不应合并", importance: 4 },
+            { action: "archive", ids: [b.id], reason: "stale" },
+            { action: "archive", ids: [c.id], reason: "stale" }
+          ]) };
+        } else {
+          yield { type: "text-delta", index: 0, text: "记忆库总览：degraded 轮的跳过明细可从审计行回放。" };
+        }
+        yield { type: "finish", reason: { kind: "stop" } };
+      }
+    }
+  };
+  const dream = createDreamScheduler({ thresholdCount: 1, thresholdChars: 0, delayMs: 0 });
+  const result = await dream.runDream(ctx, service, { dreamProvider: "mock", dreamModel: "mock-model" });
+  assert.equal(result.status, "degraded", "run degrades on the skipped decision");
+  // 落库验证：skipped 列不再是 NULL，逐条带 index/action/error，事后无需重跑即可定位成因。
+  const run = store.getDreamRun(result.runId);
+  assert.ok(Array.isArray(run?.skipped) && run.skipped.length === 1, "skipped detail persisted in dream_runs.skipped");
+  assert.equal(run.skipped[0].index, 0, "the skipped entry is the cross-type merge");
+  assert.equal(run.skipped[0].action, "merge");
+  assert.match(run.skipped[0].error, /multiple types/, "per-item skip reason is kept");
+  // 独立字段，不污染按「决策数组」消费 decisions 的下游读者。
+  assert.ok(!run.decisions.some((d) => d && d._skipped !== undefined), "decisions stays free of inline markers");
+  store.close();
+});
+
 test("issue#89: dreamSkipInvalid:false restores the whole-batch strict rejection", async () => {
   const { store, service } = dreamSetup();
   const a = service.saveWithDedupe({ type: "project", title: "旧A", content: "过时A" }).memory;


### PR DESCRIPTION
## 背景

`degraded`（合法子集已应用）路径上，`validateDecisions` 会把非法决策就地 `splice` 出数组（数组长度可能不变、内容已变——`src/dream/decisions.js` 末尾有一段注释专门说明这一点），`dream_runs.decisions` 落库的是**幸存列表**，被跳过的条目只进 `logger.warn`。

离线回放 `dream_runs` 因此无法定位 degraded 的成因：分不清被跳的是跨类型 merge、update 保护期还是 unknown id。

`#137` 覆盖的是**整单拒绝**（failed）路径（`decisions: [{ _validationFailed: true, errors, skipped }]`），degraded 路径此前没有等价的落库形态。

证据等级：

| 论断 | 等级 | 依据 |
|---|---|---|
| 被跳决策在 `validateDecisions` 里被就地抹掉 | 可执行实测 | 用 `main` 的 `src/dream/decisions.js` 纯函数复现，输出见 #104 跟进评论 |
| degraded 出口不把 `skipped` 交给落库 | 代码结构事实 | `main` 的 `src/dream.js` degraded 出口 `finish` 载荷不含 `skipped` |

## 改动

按 #104 中确认的形态实现——**独立字段，不用内联标记**：

| 文件 | 改动 |
|---|---|
| `src/store.js` | `dream_runs` 新增 `skipped TEXT`（JSON）+ `addColumn` 幂等迁移（同 `policy_epoch`/`run_type` 先例）；`saveDreamRun` 写入、`toDreamRun` 读回 |
| `src/dream.js` | degraded 出口把 `skipped` 透传给 `finish`，由 `finish` 写进审计行 |
| `test/dream.test.js` | 新增断言：degraded run 的审计行含逐条 `index`/`action`/`error`，且 `decisions` 不含内联标记 |

只在真发生跳过时才写（degraded 也可能仅因 summary 为空而 degraded），ok 轮落 NULL——避免「空数组」与「无此字段」两种假明细占据审计行。

这样 degraded 与 failed 两条路径的处置都可在审计行里离线定位，不必重跑 LLM。

## 验证

`npm test`：848 个用例，847 通过。唯一失败是 `test/peer-blockers.test.js` 的 peer-C（8 进程并发原子递增），在本机沙箱下 `spawn EPERM`（环境不允许子进程命名管道），与本改动无关。

`lib/` 由 `npm run sync` 同步（仅 `dream.js` / `store.js` 内容变化）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Degraded consolidation runs now preserve details about decisions that were skipped due to validation issues.
  * Run results and audit records distinguish partially applied runs from successful runs without adding empty skip data.
  * Previously recorded runs continue to work through an automatic database update.

* **Observability**
  * Skipped decision details are now available in the run history, improving troubleshooting and replayability of degraded runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->