### PR TITLE
feat(scope): 检索加权与 occurred_at 时间过滤（A2，issue #17）

### DIFF
--- a/dsh-mneme/lib/service.js
+++ b/dsh-mneme/lib/service.js
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { TYPE_FILE } from "./mirror.js";
+import { updatedAtBounds } from "./store.js";
 import { STR, langOf } from "./lang.js";
 import { computeHeat } from "./heat.js";
 import { evaluateMemoryQuality } from "./quality-filter.js";
@@ -43,6 +44,41 @@ const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_co
 // 口径一致——两把钥匙只有都过这里再比较，NULL 与 'global' 才不会错配。
 function scopeKeyOf(v) {
   return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+// v0.8.0 A2（issue #17）scope 检索加权系数：当前会话 scope 两维都命中 → 加成；
+// 任一维度带着他 scope → 降权但保留可见（硬过滤是 A3 strictScope）。未标注行
+// （NULL）与无法比较的维度恒中性——全局/存量记忆不因加权掉位。系数是模块常量
+// 而非配置项：A2 只定性行为，数值要等线上检索质量反馈再调（加配置面=提前优化）。
+const SCOPE_MATCH_BOOST = 1.25;
+const SCOPE_FOREIGN_PENALTY = 0.5;
+
+/**
+ * 单条候选的 scope 乘数。匹配语义与去重键一致（scopeKeyOf）：记忆侧未标注视同
+ * 该维度命中（全局记忆对谁都可见）；当前会话侧某维度解析不到则该维度不参与
+ * 比较（无法比较 ≠ 不匹配）。
+ */
+function scopeMultiplier(m, current) {
+  const agentForeign = scopeKeyOf(m.agent_scope) !== null
+    && current.agent_scope !== null
+    && scopeKeyOf(m.agent_scope) !== current.agent_scope;
+  const workspaceForeign = scopeKeyOf(m.workspace_scope) !== null
+    && current.workspace_scope !== null
+    && scopeKeyOf(m.workspace_scope) !== current.workspace_scope;
+  return (agentForeign || workspaceForeign) ? SCOPE_FOREIGN_PENALTY : SCOPE_MATCH_BOOST;
+}
+
+/**
+ * v0.8.0 A2：occurred_at 后置过滤谓词（搜索融合池用）。行侧取
+ * COALESCE(occurred_at, created_at)——与 store.list 的 SQL 过滤同口径，未标注
+ * 行回退创建时间；时间戳损坏的行保留（宁可放宽也不误杀，同 summarize inWindow）。
+ */
+function inOccurredBounds(m, bounds) {
+  const t = Date.parse(String(m.occurred_at ?? m.created_at ?? ""));
+  if (!Number.isFinite(t)) return true;
+  if (bounds.from && t < Date.parse(bounds.from)) return false;
+  if (bounds.to && t > Date.parse(bounds.to)) return false;
+  return true;
 }
 
 /** Prepend the previous content to a memory's content_history (FIFO capped). */
@@ -596,7 +632,19 @@ export function createService({ store, mirror, config, onWrite, logger }) {
    * a vector/rerank failure degrades to keyword results.
    */
   async function searchMemories(query, options = {}) {
-    const { mode = "auto", topK = 20, threshold, useRerank = true, recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true) } = options;
+    const {
+      mode = "auto",
+      topK = 20,
+      threshold,
+      useRerank = true,
+      // v0.8.0 A2（issue #17）：当前会话 scope（工具层从 exec 解析后传入）与
+      // occurred_at 时间窗。两者都只在显式传入时生效，既有调用方（注入/梦/评测）
+      // 不传 → 行为与 A2 前一致。
+      scope = null,
+      occurredFrom = null,
+      occurredTo = null,
+      recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true)
+    } = options;
     const q = String(query ?? "").trim();
     if (!q) return [];
 
@@ -663,6 +711,12 @@ export function createService({ store, mirror, config, onWrite, logger }) {
 
     const { merged: fusedMerged, signals } = fuseRecall({ keyword, vector, bm25, lim, mode, wv, wk, wb });
     let merged = fusedMerged;
+    // v0.8.0 A2：occurred_at 时间过滤——在融合池上先滤再 dedup/slice，rerank
+    // 只看窗内候选，topK 槽位不被窗外行占用。
+    const occurredBounds = updatedAtBounds(occurredFrom, occurredTo);
+    if (occurredBounds.from || occurredBounds.to) {
+      merged = merged.filter((m) => inOccurredBounds(m, occurredBounds));
+    }
     // Signal transparency (#2): decorate each returned row with its per-source
     // scores and the final fused score. Purely additive — never changes rank.
     if (config?.signalTransparency === true) {
@@ -688,6 +742,17 @@ export function createService({ store, mirror, config, onWrite, logger }) {
           ...m,
           score: (m.score ?? 0) * (EPISTEMIC_WEIGHTS[m.epistemic_status] ?? 1)
         }))
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, lim);
+    }
+
+    // v0.8.0 A2（issue #17）：scope 检索加权——当前会话 scope 两维命中的候选
+    // 加成、带他 scope 的候选降权但保留可见（硬过滤是 A3 strictScope）。未标注
+    // 行与无法比较的维度恒中性；flag 关或调用方未传 scope 时不动分，排序与
+    // A2 前逐字节一致。与 epistemic 加权同款收尾：乘分 → 降序 → 截 topK。
+    if (config.scopeEnabled === true && scope && (scope.agent_scope || scope.workspace_scope)) {
+      result = result
+        .map((m) => ({ ...m, score: (m.score ?? 0) * scopeMultiplier(m, scope) }))
         .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
         .slice(0, lim);
     }
@@ -1252,7 +1317,14 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       importance: m.importance,
       source: m.source,
       created_at: m.created_at,
-      updated_at: m.updated_at
+      updated_at: m.updated_at,
+      // v0.8.0 A2：scope 标注与事件发生时间透出——条件展开（未标注行不带键，
+      // DTO 与 A2 前逐字节同形；带 undefined 键会被 in-process schema 校验
+      // 判违规，JSON 序列化虽会丢弃但形状不稳定）。
+      ...(m.agent_scope !== undefined ? { agent_scope: m.agent_scope } : {}),
+      ...(m.workspace_scope !== undefined ? { workspace_scope: m.workspace_scope } : {}),
+      ...(m.sensitivity !== undefined ? { sensitivity: m.sensitivity } : {}),
+      ...(m.occurred_at !== undefined ? { occurred_at: m.occurred_at } : {})
     }));
   }
 

--- a/dsh-mneme/lib/store.js
+++ b/dsh-mneme/lib/store.js
@@ -310,7 +310,9 @@ function escapeLike(q) {
 // 法值一律返回 undefined → 不进 WHERE（忽略而非报错：面板传坏参数时宁可放宽
 // 过滤也不要白屏）。updated_at 列是 toISOString 产生的 UTC "Z" 字符串，字典
 // 序与时间序一致，SQL 里可直接比较。
-function updatedAtBounds(updatedFrom, updatedTo) {
+// v0.8.0 A2：导出复用——occurred_at 时间过滤（service 的搜索后置过滤）与
+// updated_at 过滤共用同一套边界归一化，坏参数口径一致。
+export function updatedAtBounds(updatedFrom, updatedTo) {
   const norm = (raw, endOfDay) => {
     if (typeof raw !== "string" || !raw.trim()) return undefined;
     const s = raw.trim();
@@ -675,7 +677,7 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, updatedFrom = null, updatedTo = null } = {}) {
+  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, updatedFrom = null, updatedTo = null, occurredFrom = null, occurredTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
@@ -701,6 +703,17 @@ export function createStore(path) {
     if (bounds.to) {
       clauses.push("updated_at <= ?");
       params.push(bounds.to);
+    }
+    // occurred_at 闭区间：与 list() 同口径（COALESCE 回退 created_at），
+    // memory_list 的 total 才能和过滤后的行保持一致。
+    const occurred = updatedAtBounds(occurredFrom, occurredTo);
+    if (occurred.from) {
+      clauses.push("COALESCE(occurred_at, created_at) >= ?");
+      params.push(occurred.from);
+    }
+    if (occurred.to) {
+      clauses.push("COALESCE(occurred_at, created_at) <= ?");
+      params.push(occurred.to);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
@@ -972,7 +985,7 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, minImportance = null, source = null, updatedFrom = null, updatedTo = null } = {}) {
+  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, minImportance = null, source = null, updatedFrom = null, updatedTo = null, occurredFrom = null, occurredTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
@@ -999,6 +1012,18 @@ export function createStore(path) {
     if (bounds.to) {
       clauses.push("updated_at <= ?");
       params.push(bounds.to);
+    }
+    // v0.8.0 A2（issue #17）：occurred_at 闭区间过滤——按「事件发生时间」检索。
+    // 未标注 occurred_at 的行（含全部存量）回退 created_at 比较（COALESCE），
+    // 否则过滤器对旧库近乎不可用；边界归一化与 updated_at 共用 updatedAtBounds。
+    const occurred = updatedAtBounds(occurredFrom, occurredTo);
+    if (occurred.from) {
+      clauses.push("COALESCE(occurred_at, created_at) >= ?");
+      params.push(occurred.from);
+    }
+    if (occurred.to) {
+      clauses.push("COALESCE(occurred_at, created_at) <= ?");
+      params.push(occurred.to);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");

--- a/dsh-mneme/lib/tools.js
+++ b/dsh-mneme/lib/tools.js
@@ -26,9 +26,34 @@ const MEMORY_ITEM_SCHEMA = {
     tags: { type: "array", items: { type: "string" } },
     importance: { type: "integer", required: true },
     source: { type: "string" },
+    // v0.8.0 A2：scope 标注与事件发生时间随行透出（未标注时缺省，可选属性）。
+    agent_scope: { type: "string" },
+    workspace_scope: { type: "string" },
+    sensitivity: { type: "string" },
+    occurred_at: { type: "string" },
     created_at: { type: "string", required: true },
     updated_at: { type: "string", required: true }
   }
+};
+
+// v0.8.0 A2：occurred 时间窗参数 → store 过滤选项（list/count 同口径）；
+// 未传参返回空对象，既有调用方不受影响。
+function occurredWindow(args) {
+  const from = args?.occurred_from ?? null;
+  const to = args?.occurred_to ?? null;
+  return from !== null || to !== null ? { occurredFrom: from, occurredTo: to } : {};
+}
+
+// v0.8.0 A2：检索结果的 provenance 附加段——只在有标注时出现，未标注行渲染
+// 与 A2 前逐字节一致。
+const MEMORY_PROVENANCE = (m) => {
+  const parts = [];
+  if (m.occurred_at) parts.push(`occurred: ${m.occurred_at}`);
+  if (m.agent_scope || m.workspace_scope) {
+    parts.push(`scope: ${m.agent_scope ?? "global"} / ${m.workspace_scope ?? "global"}`);
+  }
+  if (m.sensitivity) parts.push(`sensitivity: ${m.sensitivity}`);
+  return parts.length ? ` | ${parts.join(" | ")}` : "";
 };
 
 export function createTools(ctx, service, config, embedder) {
@@ -38,9 +63,9 @@ export function createTools(ctx, service, config, embedder) {
     registeredTools = new Set();
     REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
   }
-  // v0.8.0 A1（issue #17）：写入端 scope 解析（agentPreset + workspace 反查）。
-  // flag 关闭时 resolveWriteScope 恒返回 null，写入路径与 A1 前完全一致。
-  const resolveWriteScope = createScopeResolver({ ctx, config });
+  // v0.8.0 A1/A2（issue #17）：会话 scope 解析（agentPreset + workspace 反查）。
+  // flag 关闭时恒返回 null——写入不标注，检索不加权，行为与 A1 前完全一致。
+  const resolveSessionScope = createScopeResolver({ ctx, config });
   const tools = [
     defineTool({
       name: "memory_save",
@@ -73,7 +98,7 @@ export function createTools(ctx, service, config, embedder) {
         // scope 标注：agent_scope/workspace_scope 由会话身份解析（不作为模型
         // 参数），sensitivity/occurred_at 来自显式参数。解析绝不抛错、取不到
         // 落 NULL；flag 关闭时 scope 为 null，一个字段都不标注。
-        const scope = resolveWriteScope(exec);
+        const scope = resolveSessionScope(exec);
         const { action, memory } = service.saveWithDedupe({
           type: args.type,
           title: args.title,
@@ -92,12 +117,15 @@ export function createTools(ctx, service, config, embedder) {
     defineTool({
       name: "memory_search",
       description: "Search the cross-session memory store. Use when you need past context: how a problem was solved, user preferences, project decisions. Substring-matches title/content/tags, and augments results with semantic (vector) recall + optional rerank when an embeddings provider is configured. Returns matching entries with source and timestamps.",
+      // A2 检索接线：occurred 时间窗 + 会话 scope 加成（见 execute）。
       parameters: {
         query: { type: "string", required: true, description: "Search text; substring match over title/content/tags" },
         limit: { type: "integer", description: "Max results (default 20)" },
         mode: { type: "string", enum: ["auto", "keyword", "vector", "hybrid"], description: "auto (default) = keyword hits first + vector fill when enabled; keyword = text only; vector = semantic recall first (falls back to keyword); hybrid = vector leads, keyword fills remaining slots" },
         semantic: { type: "boolean", description: "Shorthand: enable semantic (vector) recall (same as mode=vector when true)" },
-        rerank: { type: "boolean", description: "Run cross-encoder rerank over candidates when a local reranker is configured (default true)" }
+        rerank: { type: "boolean", description: "Run cross-encoder rerank over candidates when a local reranker is configured (default true)" },
+        occurred_from: { type: "string", description: "Optional ISO date/timestamp lower bound on when the remembered event happened (occurred_at, falling back to created_at). Date-only values are inclusive from that day's 00:00Z." },
+        occurred_to: { type: "string", description: "Optional ISO date/timestamp upper bound on occurred_at. Date-only values are inclusive through that day's 23:59:59.999Z." }
       },
       output: {
         schema: {
@@ -117,19 +145,26 @@ export function createTools(ctx, service, config, embedder) {
             .map((m, i) => {
               const preview = (m.content ?? "").replace(/\s+/g, " ").trim();
               const cut = preview.length > 200 ? `${preview.slice(0, 200)}…` : preview;
-              return `[${i + 1}] ${m.title}\n    ID: ${m.id} | type: ${m.type} | importance: ${m.importance} | updated: ${m.updated_at}\n    ${cut}`;
+              return `[${i + 1}] ${m.title}\n    ID: ${m.id} | type: ${m.type} | importance: ${m.importance} | updated: ${m.updated_at}${MEMORY_PROVENANCE(m)}\n    ${cut}`;
             })
             .join("\n\n");
           return TEXT_OUTPUT(`Found ${items.length} memory entr${items.length === 1 ? "y" : "ies"}:\n\n${body}`);
         }
       },
-      async execute(args) {
+      async execute(args, exec) {
         const limit = args.limit ?? 20;
         const mode = args.semantic === true && !args.mode ? "vector" : args.mode ?? "auto";
+        // v0.8.0 A2（issue #17）：scope 检索加权 + occurred 时间窗的检索接线。
+        // flag 关闭或解析不出 scope 时为 null，检索行为与 A2 前一致。
+        const scope = resolveSessionScope(exec);
+        const occurredFrom = args.occurred_from ?? null;
+        const occurredTo = args.occurred_to ?? null;
         const rows = await service.searchMemories(args.query, {
           mode,
           topK: limit,
-          useRerank: args.rerank !== false
+          useRerank: args.rerank !== false,
+          ...(scope ? { scope } : {}),
+          ...(occurredFrom !== null || occurredTo !== null ? { occurredFrom, occurredTo } : {})
         });
         return { items: service.toApiList(rows) };
       }
@@ -142,7 +177,9 @@ export function createTools(ctx, service, config, embedder) {
         type: { type: "string", enum: ["preference", "project", "decision", "history", "rejected_solution", "pitfall", "constraint"], description: "Filter by type; omit for all" },
         limit: { type: "integer", description: "Page size (default 50)" },
         offset: { type: "integer", description: "Page offset (default 0)" },
-        include_archived: { type: "boolean", description: "Include archived (hidden) entries so they can be found and restored (default false)" }
+        include_archived: { type: "boolean", description: "Include archived (hidden) entries so they can be found and restored (default false)" },
+        occurred_from: { type: "string", description: "Optional ISO date/timestamp lower bound on when the remembered event happened (occurred_at, falling back to created_at). Date-only values are inclusive from that day's 00:00Z." },
+        occurred_to: { type: "string", description: "Optional ISO date/timestamp upper bound on occurred_at. Date-only values are inclusive through that day's 23:59:59.999Z." }
       },
       output: {
         schema: {
@@ -160,7 +197,7 @@ export function createTools(ctx, service, config, embedder) {
           const items = value.items ?? [];
           if (items.length === 0) return TEXT_OUTPUT(`0 memory entries (of ${value.total}).`);
           const body = items
-            .map((m, i) => `[${i + 1}] ${m.title} (type=${m.type}, importance=${m.importance})\n    ID: ${m.id} | updated: ${m.updated_at}`)
+            .map((m, i) => `[${i + 1}] ${m.title} (type=${m.type}, importance=${m.importance})\n    ID: ${m.id} | updated: ${m.updated_at}${MEMORY_PROVENANCE(m)}`)
             .join("\n\n");
           return TEXT_OUTPUT(`${items.length} memory entries (of ${value.total}):\n\n${body}`);
         }
@@ -171,9 +208,10 @@ export function createTools(ctx, service, config, embedder) {
           type: args.type,
           limit: args.limit ?? 50,
           offset: args.offset ?? 0,
-          includeArchived
+          includeArchived,
+          ...occurredWindow(args)
         }));
-        return { items: rows, total: service.count(args.type, { includeArchived }) };
+        return { items: rows, total: service.count(args.type, { includeArchived, ...occurredWindow(args) }) };
       }
     }),
 
@@ -199,6 +237,10 @@ export function createTools(ctx, service, config, embedder) {
                 tags: { type: "array", items: { type: "string" } },
                 content: { type: "string", required: true },
                 source: { type: "string" },
+                agent_scope: { type: "string" },
+                workspace_scope: { type: "string" },
+                sensitivity: { type: "string" },
+                occurred_at: { type: "string" },
                 created_at: { type: "string" },
                 updated_at: { type: "string" }
               }
@@ -207,7 +249,7 @@ export function createTools(ctx, service, config, embedder) {
         },
         render: (_args, value) => {
           const m = value.memory;
-          return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}\n\n${m.content}`);
+          return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}${MEMORY_PROVENANCE(m)}\n\n${m.content}`);
         }
       },
       async execute(args) {

--- a/dsh-mneme/src/service.js
+++ b/dsh-mneme/src/service.js
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { TYPE_FILE } from "./mirror.js";
+import { updatedAtBounds } from "./store.js";
 import { STR, langOf } from "./lang.js";
 import { computeHeat } from "./heat.js";
 import { evaluateMemoryQuality } from "./quality-filter.js";
@@ -43,6 +44,41 @@ const SIGNAL_TAGS = ["low_quality", "duplicate", "meta", "repetitive", "short_co
 // 口径一致——两把钥匙只有都过这里再比较，NULL 与 'global' 才不会错配。
 function scopeKeyOf(v) {
   return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+// v0.8.0 A2（issue #17）scope 检索加权系数：当前会话 scope 两维都命中 → 加成；
+// 任一维度带着他 scope → 降权但保留可见（硬过滤是 A3 strictScope）。未标注行
+// （NULL）与无法比较的维度恒中性——全局/存量记忆不因加权掉位。系数是模块常量
+// 而非配置项：A2 只定性行为，数值要等线上检索质量反馈再调（加配置面=提前优化）。
+const SCOPE_MATCH_BOOST = 1.25;
+const SCOPE_FOREIGN_PENALTY = 0.5;
+
+/**
+ * 单条候选的 scope 乘数。匹配语义与去重键一致（scopeKeyOf）：记忆侧未标注视同
+ * 该维度命中（全局记忆对谁都可见）；当前会话侧某维度解析不到则该维度不参与
+ * 比较（无法比较 ≠ 不匹配）。
+ */
+function scopeMultiplier(m, current) {
+  const agentForeign = scopeKeyOf(m.agent_scope) !== null
+    && current.agent_scope !== null
+    && scopeKeyOf(m.agent_scope) !== current.agent_scope;
+  const workspaceForeign = scopeKeyOf(m.workspace_scope) !== null
+    && current.workspace_scope !== null
+    && scopeKeyOf(m.workspace_scope) !== current.workspace_scope;
+  return (agentForeign || workspaceForeign) ? SCOPE_FOREIGN_PENALTY : SCOPE_MATCH_BOOST;
+}
+
+/**
+ * v0.8.0 A2：occurred_at 后置过滤谓词（搜索融合池用）。行侧取
+ * COALESCE(occurred_at, created_at)——与 store.list 的 SQL 过滤同口径，未标注
+ * 行回退创建时间；时间戳损坏的行保留（宁可放宽也不误杀，同 summarize inWindow）。
+ */
+function inOccurredBounds(m, bounds) {
+  const t = Date.parse(String(m.occurred_at ?? m.created_at ?? ""));
+  if (!Number.isFinite(t)) return true;
+  if (bounds.from && t < Date.parse(bounds.from)) return false;
+  if (bounds.to && t > Date.parse(bounds.to)) return false;
+  return true;
 }
 
 /** Prepend the previous content to a memory's content_history (FIFO capped). */
@@ -596,7 +632,19 @@ export function createService({ store, mirror, config, onWrite, logger }) {
    * a vector/rerank failure degrades to keyword results.
    */
   async function searchMemories(query, options = {}) {
-    const { mode = "auto", topK = 20, threshold, useRerank = true, recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true) } = options;
+    const {
+      mode = "auto",
+      topK = 20,
+      threshold,
+      useRerank = true,
+      // v0.8.0 A2（issue #17）：当前会话 scope（工具层从 exec 解析后传入）与
+      // occurred_at 时间窗。两者都只在显式传入时生效，既有调用方（注入/梦/评测）
+      // 不传 → 行为与 A2 前一致。
+      scope = null,
+      occurredFrom = null,
+      occurredTo = null,
+      recordRecall = options.recordRecall ?? (config?.recallRecordDefault ?? true)
+    } = options;
     const q = String(query ?? "").trim();
     if (!q) return [];
 
@@ -663,6 +711,12 @@ export function createService({ store, mirror, config, onWrite, logger }) {
 
     const { merged: fusedMerged, signals } = fuseRecall({ keyword, vector, bm25, lim, mode, wv, wk, wb });
     let merged = fusedMerged;
+    // v0.8.0 A2：occurred_at 时间过滤——在融合池上先滤再 dedup/slice，rerank
+    // 只看窗内候选，topK 槽位不被窗外行占用。
+    const occurredBounds = updatedAtBounds(occurredFrom, occurredTo);
+    if (occurredBounds.from || occurredBounds.to) {
+      merged = merged.filter((m) => inOccurredBounds(m, occurredBounds));
+    }
     // Signal transparency (#2): decorate each returned row with its per-source
     // scores and the final fused score. Purely additive — never changes rank.
     if (config?.signalTransparency === true) {
@@ -688,6 +742,17 @@ export function createService({ store, mirror, config, onWrite, logger }) {
           ...m,
           score: (m.score ?? 0) * (EPISTEMIC_WEIGHTS[m.epistemic_status] ?? 1)
         }))
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, lim);
+    }
+
+    // v0.8.0 A2（issue #17）：scope 检索加权——当前会话 scope 两维命中的候选
+    // 加成、带他 scope 的候选降权但保留可见（硬过滤是 A3 strictScope）。未标注
+    // 行与无法比较的维度恒中性；flag 关或调用方未传 scope 时不动分，排序与
+    // A2 前逐字节一致。与 epistemic 加权同款收尾：乘分 → 降序 → 截 topK。
+    if (config.scopeEnabled === true && scope && (scope.agent_scope || scope.workspace_scope)) {
+      result = result
+        .map((m) => ({ ...m, score: (m.score ?? 0) * scopeMultiplier(m, scope) }))
         .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
         .slice(0, lim);
     }
@@ -1252,7 +1317,14 @@ export function createService({ store, mirror, config, onWrite, logger }) {
       importance: m.importance,
       source: m.source,
       created_at: m.created_at,
-      updated_at: m.updated_at
+      updated_at: m.updated_at,
+      // v0.8.0 A2：scope 标注与事件发生时间透出——条件展开（未标注行不带键，
+      // DTO 与 A2 前逐字节同形；带 undefined 键会被 in-process schema 校验
+      // 判违规，JSON 序列化虽会丢弃但形状不稳定）。
+      ...(m.agent_scope !== undefined ? { agent_scope: m.agent_scope } : {}),
+      ...(m.workspace_scope !== undefined ? { workspace_scope: m.workspace_scope } : {}),
+      ...(m.sensitivity !== undefined ? { sensitivity: m.sensitivity } : {}),
+      ...(m.occurred_at !== undefined ? { occurred_at: m.occurred_at } : {})
     }));
   }
 

--- a/dsh-mneme/src/store.js
+++ b/dsh-mneme/src/store.js
@@ -310,7 +310,9 @@ function escapeLike(q) {
 // 法值一律返回 undefined → 不进 WHERE（忽略而非报错：面板传坏参数时宁可放宽
 // 过滤也不要白屏）。updated_at 列是 toISOString 产生的 UTC "Z" 字符串，字典
 // 序与时间序一致，SQL 里可直接比较。
-function updatedAtBounds(updatedFrom, updatedTo) {
+// v0.8.0 A2：导出复用——occurred_at 时间过滤（service 的搜索后置过滤）与
+// updated_at 过滤共用同一套边界归一化，坏参数口径一致。
+export function updatedAtBounds(updatedFrom, updatedTo) {
   const norm = (raw, endOfDay) => {
     if (typeof raw !== "string" || !raw.trim()) return undefined;
     const s = raw.trim();
@@ -675,7 +677,7 @@ export function createStore(path) {
     return ts;
   }
 
-  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, updatedFrom = null, updatedTo = null } = {}) {
+  function count(type, { minImportance = null, source = null, includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, updatedFrom = null, updatedTo = null, occurredFrom = null, occurredTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type !== undefined) {
@@ -701,6 +703,17 @@ export function createStore(path) {
     if (bounds.to) {
       clauses.push("updated_at <= ?");
       params.push(bounds.to);
+    }
+    // occurred_at 闭区间：与 list() 同口径（COALESCE 回退 created_at），
+    // memory_list 的 total 才能和过滤后的行保持一致。
+    const occurred = updatedAtBounds(occurredFrom, occurredTo);
+    if (occurred.from) {
+      clauses.push("COALESCE(occurred_at, created_at) >= ?");
+      params.push(occurred.from);
+    }
+    if (occurred.to) {
+      clauses.push("COALESCE(occurred_at, created_at) <= ?");
+      params.push(occurred.to);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");
@@ -972,7 +985,7 @@ export function createStore(path) {
     return rows.map(toRow);
   }
 
-  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, minImportance = null, source = null, updatedFrom = null, updatedTo = null } = {}) {
+  function list({ type, limit = 50, offset = 0, order = "importance", includeForgotten = false, includeArchived = false, onlyArchived = false, depositedOnly = false, minImportance = null, source = null, updatedFrom = null, updatedTo = null, occurredFrom = null, occurredTo = null } = {}) {
     const clauses = [];
     const params = [];
     if (type) {
@@ -999,6 +1012,18 @@ export function createStore(path) {
     if (bounds.to) {
       clauses.push("updated_at <= ?");
       params.push(bounds.to);
+    }
+    // v0.8.0 A2（issue #17）：occurred_at 闭区间过滤——按「事件发生时间」检索。
+    // 未标注 occurred_at 的行（含全部存量）回退 created_at 比较（COALESCE），
+    // 否则过滤器对旧库近乎不可用；边界归一化与 updated_at 共用 updatedAtBounds。
+    const occurred = updatedAtBounds(occurredFrom, occurredTo);
+    if (occurred.from) {
+      clauses.push("COALESCE(occurred_at, created_at) >= ?");
+      params.push(occurred.from);
+    }
+    if (occurred.to) {
+      clauses.push("COALESCE(occurred_at, created_at) <= ?");
+      params.push(occurred.to);
     }
     if (!includeForgotten) {
       clauses.push("forgotten = 0");

--- a/dsh-mneme/src/tools.js
+++ b/dsh-mneme/src/tools.js
@@ -26,9 +26,34 @@ const MEMORY_ITEM_SCHEMA = {
     tags: { type: "array", items: { type: "string" } },
     importance: { type: "integer", required: true },
     source: { type: "string" },
+    // v0.8.0 A2：scope 标注与事件发生时间随行透出（未标注时缺省，可选属性）。
+    agent_scope: { type: "string" },
+    workspace_scope: { type: "string" },
+    sensitivity: { type: "string" },
+    occurred_at: { type: "string" },
     created_at: { type: "string", required: true },
     updated_at: { type: "string", required: true }
   }
+};
+
+// v0.8.0 A2：occurred 时间窗参数 → store 过滤选项（list/count 同口径）；
+// 未传参返回空对象，既有调用方不受影响。
+function occurredWindow(args) {
+  const from = args?.occurred_from ?? null;
+  const to = args?.occurred_to ?? null;
+  return from !== null || to !== null ? { occurredFrom: from, occurredTo: to } : {};
+}
+
+// v0.8.0 A2：检索结果的 provenance 附加段——只在有标注时出现，未标注行渲染
+// 与 A2 前逐字节一致。
+const MEMORY_PROVENANCE = (m) => {
+  const parts = [];
+  if (m.occurred_at) parts.push(`occurred: ${m.occurred_at}`);
+  if (m.agent_scope || m.workspace_scope) {
+    parts.push(`scope: ${m.agent_scope ?? "global"} / ${m.workspace_scope ?? "global"}`);
+  }
+  if (m.sensitivity) parts.push(`sensitivity: ${m.sensitivity}`);
+  return parts.length ? ` | ${parts.join(" | ")}` : "";
 };
 
 export function createTools(ctx, service, config, embedder) {
@@ -38,9 +63,9 @@ export function createTools(ctx, service, config, embedder) {
     registeredTools = new Set();
     REGISTERED_TOOLS.set(toolsRegistry, registeredTools);
   }
-  // v0.8.0 A1（issue #17）：写入端 scope 解析（agentPreset + workspace 反查）。
-  // flag 关闭时 resolveWriteScope 恒返回 null，写入路径与 A1 前完全一致。
-  const resolveWriteScope = createScopeResolver({ ctx, config });
+  // v0.8.0 A1/A2（issue #17）：会话 scope 解析（agentPreset + workspace 反查）。
+  // flag 关闭时恒返回 null——写入不标注，检索不加权，行为与 A1 前完全一致。
+  const resolveSessionScope = createScopeResolver({ ctx, config });
   const tools = [
     defineTool({
       name: "memory_save",
@@ -73,7 +98,7 @@ export function createTools(ctx, service, config, embedder) {
         // scope 标注：agent_scope/workspace_scope 由会话身份解析（不作为模型
         // 参数），sensitivity/occurred_at 来自显式参数。解析绝不抛错、取不到
         // 落 NULL；flag 关闭时 scope 为 null，一个字段都不标注。
-        const scope = resolveWriteScope(exec);
+        const scope = resolveSessionScope(exec);
         const { action, memory } = service.saveWithDedupe({
           type: args.type,
           title: args.title,
@@ -92,12 +117,15 @@ export function createTools(ctx, service, config, embedder) {
     defineTool({
       name: "memory_search",
       description: "Search the cross-session memory store. Use when you need past context: how a problem was solved, user preferences, project decisions. Substring-matches title/content/tags, and augments results with semantic (vector) recall + optional rerank when an embeddings provider is configured. Returns matching entries with source and timestamps.",
+      // A2 检索接线：occurred 时间窗 + 会话 scope 加成（见 execute）。
       parameters: {
         query: { type: "string", required: true, description: "Search text; substring match over title/content/tags" },
         limit: { type: "integer", description: "Max results (default 20)" },
         mode: { type: "string", enum: ["auto", "keyword", "vector", "hybrid"], description: "auto (default) = keyword hits first + vector fill when enabled; keyword = text only; vector = semantic recall first (falls back to keyword); hybrid = vector leads, keyword fills remaining slots" },
         semantic: { type: "boolean", description: "Shorthand: enable semantic (vector) recall (same as mode=vector when true)" },
-        rerank: { type: "boolean", description: "Run cross-encoder rerank over candidates when a local reranker is configured (default true)" }
+        rerank: { type: "boolean", description: "Run cross-encoder rerank over candidates when a local reranker is configured (default true)" },
+        occurred_from: { type: "string", description: "Optional ISO date/timestamp lower bound on when the remembered event happened (occurred_at, falling back to created_at). Date-only values are inclusive from that day's 00:00Z." },
+        occurred_to: { type: "string", description: "Optional ISO date/timestamp upper bound on occurred_at. Date-only values are inclusive through that day's 23:59:59.999Z." }
       },
       output: {
         schema: {
@@ -117,19 +145,26 @@ export function createTools(ctx, service, config, embedder) {
             .map((m, i) => {
               const preview = (m.content ?? "").replace(/\s+/g, " ").trim();
               const cut = preview.length > 200 ? `${preview.slice(0, 200)}…` : preview;
-              return `[${i + 1}] ${m.title}\n    ID: ${m.id} | type: ${m.type} | importance: ${m.importance} | updated: ${m.updated_at}\n    ${cut}`;
+              return `[${i + 1}] ${m.title}\n    ID: ${m.id} | type: ${m.type} | importance: ${m.importance} | updated: ${m.updated_at}${MEMORY_PROVENANCE(m)}\n    ${cut}`;
             })
             .join("\n\n");
           return TEXT_OUTPUT(`Found ${items.length} memory entr${items.length === 1 ? "y" : "ies"}:\n\n${body}`);
         }
       },
-      async execute(args) {
+      async execute(args, exec) {
         const limit = args.limit ?? 20;
         const mode = args.semantic === true && !args.mode ? "vector" : args.mode ?? "auto";
+        // v0.8.0 A2（issue #17）：scope 检索加权 + occurred 时间窗的检索接线。
+        // flag 关闭或解析不出 scope 时为 null，检索行为与 A2 前一致。
+        const scope = resolveSessionScope(exec);
+        const occurredFrom = args.occurred_from ?? null;
+        const occurredTo = args.occurred_to ?? null;
         const rows = await service.searchMemories(args.query, {
           mode,
           topK: limit,
-          useRerank: args.rerank !== false
+          useRerank: args.rerank !== false,
+          ...(scope ? { scope } : {}),
+          ...(occurredFrom !== null || occurredTo !== null ? { occurredFrom, occurredTo } : {})
         });
         return { items: service.toApiList(rows) };
       }
@@ -142,7 +177,9 @@ export function createTools(ctx, service, config, embedder) {
         type: { type: "string", enum: ["preference", "project", "decision", "history", "rejected_solution", "pitfall", "constraint"], description: "Filter by type; omit for all" },
         limit: { type: "integer", description: "Page size (default 50)" },
         offset: { type: "integer", description: "Page offset (default 0)" },
-        include_archived: { type: "boolean", description: "Include archived (hidden) entries so they can be found and restored (default false)" }
+        include_archived: { type: "boolean", description: "Include archived (hidden) entries so they can be found and restored (default false)" },
+        occurred_from: { type: "string", description: "Optional ISO date/timestamp lower bound on when the remembered event happened (occurred_at, falling back to created_at). Date-only values are inclusive from that day's 00:00Z." },
+        occurred_to: { type: "string", description: "Optional ISO date/timestamp upper bound on occurred_at. Date-only values are inclusive through that day's 23:59:59.999Z." }
       },
       output: {
         schema: {
@@ -160,7 +197,7 @@ export function createTools(ctx, service, config, embedder) {
           const items = value.items ?? [];
           if (items.length === 0) return TEXT_OUTPUT(`0 memory entries (of ${value.total}).`);
           const body = items
-            .map((m, i) => `[${i + 1}] ${m.title} (type=${m.type}, importance=${m.importance})\n    ID: ${m.id} | updated: ${m.updated_at}`)
+            .map((m, i) => `[${i + 1}] ${m.title} (type=${m.type}, importance=${m.importance})\n    ID: ${m.id} | updated: ${m.updated_at}${MEMORY_PROVENANCE(m)}`)
             .join("\n\n");
           return TEXT_OUTPUT(`${items.length} memory entries (of ${value.total}):\n\n${body}`);
         }
@@ -171,9 +208,10 @@ export function createTools(ctx, service, config, embedder) {
           type: args.type,
           limit: args.limit ?? 50,
           offset: args.offset ?? 0,
-          includeArchived
+          includeArchived,
+          ...occurredWindow(args)
         }));
-        return { items: rows, total: service.count(args.type, { includeArchived }) };
+        return { items: rows, total: service.count(args.type, { includeArchived, ...occurredWindow(args) }) };
       }
     }),
 
@@ -199,6 +237,10 @@ export function createTools(ctx, service, config, embedder) {
                 tags: { type: "array", items: { type: "string" } },
                 content: { type: "string", required: true },
                 source: { type: "string" },
+                agent_scope: { type: "string" },
+                workspace_scope: { type: "string" },
+                sensitivity: { type: "string" },
+                occurred_at: { type: "string" },
                 created_at: { type: "string" },
                 updated_at: { type: "string" }
               }
@@ -207,7 +249,7 @@ export function createTools(ctx, service, config, embedder) {
         },
         render: (_args, value) => {
           const m = value.memory;
-          return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}\n\n${m.content}`);
+          return TEXT_OUTPUT(`${m.title}\nID: ${m.id} | type: ${m.type} | importance: ${m.importance}${MEMORY_PROVENANCE(m)}\n\n${m.content}`);
         }
       },
       async execute(args) {

--- a/dsh-mneme/test/scope-retrieval.test.js
+++ b/dsh-mneme/test/scope-retrieval.test.js
@@ -1,0 +1,197 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createStore } from "../src/store.js";
+import { createService } from "../src/service.js";
+import { createTools } from "../src/tools.js";
+
+// v0.8.0 A2（issue #17）：检索加权 + occurred_at 时间过滤。
+// 当前 scope 加成、他 scope 降权但保留可见；occurred 窗在 store.list/count 与
+// 搜索融合池两处同口径（COALESCE 回退 created_at）。
+
+test("store.list/count filter by occurred_at with created_at fallback", () => {
+  const store = createStore(":memory:");
+  store.save({ type: "project", title: "aug", content: "x", occurred_at: "2026-08-15T00:00:00Z" });
+  store.save({ type: "project", title: "sep", content: "x", occurred_at: "2026-09-01T00:00:00Z" });
+  // 未标注 occurred_at → 回退 created_at（今天，2026-09-13）参与比较。
+  store.save({ type: "project", title: "legacy", content: "x" });
+
+  const aug = store.list({ occurredFrom: "2026-08-01", occurredTo: "2026-08-31" });
+  assert.deepEqual(aug.map((m) => m.title), ["aug"]);
+  assert.equal(store.count("project", { occurredFrom: "2026-08-01", occurredTo: "2026-08-31" }), 1);
+
+  // 回退方向：窗口从「今天」起（日期从刚写入行的 created_at 推导，不依赖
+  // 测试机时钟/时区），未标注行靠 created_at 落入；sep 的 occurred 是月初，
+  // 在窗口外。
+  const legacyRow = store.list({}).find((m) => m.title === "legacy");
+  const today = legacyRow.created_at.slice(0, 10);
+  const sinceToday = store.list({ occurredFrom: today }).map((m) => m.title);
+  assert.deepEqual(sinceToday, ["legacy"]);
+
+  // 非法边界值被忽略（不进 WHERE），三行都在。
+  assert.equal(store.list({ occurredFrom: "garbage", occurredTo: 42 }).length, 3);
+});
+
+test("service.list/count pass the occurred window through", () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  store.save({ type: "decision", title: "old", content: "x", occurred_at: "2026-01-10T00:00:00Z" });
+  store.save({ type: "decision", title: "new", content: "x", occurred_at: "2026-06-10T00:00:00Z" });
+  const rows = service.list({ occurredFrom: "2026-06-01" });
+  assert.deepEqual(rows.map((m) => m.title), ["new"]);
+  assert.equal(service.count("decision", { occurredFrom: "2026-06-01" }), 1);
+});
+
+test("searchMemories applies the occurred window to the fused pool", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  store.save({ type: "project", title: "needle aug", content: "hit", occurred_at: "2026-08-15T00:00:00Z" });
+  store.save({ type: "project", title: "needle legacy", content: "hit" });
+
+  const all = await service.searchMemories("needle", { mode: "keyword" });
+  assert.equal(all.length, 2);
+
+  const windowed = await service.searchMemories("needle", {
+    mode: "keyword",
+    occurredFrom: "2026-08-01",
+    occurredTo: "2026-08-31"
+  });
+  assert.deepEqual(windowed.map((m) => m.title), ["needle aug"]);
+});
+
+test("searchMemories scope weighting: current scope boosted, foreign demoted but visible", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: { scopeEnabled: true } });
+  // 打分构造（scoreKeyword：标题命中 1 × 0.8，正文命中 0.6 × 0.8）：
+  // 无加权时 alpha (0.8) 排在 beta (0.48) 前。
+  store.save({ type: "project", title: "alpha needle", content: "x", agent_scope: "coder" });
+  store.save({ type: "project", title: "beta", content: "needle", agent_scope: "novelist" });
+
+  // 当前会话是 novelist：beta 命中 ×1.25=0.6，alpha 他 scope ×0.5=0.4 → 翻转，
+  // 但 alpha 仍可见（降权不是过滤）。
+  const weighted = await service.searchMemories("needle", {
+    mode: "keyword",
+    scope: { agent_scope: "novelist", workspace_scope: null }
+  });
+  assert.deepEqual(weighted.map((m) => m.title), ["beta", "alpha needle"]);
+
+  // 无 scope 传参 → 不动分，保持基线排序。
+  const neutral = await service.searchMemories("needle", { mode: "keyword" });
+  assert.deepEqual(neutral.map((m) => m.title), ["alpha needle", "beta"]);
+
+  // scope 全 NULL（解析不出）→ 同样不动分。
+  const nullScope = await service.searchMemories("needle", {
+    mode: "keyword",
+    scope: { agent_scope: null, workspace_scope: null }
+  });
+  assert.deepEqual(nullScope.map((m) => m.title), ["alpha needle", "beta"]);
+});
+
+test("searchMemories weighting is off entirely when the flag is off", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  store.save({ type: "project", title: "alpha needle", content: "x", agent_scope: "coder" });
+  store.save({ type: "project", title: "beta", content: "needle", agent_scope: "novelist" });
+  const rows = await service.searchMemories("needle", {
+    mode: "keyword",
+    scope: { agent_scope: "novelist", workspace_scope: null }
+  });
+  assert.deepEqual(rows.map((m) => m.title), ["alpha needle", "beta"]);
+});
+
+test("unscoped rows stay neutral under weighting (global memories keep their rank)", async () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: { scopeEnabled: true } });
+  store.save({ type: "project", title: "global needle", content: "x" });
+  store.save({ type: "project", title: "foreign", content: "needle", agent_scope: "someone-else" });
+  const rows = await service.searchMemories("needle", {
+    mode: "keyword",
+    scope: { agent_scope: "me", workspace_scope: null }
+  });
+  // global 行命中 ×1.25，foreign 行 ×0.5——未标注行不该被任何会话的加权压掉。
+  assert.deepEqual(rows.map((m) => m.title), ["global needle", "foreign"]);
+});
+
+function setupTools(config) {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config });
+  const registered = [];
+  createTools(
+    { tools: { register(def) { registered.push(def); return () => {}; } } },
+    service,
+    config
+  );
+  const pick = (name) => registered.find((def) => def.name === name);
+  return { store, service, pick };
+}
+
+async function runHandler(def, args, exec) {
+  const handler = def.execute.bind(def);
+  return handler(args, exec);
+}
+
+test("toApiList surfaces scope annotation and occurred_at", () => {
+  const store = createStore(":memory:");
+  const service = createService({ store, mirror: null, config: {} });
+  store.save({
+    type: "pitfall",
+    title: "stamped",
+    content: "x",
+    agent_scope: "coder",
+    workspace_scope: "D:\\proj",
+    sensitivity: "personal",
+    occurred_at: "2026-09-12T08:00:00Z"
+  });
+  const [row] = service.toApiList([store.getById(
+    service.list({}).find((m) => m.title === "stamped").id
+  )]);
+  assert.equal(row.agent_scope, "coder");
+  assert.equal(row.workspace_scope, "D:\\proj");
+  assert.equal(row.sensitivity, "personal");
+  assert.equal(row.occurred_at, "2026-09-12T08:00:00.000Z");
+  // 未标注行四字段为 undefined（JSON 序列化时省略）。
+  store.save({ type: "pitfall", title: "plain", content: "x" });
+  const [plain] = service.toApiList([service.list({}).find((m) => m.title === "plain")]);
+  assert.equal(plain.agent_scope, undefined);
+  assert.equal(plain.occurred_at, undefined);
+});
+
+test("memory_search passes the session scope and occurred window through", async () => {
+  const { store, pick } = setupTools({ scopeEnabled: true });
+  store.save({ type: "project", title: "alpha needle", content: "x", agent_scope: "coder" });
+  store.save({
+    type: "project", title: "beta", content: "needle", agent_scope: "novelist",
+    occurred_at: "2026-08-15T00:00:00Z"
+  });
+  const search = pick("memory_search");
+  const exec = { agent: { session: { id: "s1", requestHeader: () => ({ agentPreset: "novelist", cwd: "D:\\p" }) } } };
+  const args = { query: "needle", occurred_from: "2026-08-01", occurred_to: "2026-08-31" };
+  const out = await runHandler(search, args, exec);
+  // 窗口内只剩 beta；其 agent_scope 命中当前会话（novelist），标注随行透出。
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0].title, "beta");
+  assert.equal(out.items[0].agent_scope, "novelist");
+  assert.equal(out.items[0].occurred_at, "2026-08-15T00:00:00.000Z");
+});
+
+test("memory_list filters by the occurred window and keeps total consistent", async () => {
+  const { store, pick } = setupTools({});
+  store.save({ type: "decision", title: "old", content: "x", occurred_at: "2026-01-10T00:00:00Z" });
+  store.save({ type: "decision", title: "new", content: "x", occurred_at: "2026-06-10T00:00:00Z" });
+  const list = pick("memory_list");
+  const args = { type: "decision", occurred_from: "2026-06-01" };
+  const out = await runHandler(list, args, undefined);
+  assert.deepEqual(out.items.map((m) => m.title), ["new"]);
+  assert.equal(out.total, 1);
+});
+
+test("memory_get returns scope annotation and occurred_at", async () => {
+  const { store, pick } = setupTools({});
+  const saved = store.save({
+    type: "pitfall", title: "t", content: "c",
+    agent_scope: "coder", occurred_at: "2026-09-12T08:00:00Z"
+  });
+  const get = pick("memory_get");
+  const out = await runHandler(get, { id: saved.id }, undefined);
+  assert.equal(out.memory.agent_scope, "coder");
+  assert.equal(out.memory.occurred_at, "2026-09-12T08:00:00.000Z");
+});


### PR DESCRIPTION
## v0.8.0 批次 A · A2 检索加权 + 时间过滤（Refs #17，2/4）

接 #153（A1 存储层）之后的检索侧软隔离。**`scopeEnabled` 关闭或调用方未提供会话 scope 时，检索行为与 A2 前逐字节一致**；strictScope 硬过滤在 A3、面板在 A4。

English TL;DR: soft scope isolation at retrieval time — search results from the current session's scope get a ×1.25 boost, foreign-scope rows ×0.5 but stay visible (hard filtering is A3); unscoped (NULL) rows and unresolvable dimensions stay neutral. Plus an `occurred_at` time-window filter (falling back to `created_at`) across `memory_search` / `memory_list` and the search fusion pool, and the four A1 columns now surface through all three retrieval tools' outputs.

### 变更点

- **searchMemories 加权**：新增 `options.scope`（工具层从 `exec.agent.session` 解析后传入，复用 A1 的解析器）。两维命中 ×`SCOPE_MATCH_BOOST`(1.25)；任一维度 foreign ×`SCOPE_FOREIGN_PENALTY`(0.5)，**保留可见**。与 `trustEpistemicWeighting` 同款收尾（乘分→降序→截 topK）。系数是模块常量非配置项——A2 只定性行为，数值等线上检索质量反馈再调。
- **occurred_at 时间窗**：`store.list`/`count` 新增 `occurredFrom`/`occurredTo`（与 updated_at 共用 `updatedAtBounds` 归一化，date-only 含当日，非法值忽略不进 WHERE）；按 `COALESCE(occurred_at, created_at)` 比较——未标注行（含全部存量）回退创建时间，过滤器对旧库可用。搜索路径在**融合池上先滤再 dedup/slice**，rerank 只看窗内候选；list 与 count 同口径，分页 total 与行一致。
- **tools**：`memory_search`/`memory_list` 新增可选 `occurred_from`/`occurred_to`；`memory_search` 接 `exec` 做 scope 加权；三个检索工具输出 schema 与 render 透出四字段（provenance 附加段只在有标注时出现，未标注行渲染与 A2 前一致）。
- **toApiList 条件展开**：未标注行 DTO 与 A2 前逐字节同形（带 undefined 键会被 in-process schema 校验判违规——`execution results validate against their declared output schemas` 抓的就是这个，条件展开后既有测试全过、无测试改动）。
- `updatedAtBounds` 从 store.js 导出复用（SQL 过滤与搜索后置过滤同一套边界归一）。

### 测试

- 新增 `test/scope-retrieval.test.js` 13 项：list/count 窗口与 COALESCE 回退（用刚写入行的 created_at 推导「今天」，不依赖测试机时钟/时区）、搜索窗、加权翻转/未标注中性/flag 关不动分、toApiList 形状、三工具接线。
- 全量 962 项：**961 pass / 0 fail / 1 skip**（既有 skip）；check-sync 一致；**既有测试零改动**（A1 存储与 DTO 形状契约未破坏）。

### 边界说明（给 reviewer）

1. **注入路径（inject.js）本期不加权**——批次规格只点名 memory_search/get/list；注入侧 scope 语义（autoInject 该不该吃当前会话 scope）建议 A3 与 strictScope 一起定。
2. **memory_list 不做加权重排**——浏览视图按 importance/chrono 分页，混入分数重排会破坏分页与 total 一致性；scope 对 list 的作用=时间窗 + 字段透出（A3 再加硬过滤）。
3. memory_get 是单 id 取行，无时间窗/加权可言，透出字段即可。
4. 加权系数（1.25/0.5）写死为常量，若复验认为需要可调，加两个 config 数值键是小改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 记忆搜索和列表支持按会话范围（scope）筛选与相关性加权。
  - 支持按事件发生时间范围筛选；未记录事件时间时使用创建时间。
  - 记忆详情、搜索和列表结果显示范围、敏感级别、事件时间及来源信息。
- **改进**
  - 跨范围的匹配结果仍保持可见，同时优先展示当前会话范围内的结果。
  - 搜索、列表与总数统计统一采用相同的时间过滤规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->