### PR TITLE
feat(summarize): 节流、产出上限与同会话写入端去重 (#127)

### DIFF
--- a/dsh-mneme/lib/api.js
+++ b/dsh-mneme/lib/api.js
@@ -115,6 +115,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   const flagKeys = [
     ...FEATURE_FLAG_SPEC.booleans,
     ...Object.keys(FEATURE_FLAG_SPEC.ints),
+    ...Object.keys(FEATURE_FLAG_SPEC.numbers),
     ...FEATURE_FLAG_SPEC.strings,
     ...FEATURE_FLAG_SPEC.urls,
     ...Object.keys(FEATURE_FLAG_SPEC.enums)

--- a/dsh-mneme/lib/config.js
+++ b/dsh-mneme/lib/config.js
@@ -18,6 +18,17 @@ export const Config = z.object({
   // 蒸馏把完整对话上下文交给 LLM 提炼，不硬裁到 8000 字就截断语义；默认
   // 24000 字符（约覆盖一整轮中等对话），需要更完整可调大。
   distillMaxChars: z.natural().min(1000).max(200000).default(24000),
+  // autoSummarize 节流、产出上限与写入端同会话去重（Issue #127，默认全 0/off =
+  // 零行为变化）。此前每个 turn/end 必跑、产出条数由模型输出决定、写入端只按
+  // 「同类型 + 标题 trim 全等」去重——本机实测单日 84 次、单会话一天 198 条、
+  // 同一事实 6 小时铸出 28+ 条。阀门交给用户按需拧，升级本身不改行为。
+  summarizeMinIntervalMinutes: z.natural().min(0).max(10080).default(0),
+  summarizeMaxEntriesPerRun: z.natural().min(0).max(50).default(0),
+  // 落库前去重档位：off（默认，等同现状）/ title（零成本，仅拦完全同名）/
+  // vector（复用已有 embedding 列做同会话语义近邻，无 LLM 调用）。
+  summarizeDedupeMode: z.union([z.const("off"), z.const("title"), z.const("vector")]).default("off"),
+  summarizeDedupeMinSim: z.number().min(0.5).max(0.99).default(0.92),
+  summarizeDedupeWindowHours: z.natural().min(0).max(168).default(24),
   // 智能调速器（429 保护，默认开）：蒸馏 LLM 调用全局串行排队，相邻请求
   // 间隔 distillRateLimitIntervalMs（默认 1s 一次）；命中 429 限流时按
   // distillRateLimitBaseDelayMs 指数退避（1s→2s→4s…）自动重试

--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -873,6 +873,60 @@ export function createService({ store, mirror, config, onWrite, logger }) {
   }
 
   /**
+   * 写入端同会话语义去重（Issue #127，opt-in，默认 off）：落库前把新条目与
+   * 「同会话 + 时间窗」内已落库的记忆比对，命中即并入既有条目，不再新造一行。
+   *
+   * 分层：title 档走零成本的标题归一化；vector 档复用已有 embedding 列做近邻，
+   * 新条目的向量由 embedder 现算（embedQuery），全程无 LLM 调用。embedder 不可用
+   * 或向量缺失一律返回 undefined 回落正常写入——去重是增强，绝不能成为写入依赖。
+   *
+   * 作用域刻意限定「同会话」：跨会话的同类事实仍交给 autoDream / sleep 的批量裁决。
+   * 比对逻辑与并入动作分别复用 cosineVec 与 saveWithDedupe 的 _mergeInto 分支。
+   *
+   * @returns {{action: "merged", memory: object, sim: number}|undefined} 命中则返回
+   *          并入目标与相似度；未命中（含任何异常）返回 undefined。
+   */
+  async function findSessionDuplicate(memory, { mode = "off", minSim = 0.92, windowHours = 24, source } = {}) {
+    if (mode === "off" || !source || !memory?.title) return undefined;
+    try {
+      const sinceMs = windowHours > 0 ? Date.now() - windowHours * 3600000 : 0;
+      const inWindow = (m) => {
+        if (sinceMs <= 0) return true;
+        const t = Date.parse(m.created_at ?? "");
+        return !Number.isFinite(t) || t >= sinceMs; // 时间戳损坏时不误杀
+      };
+      const candidates = store
+        .list({ type: memory.type, source, limit: 200 })
+        .filter((m) => !m.archived && inWindow(m));
+      if (!candidates.length) return undefined;
+
+      if (mode === "title") {
+        const norm = (s) => String(s ?? "").toLowerCase().replace(/[\s\p{P}]+/gu, "");
+        const key = norm(memory.title);
+        if (!key) return undefined;
+        const hit = candidates.find((m) => norm(m.title) === key);
+        return hit ? { action: "merged", memory: hit, sim: 1 } : undefined;
+      }
+      if (mode !== "vector") return undefined;
+
+      const vecs = store.getEmbeddings(candidates.map((m) => m.id));
+      if (!vecs.size) return undefined;
+      const probe = await embedQuery([memory.title, memory.content].filter(Boolean).join("\n"));
+      if (!probe) return undefined;
+      let best;
+      for (const m of candidates) {
+        const v = vecs.get(m.id);
+        if (!v) continue; // 无向量的既有行不参与比对（无信号 = 不判定）
+        const sim = cosineVec(probe, v);
+        if (sim >= minSim && (!best || sim > best.sim)) best = { action: "merged", memory: m, sim };
+      }
+      return best;
+    } catch {
+      return undefined; // 去重失败绝不阻塞写入
+    }
+  }
+
+  /**
    * Save a memory, merging into an existing one when title matches within the same type.
    *
    * Bug5: a same-title merge no longer overwrites — the new content is appended
@@ -911,10 +965,15 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     // 标题变化，若仍按 (type, title) 匹配会出现两个活跃的 summary 同时注入。
     // 其余类型维持 (type, title) 匹配不变。
     const candidates = store.list({ type: memory.type, limit: 100 });
-    const existing = (memory.type === "summary" && memory.source === "dream")
-      ? (candidates.find((m) => m.source === "dream")
-        ?? candidates.find((m) => m.title.trim() === String(memory.title).trim()))
-      : candidates.find((m) => m.title.trim() === String(memory.title).trim());
+    // Issue #127：写入端语义去重命中时，调用方用 _mergeInto 指定并入目标——复用
+    // 下面这段并入逻辑（appendContent + content_history + 质量处置），不另写第二份
+    // 实现。目标已被并发删除时回落到常规匹配。
+    const existing = memory._mergeInto
+      ? store.getById(memory._mergeInto)
+      : (memory.type === "summary" && memory.source === "dream")
+        ? (candidates.find((m) => m.source === "dream")
+          ?? candidates.find((m) => m.title.trim() === String(memory.title).trim()))
+        : candidates.find((m) => m.title.trim() === String(memory.title).trim());
     if (existing) {
       const newContent = String(memory.content ?? "");
       if (!newContent.trim()) {
@@ -1493,6 +1552,7 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     setRecallRecorder(fn) { recallRecorder = fn; },
     searchMemories,
     embedQuery,
+    findSessionDuplicate,
     evaluateRetrieval,
     computeRetrievalMetrics,
     // passthroughs used by tools and api layers; mutations keep the mirror in sync

--- a/dsh-mneme/lib/settings.js
+++ b/dsh-mneme/lib/settings.js
@@ -78,7 +78,17 @@ const FEATURE_FLAG_INT_RANGES = {
   distillMaxChars: [1000, 200000],
   codingBoostFactor: [1, 5],
   dreamMinIntervalMinutes: [0, 10080],
-  dreamMaxTokens: [256, 131072]
+  dreamMaxTokens: [256, 131072],
+  // Issue #127：autoSummarize 节流三键（0 = 零行为变化，等同现状）。
+  summarizeMinIntervalMinutes: [0, 10080],
+  summarizeMaxEntriesPerRun: [0, 50],
+  summarizeDedupeWindowHours: [0, 168]
+};
+// 浮点开关的闭区间（与 config.js 的 z.number().min().max() 对齐）。与整数开关
+// 分开：面板的整数控件要求 Number.isInteger，而余弦相似度阈值必须允许小数。
+const FEATURE_FLAG_NUMBER_RANGES = {
+  // Issue #127：vector 去重档的并入阈值。
+  summarizeDedupeMinSim: [0.5, 0.99]
 };
 // 自由字符串开关（与 config.js 的 z.string() 同名同型）：trim 后 ≤200 字符，
 // 空串合法（= 跟随主对话模型/默认路径，面板显示 placeholder）。
@@ -106,7 +116,9 @@ const FEATURE_FLAG_ENUMS = {
   // rank/scale-aware alternatives selected by the panel.
   recallFusion: ["blend", "rrf", "minmax"],
   // 实体抽取思考强度（issue #109）：与 dreamReasoningEffort 枚举对齐。
-  entityExtractionReasoning: ["low", "medium", "high", "none"]
+  entityExtractionReasoning: ["low", "medium", "high", "none"],
+  // Issue #127：落库前去重档位（off 默认，等同现状）。
+  summarizeDedupeMode: ["off", "title", "vector"]
 };
 const FEATURE_FLAG_STRING_MAX = 200;
 
@@ -114,6 +126,7 @@ const FEATURE_FLAG_STRING_MAX = 200;
 export const FEATURE_FLAG_SPEC = {
   booleans: FEATURE_FLAG_BOOLEANS,
   ints: FEATURE_FLAG_INT_RANGES,
+  numbers: FEATURE_FLAG_NUMBER_RANGES,
   strings: FEATURE_FLAG_STRINGS,
   urls: FEATURE_FLAG_URLS,
   enums: FEATURE_FLAG_ENUMS
@@ -142,6 +155,14 @@ function validateFlag(key, value) {
     const [min, max] = range;
     if (!Number.isInteger(value) || value < min || value > max) {
       throw new TypeError(`feature flag "${key}" must be an integer in [${min}, ${max}]`);
+    }
+    return value;
+  }
+  const numRange = FEATURE_FLAG_NUMBER_RANGES[key];
+  if (numRange) {
+    const [min, max] = numRange;
+    if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) {
+      throw new TypeError(`feature flag "${key}" must be a number in [${min}, ${max}]`);
     }
     return value;
   }
@@ -184,6 +205,11 @@ function sanitizeFlags(raw) {
   }
   for (const [key, [min, max]] of Object.entries(FEATURE_FLAG_INT_RANGES)) {
     if (Number.isInteger(raw[key]) && raw[key] >= min && raw[key] <= max) out[key] = raw[key];
+  }
+  for (const [key, [min, max]] of Object.entries(FEATURE_FLAG_NUMBER_RANGES)) {
+    if (typeof raw[key] === "number" && Number.isFinite(raw[key]) && raw[key] >= min && raw[key] <= max) {
+      out[key] = raw[key];
+    }
   }
   for (const key of FEATURE_FLAG_STRINGS) {
     if (typeof raw[key] === "string" && raw[key].trim().length <= FEATURE_FLAG_STRING_MAX) {

--- a/dsh-mneme/lib/summarize.js
+++ b/dsh-mneme/lib/summarize.js
@@ -184,10 +184,54 @@ export function createSummarizer(ctx, service, config) {
   if (!config.autoSummarize) return { dispose: () => {} };
 
   const inFlight = new Map();
+  // Issue #127：per-session 上一次实际开跑时刻（最小间隔闸门用）。与 inFlight
+  // 同生命周期，dispose 时一并清空。
+  const lastRunAt = new Map();
   let disposed = false;
+
+  /** 写一条 autoSummarize 的 LLM 审计行（审计失败绝不阻塞蒸馏本身）。 */
+  function writeAudit(entry) {
+    if (config?.llmAudit?.enabled === false || typeof service.saveLlmAudit !== "function") return;
+    try {
+      service.saveLlmAudit({
+        trigger_source: "autoSummarize",
+        operation_type: "summarize_compress",
+        related_memory_ids: [],
+        ...entry
+      });
+    } catch (auditError) {
+      ctx.logger?.warn?.(`dsh-mneme: llm audit write failed: ${String(auditError)}`);
+    }
+  }
 
   async function summarize(session) {
     if (disposed || inFlight.has(session.id)) return;
+
+    const header = session.requestHeader?.()?.config;
+    // Config override takes priority, then session header, then nothing.
+    const route = (config.summarizeProvider && config.summarizeModel)
+      ? { provider: config.summarizeProvider, model: config.summarizeModel }
+      : (header?.provider && header?.model)
+        ? { provider: header.provider, model: header.model }
+        : undefined;
+
+    // Issue #127 间隔门：同一会话两次蒸馏之间的最小间隔（0 = 现状，不限）。进入
+    // 即打点——失败/degraded 的 run 也占用间隔，与 dreamMinIntervalMinutes 语义
+    // 一致，防止失败连发。被挡下的 turn/end 静默跳过，但留一行 status='skipped'
+    // 审计，否则「这一轮为什么没蒸馏」对用户完全不可观测。
+    const gapMs = (config.summarizeMinIntervalMinutes ?? 0) * 60000;
+    const prevClaim = lastRunAt.get(session.id);
+    if (gapMs > 0 && Date.now() - (prevClaim ?? 0) < gapMs) {
+      writeAudit({
+        timestamp: new Date().toISOString(),
+        model_id: route ? `${route.provider}:${route.model}` : "unknown",
+        status: "skipped",
+        error_message: "min-interval"
+      });
+      return;
+    }
+    lastRunAt.set(session.id, Date.now());
+
     const controller = new AbortController();
     inFlight.set(session.id, controller);
     // audit state for the compression call. null = no audit for this run
@@ -196,14 +240,8 @@ export function createSummarizer(ctx, service, config) {
     // so a failed/aborted stream still leaves a status='error' trail without
     // ever blocking the summarization itself.
     let audit = null;
+    let abortedRun = false;
     try {
-      const header = session.requestHeader?.()?.config;
-      // Config override takes priority, then session header, then nothing.
-      const route = (config.summarizeProvider && config.summarizeModel)
-        ? { provider: config.summarizeProvider, model: config.summarizeModel }
-        : (header?.provider && header?.model)
-          ? { provider: header.provider, model: header.model }
-          : undefined;
       if (!route) return;
       // 完整转录（Codex 式）：蒸馏把整轮对话交给 LLM 提炼原子记忆，不再硬裁
       // 8000 字截断语义；上限由 distillMaxChars 控制（默认 24000，可调大）。
@@ -301,8 +339,19 @@ export function createSummarizer(ctx, service, config) {
           }
         }
       }, intervalMs);
-      if (aborted) return;
-      const entries = parseSummaryJson(text || assembledText);
+      if (aborted) {
+        abortedRun = true;
+        return;
+      }
+      const parsed = parseSummaryJson(text || assembledText);
+      // Issue #127 条数上限：0 = 不限（现状）。被截断的条数与去重命中数一并进
+      // 审计 metadata——此前产出条数完全由模型输出决定，用户无从自查。
+      const cap = config.summarizeMaxEntriesPerRun ?? 0;
+      const entries = cap > 0 ? parsed.slice(0, cap) : parsed;
+      const capped = parsed.length - entries.length;
+      const dedupeMode = config.summarizeDedupeMode ?? "off";
+      let deduped = 0;
+      let dedupeMaxSim = 0;
       for (const entry of entries) {
         // Provenance: the summarizer runs on a real session (turn/end hook), so
         // session.id is always available here — it rides the human-readable
@@ -310,12 +359,45 @@ export function createSummarizer(ctx, service, config) {
         // 编码记忆类型（codingRetrospect）不带 tag：读取侧门控/加权靠 m.type
         // （rejected_solution/pitfall/constraint）区分即可，tag 体系
         // sanitizeTags 不认 `type:` 前缀反而会清空 tags 列（额外一次 UPDATE）。
+        const source = `session:${session.id}`;
+        // Issue #127 落库前去重（opt-in，默认 off = 现状）：命中则并入既有条目
+        // （saveWithDedupe 的 _mergeInto 分支），不再新造一行。作用域 = 同会话 +
+        // 时间窗；跨会话的同类事实仍交给 autoDream / sleep 的批量裁决。
+        const dup = (dedupeMode !== "off" && typeof service.findSessionDuplicate === "function")
+          ? await service.findSessionDuplicate(
+            { ...entry, source },
+            {
+              mode: dedupeMode,
+              minSim: config.summarizeDedupeMinSim ?? 0.92,
+              windowHours: config.summarizeDedupeWindowHours ?? 24,
+              source
+            }
+          )
+          : undefined;
+        if (dup) {
+          deduped++;
+          dedupeMaxSim = Math.max(dedupeMaxSim, dup.sim ?? 0);
+        }
         service.saveWithDedupe({
           ...entry,
-          source: `session:${session.id}`
+          source,
+          ...(dup ? { _mergeInto: dup.memory.id } : {})
         });
       }
+      if (audit && (capped > 0 || deduped > 0)) {
+        audit.metadata = {
+          parsed: parsed.length,
+          ...(capped > 0 ? { capped } : {}),
+          ...(deduped > 0 ? { deduped, mode: dedupeMode, maxSim: Number(dedupeMaxSim.toFixed(4)) } : {})
+        };
+      }
     } finally {
+      // Issue #127：aborted（会话关闭 / 插件 dispose）不占间隔，避免误伤该会话的
+      // 下一次蒸馏；其余情况（含失败）的打点保留，与 dreamMinIntervalMinutes 一致。
+      if (abortedRun || controller.signal.aborted) {
+        if (prevClaim === undefined) lastRunAt.delete(session.id);
+        else lastRunAt.set(session.id, prevClaim);
+      }
       if (audit) {
         try {
           service.saveLlmAudit({
@@ -330,7 +412,10 @@ export function createSummarizer(ctx, service, config) {
             duration_ms: Date.now() - audit.startedAt,
             status: audit.status,
             error_message: audit.errorMessage,
-            related_memory_ids: []
+            related_memory_ids: [],
+            // Issue #127：parsed / capped / deduped 的观测数据。零 schema 变更
+            // （llm_audit_logs.metadata 已存在），一条 SQL 即可验证节流是否生效。
+            metadata: audit.metadata
           });
         } catch (auditError) {
           ctx.logger?.warn?.(`dsh-mneme: llm audit write failed: ${String(auditError)}`);
@@ -358,6 +443,7 @@ export function createSummarizer(ctx, service, config) {
       unsubscribe?.();
       for (const controller of inFlight.values()) controller.abort();
       inFlight.clear();
+      lastRunAt.clear();
     }
   };
 }

--- a/dsh-mneme/src/api.js
+++ b/dsh-mneme/src/api.js
@@ -115,6 +115,7 @@ export function createApi(ctx, service, settings, commands, embedder, semantic =
   const flagKeys = [
     ...FEATURE_FLAG_SPEC.booleans,
     ...Object.keys(FEATURE_FLAG_SPEC.ints),
+    ...Object.keys(FEATURE_FLAG_SPEC.numbers),
     ...FEATURE_FLAG_SPEC.strings,
     ...FEATURE_FLAG_SPEC.urls,
     ...Object.keys(FEATURE_FLAG_SPEC.enums)

--- a/dsh-mneme/src/config.js
+++ b/dsh-mneme/src/config.js
@@ -18,6 +18,17 @@ export const Config = z.object({
   // 蒸馏把完整对话上下文交给 LLM 提炼，不硬裁到 8000 字就截断语义；默认
   // 24000 字符（约覆盖一整轮中等对话），需要更完整可调大。
   distillMaxChars: z.natural().min(1000).max(200000).default(24000),
+  // autoSummarize 节流、产出上限与写入端同会话去重（Issue #127，默认全 0/off =
+  // 零行为变化）。此前每个 turn/end 必跑、产出条数由模型输出决定、写入端只按
+  // 「同类型 + 标题 trim 全等」去重——本机实测单日 84 次、单会话一天 198 条、
+  // 同一事实 6 小时铸出 28+ 条。阀门交给用户按需拧，升级本身不改行为。
+  summarizeMinIntervalMinutes: z.natural().min(0).max(10080).default(0),
+  summarizeMaxEntriesPerRun: z.natural().min(0).max(50).default(0),
+  // 落库前去重档位：off（默认，等同现状）/ title（零成本，仅拦完全同名）/
+  // vector（复用已有 embedding 列做同会话语义近邻，无 LLM 调用）。
+  summarizeDedupeMode: z.union([z.const("off"), z.const("title"), z.const("vector")]).default("off"),
+  summarizeDedupeMinSim: z.number().min(0.5).max(0.99).default(0.92),
+  summarizeDedupeWindowHours: z.natural().min(0).max(168).default(24),
   // 智能调速器（429 保护，默认开）：蒸馏 LLM 调用全局串行排队，相邻请求
   // 间隔 distillRateLimitIntervalMs（默认 1s 一次）；命中 429 限流时按
   // distillRateLimitBaseDelayMs 指数退避（1s→2s→4s…）自动重试

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -873,6 +873,60 @@ export function createService({ store, mirror, config, onWrite, logger }) {
   }
 
   /**
+   * 写入端同会话语义去重（Issue #127，opt-in，默认 off）：落库前把新条目与
+   * 「同会话 + 时间窗」内已落库的记忆比对，命中即并入既有条目，不再新造一行。
+   *
+   * 分层：title 档走零成本的标题归一化；vector 档复用已有 embedding 列做近邻，
+   * 新条目的向量由 embedder 现算（embedQuery），全程无 LLM 调用。embedder 不可用
+   * 或向量缺失一律返回 undefined 回落正常写入——去重是增强，绝不能成为写入依赖。
+   *
+   * 作用域刻意限定「同会话」：跨会话的同类事实仍交给 autoDream / sleep 的批量裁决。
+   * 比对逻辑与并入动作分别复用 cosineVec 与 saveWithDedupe 的 _mergeInto 分支。
+   *
+   * @returns {{action: "merged", memory: object, sim: number}|undefined} 命中则返回
+   *          并入目标与相似度；未命中（含任何异常）返回 undefined。
+   */
+  async function findSessionDuplicate(memory, { mode = "off", minSim = 0.92, windowHours = 24, source } = {}) {
+    if (mode === "off" || !source || !memory?.title) return undefined;
+    try {
+      const sinceMs = windowHours > 0 ? Date.now() - windowHours * 3600000 : 0;
+      const inWindow = (m) => {
+        if (sinceMs <= 0) return true;
+        const t = Date.parse(m.created_at ?? "");
+        return !Number.isFinite(t) || t >= sinceMs; // 时间戳损坏时不误杀
+      };
+      const candidates = store
+        .list({ type: memory.type, source, limit: 200 })
+        .filter((m) => !m.archived && inWindow(m));
+      if (!candidates.length) return undefined;
+
+      if (mode === "title") {
+        const norm = (s) => String(s ?? "").toLowerCase().replace(/[\s\p{P}]+/gu, "");
+        const key = norm(memory.title);
+        if (!key) return undefined;
+        const hit = candidates.find((m) => norm(m.title) === key);
+        return hit ? { action: "merged", memory: hit, sim: 1 } : undefined;
+      }
+      if (mode !== "vector") return undefined;
+
+      const vecs = store.getEmbeddings(candidates.map((m) => m.id));
+      if (!vecs.size) return undefined;
+      const probe = await embedQuery([memory.title, memory.content].filter(Boolean).join("\n"));
+      if (!probe) return undefined;
+      let best;
+      for (const m of candidates) {
+        const v = vecs.get(m.id);
+        if (!v) continue; // 无向量的既有行不参与比对（无信号 = 不判定）
+        const sim = cosineVec(probe, v);
+        if (sim >= minSim && (!best || sim > best.sim)) best = { action: "merged", memory: m, sim };
+      }
+      return best;
+    } catch {
+      return undefined; // 去重失败绝不阻塞写入
+    }
+  }
+
+  /**
    * Save a memory, merging into an existing one when title matches within the same type.
    *
    * Bug5: a same-title merge no longer overwrites — the new content is appended
@@ -911,10 +965,15 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     // 标题变化，若仍按 (type, title) 匹配会出现两个活跃的 summary 同时注入。
     // 其余类型维持 (type, title) 匹配不变。
     const candidates = store.list({ type: memory.type, limit: 100 });
-    const existing = (memory.type === "summary" && memory.source === "dream")
-      ? (candidates.find((m) => m.source === "dream")
-        ?? candidates.find((m) => m.title.trim() === String(memory.title).trim()))
-      : candidates.find((m) => m.title.trim() === String(memory.title).trim());
+    // Issue #127：写入端语义去重命中时，调用方用 _mergeInto 指定并入目标——复用
+    // 下面这段并入逻辑（appendContent + content_history + 质量处置），不另写第二份
+    // 实现。目标已被并发删除时回落到常规匹配。
+    const existing = memory._mergeInto
+      ? store.getById(memory._mergeInto)
+      : (memory.type === "summary" && memory.source === "dream")
+        ? (candidates.find((m) => m.source === "dream")
+          ?? candidates.find((m) => m.title.trim() === String(memory.title).trim()))
+        : candidates.find((m) => m.title.trim() === String(memory.title).trim());
     if (existing) {
       const newContent = String(memory.content ?? "");
       if (!newContent.trim()) {
@@ -1493,6 +1552,7 @@ export function createService({ store, mirror, config, onWrite, logger }) {
     setRecallRecorder(fn) { recallRecorder = fn; },
     searchMemories,
     embedQuery,
+    findSessionDuplicate,
     evaluateRetrieval,
     computeRetrievalMetrics,
     // passthroughs used by tools and api layers; mutations keep the mirror in sync

--- a/dsh-mneme/src/settings.js
+++ b/dsh-mneme/src/settings.js
@@ -78,7 +78,17 @@ const FEATURE_FLAG_INT_RANGES = {
   distillMaxChars: [1000, 200000],
   codingBoostFactor: [1, 5],
   dreamMinIntervalMinutes: [0, 10080],
-  dreamMaxTokens: [256, 131072]
+  dreamMaxTokens: [256, 131072],
+  // Issue #127：autoSummarize 节流三键（0 = 零行为变化，等同现状）。
+  summarizeMinIntervalMinutes: [0, 10080],
+  summarizeMaxEntriesPerRun: [0, 50],
+  summarizeDedupeWindowHours: [0, 168]
+};
+// 浮点开关的闭区间（与 config.js 的 z.number().min().max() 对齐）。与整数开关
+// 分开：面板的整数控件要求 Number.isInteger，而余弦相似度阈值必须允许小数。
+const FEATURE_FLAG_NUMBER_RANGES = {
+  // Issue #127：vector 去重档的并入阈值。
+  summarizeDedupeMinSim: [0.5, 0.99]
 };
 // 自由字符串开关（与 config.js 的 z.string() 同名同型）：trim 后 ≤200 字符，
 // 空串合法（= 跟随主对话模型/默认路径，面板显示 placeholder）。
@@ -106,7 +116,9 @@ const FEATURE_FLAG_ENUMS = {
   // rank/scale-aware alternatives selected by the panel.
   recallFusion: ["blend", "rrf", "minmax"],
   // 实体抽取思考强度（issue #109）：与 dreamReasoningEffort 枚举对齐。
-  entityExtractionReasoning: ["low", "medium", "high", "none"]
+  entityExtractionReasoning: ["low", "medium", "high", "none"],
+  // Issue #127：落库前去重档位（off 默认，等同现状）。
+  summarizeDedupeMode: ["off", "title", "vector"]
 };
 const FEATURE_FLAG_STRING_MAX = 200;
 
@@ -114,6 +126,7 @@ const FEATURE_FLAG_STRING_MAX = 200;
 export const FEATURE_FLAG_SPEC = {
   booleans: FEATURE_FLAG_BOOLEANS,
   ints: FEATURE_FLAG_INT_RANGES,
+  numbers: FEATURE_FLAG_NUMBER_RANGES,
   strings: FEATURE_FLAG_STRINGS,
   urls: FEATURE_FLAG_URLS,
   enums: FEATURE_FLAG_ENUMS
@@ -142,6 +155,14 @@ function validateFlag(key, value) {
     const [min, max] = range;
     if (!Number.isInteger(value) || value < min || value > max) {
       throw new TypeError(`feature flag "${key}" must be an integer in [${min}, ${max}]`);
+    }
+    return value;
+  }
+  const numRange = FEATURE_FLAG_NUMBER_RANGES[key];
+  if (numRange) {
+    const [min, max] = numRange;
+    if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) {
+      throw new TypeError(`feature flag "${key}" must be a number in [${min}, ${max}]`);
     }
     return value;
   }
@@ -184,6 +205,11 @@ function sanitizeFlags(raw) {
   }
   for (const [key, [min, max]] of Object.entries(FEATURE_FLAG_INT_RANGES)) {
     if (Number.isInteger(raw[key]) && raw[key] >= min && raw[key] <= max) out[key] = raw[key];
+  }
+  for (const [key, [min, max]] of Object.entries(FEATURE_FLAG_NUMBER_RANGES)) {
+    if (typeof raw[key] === "number" && Number.isFinite(raw[key]) && raw[key] >= min && raw[key] <= max) {
+      out[key] = raw[key];
+    }
   }
   for (const key of FEATURE_FLAG_STRINGS) {
     if (typeof raw[key] === "string" && raw[key].trim().length <= FEATURE_FLAG_STRING_MAX) {

--- a/dsh-mneme/src/summarize.js
+++ b/dsh-mneme/src/summarize.js
@@ -184,10 +184,54 @@ export function createSummarizer(ctx, service, config) {
   if (!config.autoSummarize) return { dispose: () => {} };
 
   const inFlight = new Map();
+  // Issue #127：per-session 上一次实际开跑时刻（最小间隔闸门用）。与 inFlight
+  // 同生命周期，dispose 时一并清空。
+  const lastRunAt = new Map();
   let disposed = false;
+
+  /** 写一条 autoSummarize 的 LLM 审计行（审计失败绝不阻塞蒸馏本身）。 */
+  function writeAudit(entry) {
+    if (config?.llmAudit?.enabled === false || typeof service.saveLlmAudit !== "function") return;
+    try {
+      service.saveLlmAudit({
+        trigger_source: "autoSummarize",
+        operation_type: "summarize_compress",
+        related_memory_ids: [],
+        ...entry
+      });
+    } catch (auditError) {
+      ctx.logger?.warn?.(`dsh-mneme: llm audit write failed: ${String(auditError)}`);
+    }
+  }
 
   async function summarize(session) {
     if (disposed || inFlight.has(session.id)) return;
+
+    const header = session.requestHeader?.()?.config;
+    // Config override takes priority, then session header, then nothing.
+    const route = (config.summarizeProvider && config.summarizeModel)
+      ? { provider: config.summarizeProvider, model: config.summarizeModel }
+      : (header?.provider && header?.model)
+        ? { provider: header.provider, model: header.model }
+        : undefined;
+
+    // Issue #127 间隔门：同一会话两次蒸馏之间的最小间隔（0 = 现状，不限）。进入
+    // 即打点——失败/degraded 的 run 也占用间隔，与 dreamMinIntervalMinutes 语义
+    // 一致，防止失败连发。被挡下的 turn/end 静默跳过，但留一行 status='skipped'
+    // 审计，否则「这一轮为什么没蒸馏」对用户完全不可观测。
+    const gapMs = (config.summarizeMinIntervalMinutes ?? 0) * 60000;
+    const prevClaim = lastRunAt.get(session.id);
+    if (gapMs > 0 && Date.now() - (prevClaim ?? 0) < gapMs) {
+      writeAudit({
+        timestamp: new Date().toISOString(),
+        model_id: route ? `${route.provider}:${route.model}` : "unknown",
+        status: "skipped",
+        error_message: "min-interval"
+      });
+      return;
+    }
+    lastRunAt.set(session.id, Date.now());
+
     const controller = new AbortController();
     inFlight.set(session.id, controller);
     // audit state for the compression call. null = no audit for this run
@@ -196,14 +240,8 @@ export function createSummarizer(ctx, service, config) {
     // so a failed/aborted stream still leaves a status='error' trail without
     // ever blocking the summarization itself.
     let audit = null;
+    let abortedRun = false;
     try {
-      const header = session.requestHeader?.()?.config;
-      // Config override takes priority, then session header, then nothing.
-      const route = (config.summarizeProvider && config.summarizeModel)
-        ? { provider: config.summarizeProvider, model: config.summarizeModel }
-        : (header?.provider && header?.model)
-          ? { provider: header.provider, model: header.model }
-          : undefined;
       if (!route) return;
       // 完整转录（Codex 式）：蒸馏把整轮对话交给 LLM 提炼原子记忆，不再硬裁
       // 8000 字截断语义；上限由 distillMaxChars 控制（默认 24000，可调大）。
@@ -301,8 +339,19 @@ export function createSummarizer(ctx, service, config) {
           }
         }
       }, intervalMs);
-      if (aborted) return;
-      const entries = parseSummaryJson(text || assembledText);
+      if (aborted) {
+        abortedRun = true;
+        return;
+      }
+      const parsed = parseSummaryJson(text || assembledText);
+      // Issue #127 条数上限：0 = 不限（现状）。被截断的条数与去重命中数一并进
+      // 审计 metadata——此前产出条数完全由模型输出决定，用户无从自查。
+      const cap = config.summarizeMaxEntriesPerRun ?? 0;
+      const entries = cap > 0 ? parsed.slice(0, cap) : parsed;
+      const capped = parsed.length - entries.length;
+      const dedupeMode = config.summarizeDedupeMode ?? "off";
+      let deduped = 0;
+      let dedupeMaxSim = 0;
       for (const entry of entries) {
         // Provenance: the summarizer runs on a real session (turn/end hook), so
         // session.id is always available here — it rides the human-readable
@@ -310,12 +359,45 @@ export function createSummarizer(ctx, service, config) {
         // 编码记忆类型（codingRetrospect）不带 tag：读取侧门控/加权靠 m.type
         // （rejected_solution/pitfall/constraint）区分即可，tag 体系
         // sanitizeTags 不认 `type:` 前缀反而会清空 tags 列（额外一次 UPDATE）。
+        const source = `session:${session.id}`;
+        // Issue #127 落库前去重（opt-in，默认 off = 现状）：命中则并入既有条目
+        // （saveWithDedupe 的 _mergeInto 分支），不再新造一行。作用域 = 同会话 +
+        // 时间窗；跨会话的同类事实仍交给 autoDream / sleep 的批量裁决。
+        const dup = (dedupeMode !== "off" && typeof service.findSessionDuplicate === "function")
+          ? await service.findSessionDuplicate(
+            { ...entry, source },
+            {
+              mode: dedupeMode,
+              minSim: config.summarizeDedupeMinSim ?? 0.92,
+              windowHours: config.summarizeDedupeWindowHours ?? 24,
+              source
+            }
+          )
+          : undefined;
+        if (dup) {
+          deduped++;
+          dedupeMaxSim = Math.max(dedupeMaxSim, dup.sim ?? 0);
+        }
         service.saveWithDedupe({
           ...entry,
-          source: `session:${session.id}`
+          source,
+          ...(dup ? { _mergeInto: dup.memory.id } : {})
         });
       }
+      if (audit && (capped > 0 || deduped > 0)) {
+        audit.metadata = {
+          parsed: parsed.length,
+          ...(capped > 0 ? { capped } : {}),
+          ...(deduped > 0 ? { deduped, mode: dedupeMode, maxSim: Number(dedupeMaxSim.toFixed(4)) } : {})
+        };
+      }
     } finally {
+      // Issue #127：aborted（会话关闭 / 插件 dispose）不占间隔，避免误伤该会话的
+      // 下一次蒸馏；其余情况（含失败）的打点保留，与 dreamMinIntervalMinutes 一致。
+      if (abortedRun || controller.signal.aborted) {
+        if (prevClaim === undefined) lastRunAt.delete(session.id);
+        else lastRunAt.set(session.id, prevClaim);
+      }
       if (audit) {
         try {
           service.saveLlmAudit({
@@ -330,7 +412,10 @@ export function createSummarizer(ctx, service, config) {
             duration_ms: Date.now() - audit.startedAt,
             status: audit.status,
             error_message: audit.errorMessage,
-            related_memory_ids: []
+            related_memory_ids: [],
+            // Issue #127：parsed / capped / deduped 的观测数据。零 schema 变更
+            // （llm_audit_logs.metadata 已存在），一条 SQL 即可验证节流是否生效。
+            metadata: audit.metadata
           });
         } catch (auditError) {
           ctx.logger?.warn?.(`dsh-mneme: llm audit write failed: ${String(auditError)}`);
@@ -358,6 +443,7 @@ export function createSummarizer(ctx, service, config) {
       unsubscribe?.();
       for (const controller of inFlight.values()) controller.abort();
       inFlight.clear();
+      lastRunAt.clear();
     }
   };
 }

--- a/dsh-mneme/test/api.test.js
+++ b/dsh-mneme/test/api.test.js
@@ -644,15 +644,15 @@ test("GET /api/dsh-mneme/features returns empty overrides and effective config d
   assert.equal(res.statusCode, 200);
   const data = JSON.parse(res.body);
   assert.deepEqual(data.overrides, {});
-  // effective 覆盖全部 42 个白名单键（含 v0.7.20 heatEnabled、Issue #89 新增
+  // effective 覆盖全部 47 个白名单键（含 v0.7.20 heatEnabled、Issue #89 新增
   // dreamSkipInvalid/allowCrossTypeMerge/dreamMinIntervalMinutes、面板可调的
   // dreamMaxTokens、睡眠路由 sleepProvider/sleepModel、PR1 新增的
-  // recallFusion/signalTransparency，以及 issue #109 新增的实体抽取路由
-  // entityExtractionProvider/entityExtractionModel/entityExtractionReasoning），
-  // 未覆盖时取 bundle 配置的解析默认值；
+  // recallFusion/signalTransparency、issue #109 新增的实体抽取路由
+  // entityExtractionProvider/entityExtractionModel/entityExtractionReasoning，
+  // 以及 issue #127 新增的 summarize 五键），未覆盖时取 bundle 配置的解析默认值；
   // dreamProvider/dreamModel 无 schema 默认值（Config({}) 解析为 undefined），
-  // 不编造给前端 → 42 - 2 = 40
-  assert.equal(Object.keys(data.effective).length, 40);
+  // 不编造给前端 → 47 - 2 = 45
+  assert.equal(Object.keys(data.effective).length, 45);
   assert.equal(data.effective.dreamSkipInvalid, true);
   assert.equal(data.effective.allowCrossTypeMerge, false);
   assert.equal(data.effective.dreamMinIntervalMinutes, 0);
@@ -682,6 +682,12 @@ test("GET /api/dsh-mneme/features returns empty overrides and effective config d
   assert.equal(data.effective.entityExtractionProvider, "");
   assert.equal(data.effective.entityExtractionModel, "");
   assert.equal(data.effective.entityExtractionReasoning, "none");
+  // issue #127：summarize 节流五键（均有默认值，故计入 effective 计数）
+  assert.equal(data.effective.summarizeMinIntervalMinutes, 0);
+  assert.equal(data.effective.summarizeMaxEntriesPerRun, 0);
+  assert.equal(data.effective.summarizeDedupeMode, "off");
+  assert.equal(data.effective.summarizeDedupeMinSim, 0.92);
+  assert.equal(data.effective.summarizeDedupeWindowHours, 24);
 });
 
 test("PUT /api/dsh-mneme/features round-trips, overrides effective and persists", async () => {

--- a/dsh-mneme/test/summarize.test.js
+++ b/dsh-mneme/test/summarize.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { createStore } from "../src/store.js";
 import { createService } from "../src/service.js";
 import { createSummarizer, parseSummaryJson } from "../src/summarize.js";
+import { createSettings } from "../src/settings.js";
 
 function setup(over = {}, opts = {}) {
   const store = createStore(":memory:");
@@ -348,4 +349,156 @@ test("codingRetrospect stores coding memory types in the coding memory type set"
   assert.deepEqual(m.tags, []);
   // 编码模式用编码 prompt（含 rejected_solution 类型说明）。
   assert.ok(calls[0].messages[0].content[0].text.includes("rejected_solution"));
+});
+
+// ── Issue #127：节流 / 条数上限 / 同会话去重 ────────────────────────────────
+
+/** A distill stream that always returns exactly these entries. */
+function streamOf(entries) {
+  return () => (async function* () {
+    yield { type: "block-start", block: { type: "text" } };
+    yield { type: "text-delta", delta: JSON.stringify(entries) };
+    yield { type: "finish", kind: "ok" };
+  })();
+}
+
+function sessionFor(id) {
+  return {
+    id,
+    requestHeader: () => ({ config: { provider: "deepseek", model: "deepseek-chat" } }),
+    events: [userMessage("继续"), { seq: 2, type: "turn/end" }]
+  };
+}
+
+test("issue#127: min-interval gate suppresses the second turn/end and audits it as skipped", async () => {
+  const { events, store, calls } = setup({ summarizeMinIntervalMinutes: 30 });
+  const handler = events.find((e) => e.name === "session/event").fn;
+  const session = sessionFor("t1");
+  await handler(session, { seq: 2, type: "turn/end" });
+  assert.equal(calls.length, 1, "the first turn/end distills");
+  assert.equal(store.count(), 2);
+  await handler(session, { seq: 3, type: "turn/end" });
+  assert.equal(calls.length, 1, "the second turn/end inside the window makes no LLM call");
+  assert.equal(store.count(), 2, "nothing new is stored");
+  // 可观测性：被节流不再静默——留一行 status='skipped'，一条 SQL 可自查。
+  const audits = store.listLlmAudits({ source: "autoSummarize" });
+  assert.ok(
+    audits.some((a) => a.status === "skipped" && a.error_message === "min-interval"),
+    "the suppression is visible as a status='skipped' audit row"
+  );
+});
+
+test("issue#127: min-interval 0 keeps the historical every-turn behavior", async () => {
+  const { events, calls } = setup({ summarizeMinIntervalMinutes: 0 });
+  const handler = events.find((e) => e.name === "session/event").fn;
+  const session = sessionFor("t2");
+  await handler(session, { seq: 2, type: "turn/end" });
+  await handler(session, { seq: 3, type: "turn/end" });
+  assert.equal(calls.length, 2, "0 = no gate (zero behavior change)");
+});
+
+test("issue#127: the interval gate is per-session (one session never throttles another)", async () => {
+  const { events, calls } = setup({ summarizeMinIntervalMinutes: 30 });
+  const handler = events.find((e) => e.name === "session/event").fn;
+  await handler(sessionFor("ta"), { seq: 2, type: "turn/end" });
+  await handler(sessionFor("tb"), { seq: 2, type: "turn/end" });
+  assert.equal(calls.length, 2, "a different session is not throttled by another's lastRunAt");
+});
+
+test("issue#127: summarizeMaxEntriesPerRun caps the stored entries and audits parsed/capped", async () => {
+  const { events, store } = setup({ summarizeMaxEntriesPerRun: 1 }, {
+    stream: streamOf([
+      { type: "decision", title: "选型", content: "确定用 node:sqlite", importance: 4 },
+      { type: "preference", title: "语言", content: "用户喜欢中文交流", importance: 5 }
+    ])
+  });
+  const handler = events.find((e) => e.name === "session/event").fn;
+  await handler(sessionFor("t3"), { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 1, "only the first capped entry is stored");
+  const audit = store.listLlmAudits({ source: "autoSummarize" })[0];
+  assert.equal(audit.metadata?.parsed, 2, "the raw parsed count is kept for tuning the cap");
+  assert.equal(audit.metadata?.capped, 1);
+});
+
+test("issue#127: title dedupe absorbs a normalized-same title", async () => {
+  const { events, store, service } = setup({ summarizeDedupeMode: "title" }, {
+    stream: streamOf([{ type: "pitfall", title: "Win7  OpenSSH  失效", content: "第二次记录", importance: 4 }])
+  });
+  // 既有条目：同会话、标题归一化后全等（大小写与空白差异）
+  const seeded = service.saveWithDedupe({
+    type: "pitfall", title: "win7 openssh 失效", content: "第一次记录", source: "session:t5"
+  }).memory;
+  const handler = events.find((e) => e.name === "session/event").fn;
+  await handler(sessionFor("t5"), { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 1, "the normalized-same title merged instead of creating a row");
+  assert.ok(store.getById(seeded.id).content.includes("第二次记录"), "content appended to the existing row");
+});
+
+test("issue#127: title dedupe leaves a rephrase alone (it only catches an exact same title)", async () => {
+  // 同一事实的另一种措辞 → title 档不命中，正常新建。这条界定了 title 档的边界，
+  // 避免被误当成 vector 档的替代（cos≥0.85 的簇里「归一化标题全同」为 0 个）。
+  const { events, store, service } = setup({ summarizeDedupeMode: "title" }, {
+    stream: streamOf([{ type: "pitfall", title: "Win7 下 OpenSSH 官方脚本装不上", content: "新记录", importance: 4 }])
+  });
+  service.saveWithDedupe({
+    type: "pitfall", title: "OpenSSH 官方脚本在 Win7 失效", content: "旧记录", source: "session:other"
+  });
+  const handler = events.find((e) => e.name === "session/event").fn;
+  await handler(sessionFor("t7"), { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 2, "a rephrase (different title) is not merged by the title tier");
+});
+
+test("issue#127: vector dedupe merges a same-fact rephrase and keeps content_history", async () => {
+  const embedder = {
+    ready: true,
+    embedSingle: async (text) => (String(text).includes("OpenSSH") ? [1, 0, 0] : [0, 1, 0])
+  };
+  const { events, store, service } = setup(
+    { summarizeDedupeMode: "vector", summarizeDedupeMinSim: 0.92 },
+    { stream: streamOf([{ type: "pitfall", title: "Win7 下 OpenSSH 官方脚本装不上", content: "重复踩坑", importance: 4 }]) }
+  );
+  service.setEmbedder(embedder);
+  // 同一事实的另一种措辞，已有向量 → 余弦 1.0 ≥ 0.92
+  const seeded = service.saveWithDedupe({
+    type: "pitfall", title: "OpenSSH 官方脚本在 Win7 失效", content: "第一次记录", source: "session:t8"
+  }).memory;
+  store.setEmbedding(seeded.id, [1, 0, 0]);
+  const handler = events.find((e) => e.name === "session/event").fn;
+  await handler(sessionFor("t8"), { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 1, "no new row: the rephrase was absorbed by cosine");
+  const merged = store.getById(seeded.id);
+  assert.ok(merged.content.includes("重复踩坑"), "content appended into the existing row");
+  assert.ok((merged.content_history ?? []).length >= 1, "content_history keeps the prior version");
+  const audit = store.listLlmAudits({ source: "autoSummarize" })[0];
+  assert.equal(audit.metadata?.deduped, 1);
+  assert.equal(audit.metadata?.mode, "vector");
+});
+
+test("issue#127: no embedder means vector dedupe silently falls back to a normal write", async () => {
+  const { events, store } = setup(
+    { summarizeDedupeMode: "vector" },
+    { stream: streamOf([{ type: "pitfall", title: "无关的一条", content: "内容", importance: 4 }]) }
+  );
+  const handler = events.find((e) => e.name === "session/event").fn;
+  await handler(sessionFor("t9"), { seq: 2, type: "turn/end" });
+  assert.equal(store.count(), 1, "dedupe failure never blocks the write");
+});
+
+test("issue#127: the five summarize knobs are whitelisted and range-checked", () => {
+  const store = createStore(":memory:");
+  const settings = createSettings(store.db);
+  const merged = settings.setFeatureFlags({
+    summarizeMinIntervalMinutes: 30,
+    summarizeMaxEntriesPerRun: 5,
+    summarizeDedupeMode: "vector",
+    summarizeDedupeMinSim: 0.9,
+    summarizeDedupeWindowHours: 12
+  });
+  assert.equal(merged.summarizeMinIntervalMinutes, 30);
+  assert.equal(merged.summarizeDedupeMode, "vector");
+  assert.equal(merged.summarizeDedupeMinSim, 0.9, "float thresholds round-trip (new numbers whitelist)");
+  // 面板/API 写入走同一套逐键校验：越界与非法枚举必须被拒。
+  assert.throws(() => settings.setFeatureFlags({ summarizeDedupeMinSim: 0.3 }), /number in \[0.5, 0.99\]/);
+  assert.throws(() => settings.setFeatureFlags({ summarizeDedupeMode: "semantic" }), /one of: off, title, vector/);
+  store.close();
 });


### PR DESCRIPTION
## 背景

`autoSummarize` 此前每个 `turn/end` 必跑、产出条数由模型输出决定、写入端只按「同类型 + 标题 `trim()` 全等」去重。本机 0.7.31 实测：单日 84 次、单会话一天落 198 条、同一事实 6 小时内被铸出 28+ 条。

按下述设计新增五个参数，**默认值全部等价于现状**，升级本身不改变任何用户行为；回滚 = 把键清空。

| 键 | 默认 | 语义 |
|---|---|---|
| `summarizeMinIntervalMinutes` | `0` | 同会话两次蒸馏的最小间隔；失败/degraded 也占间隔（与 `dreamMinIntervalMinutes` 一致），aborted 回滚打点 |
| `summarizeMaxEntriesPerRun` | `0` | 单次落库条数上限 |
| `summarizeDedupeMode` | `off` | `off` / `title` / `vector` |
| `summarizeDedupeMinSim` | `0.92` | `vector` 档的并入阈值 |
| `summarizeDedupeWindowHours` | `24` | 去重回看窗口（只看该会话最近 N 小时落库的记忆） |

## 改动

| 文件 | 改动 |
|---|---|
| `src/config.js` | 五个参数（schemastery，含默认值与 range） |
| `src/settings.js` | 四键进整数/枚举白名单；`summarizeDedupeMinSim` 进**新增的浮点白名单** `FEATURE_FLAG_NUMBER_RANGES`——整数控件的 `Number.isInteger` 校验容不下余弦阈值 |
| `src/api.js` | `features` 端点的 effective 快照纳入 `numbers` 分区 |
| `src/summarize.js` | per-session 间隔闸门（进入即打点）、条数上限、落库前分层去重、审计埋点 |
| `src/service.js` | `findSessionDuplicate`（title 档走零成本标题归一化；vector 档复用已有 `embedding` 列做同会话近邻，新条目向量由 embedder 现算，**无 LLM 调用**）；`saveWithDedupe` 新增 `_mergeInto` 并入目标，复用同一段 `appendContent` + `content_history` 逻辑，不另写第二份实现 |
| `test/summarize.test.js` | 新增 9 条用例 |
| `test/api.test.js` | `features` 断言同步到 47 个白名单键 / 45 个 effective 键 |

作用域：去重限定「同会话 + 时间窗」。跨会话的同类事实仍交给 autoDream / sleep 的批量裁决；全局写入端语义去重是另一个更大的话题（将来复用同一段比对逻辑改 scope 即可）。

降级：vector 档在 embedder 不可用或向量缺失时一律回落正常写入——去重是增强，不是写入依赖。

## 可观测性（零 schema 变更）

`llm_audit_logs.metadata` 列已存在：

- 被间隔门挡下 → `status='skipped'` + `error_message='min-interval'`；
- 被条数上限截断 / 被去重并入 → `metadata` 记 `{parsed, capped, deduped, mode, maxSim}`。

一条 SQL 即可验证节流是否生效（此前完全不可观测，也是这条 issue 难以被用户自查的原因）。

## 验证

`npm test`：848 个用例，847 通过。唯一失败是 `test/peer-blockers.test.js` 的 peer-C（8 进程并发原子递增），在本机沙箱下 `spawn EPERM`，与本改动无关。

`lib/` 由 `npm run sync` 同步（`api.js` / `config.js` / `service.js` / `settings.js` / `summarize.js` 五个文件内容变化）。

顺带：这给 #47「如何做到临时关闭记忆模式」在全局 `autoSummarize:false` 之外补了一个中间档（例如 `summarizeMinIntervalMinutes=1440` = 一天最多蒸馏一次）。
