### PR TITLE
chore: 恢复 CodeRabbit 自动审阅兜底

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,15 +1,13 @@
-# CodeRabbit 审阅配置：额度优先。
-# 个人 Free 档限额很小（1 次/小时），默认的「每个 PR 自动审、每次 push 重审」
-# 会把额度烧光。这里关掉自动审，需要 AI 审阅时在 PR 里评论 `@coderabbitai review`
-# 按需触发——外部大 PR 才值得花额度；维护者自己的小改动走本地审阅 +
-# Copilot code review（教育版额度）覆盖。
+# CodeRabbit 审阅配置：自动审兜底。
+# Copilot 教育版额度不足，恢复 CodeRabbit 自动审阅兜底。
+# Free 档限额仍小，保持 chill 档 + 锁文件/素材排除，控制额度消耗。
 language: zh-CN
 
 reviews:
   profile: chill
   auto_review:
-    enabled: false
-  # 锁文件与素材目录没有审阅价值，显式排除（预防将来开自动审时浪费额度）。
+    enabled: true
+  # 锁文件与素材目录没有审阅价值，显式排除。
   path_filters:
     - "!**/package-lock.json"
     - "!images/**"


### PR DESCRIPTION
Copilot 教育版额度不足，恢复 CodeRabbit 自动审阅兜底。

- `auto_review.enabled: true`（原为按需 `@coderabbitai review` 触发）
- 保持 `profile: chill` + 锁文件/素材 path_filters 排除，控制 Free 档额度消耗
- `chat.auto_reply: false` 不变

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 恢复自动代码审查，提交变更后可自动获得审查反馈。
  - 继续保留审查范围控制，以减少不必要的资源消耗。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->